### PR TITLE
docs: #3 align marketplace id and add per-tool install docs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,6 @@
 {
   "enabledPlugins": {
-    "superteam@patinaproject": true,
+    "superteam@patinaproject-skills": true,
     "superpowers@claude-plugins-official": true
   }
 }

--- a/README.md
+++ b/README.md
@@ -70,15 +70,21 @@ Bootstrap walks the target repo's merge settings (via `gh api`, `curl`, or visua
 
 | Tool | Surface | Covered by |
 |---|---|---|
-| Claude Code | `.claude-plugin/plugin.json` | Plugin manifest |
-| Codex (CLI + App) | `.codex-plugin/plugin.json` | Plugin manifest |
-| GitHub Copilot | `.github/copilot-instructions.md` | Instructions file |
-| Cursor | `.cursor/rules/<repo>.mdc` | Rule file |
-| Windsurf | `.windsurfrules` | Rule file |
-| Aider, Zed, Cline, Codex CLI, Opencode | — | `AGENTS.md` (native) |
-| Continue.dev | `.continue/config.json` | Opt-in |
+| [Claude Code](#claude-code) | `.claude-plugin/plugin.json` | Plugin manifest |
+| [OpenAI Codex CLI](#openai-codex-cli) | `.codex-plugin/plugin.json` | Plugin manifest |
+| [OpenAI Codex App](#openai-codex-app) | `.codex-plugin/plugin.json` | Plugin manifest |
+| [GitHub Copilot](#github-copilot) | `.github/copilot-instructions.md` | Instructions file |
+| [Cursor](#cursor) | `.cursor/rules/<repo>.mdc` | Rule file |
+| [Windsurf](#windsurf) | `.windsurfrules` | Rule file |
+| [Aider](#aider) | `AGENTS.md` | Native |
+| [Zed](#zed) | `AGENTS.md` | Native |
+| [Cline](#cline) | `AGENTS.md` | Native |
+| [Opencode](#opencode) | `AGENTS.md` | Native |
+| [Continue.dev](#continuedev) | `.continue/config.json` | Opt-in |
 
 ## Installation
+
+Bootstrap ships as a Claude Code + Codex plugin. Other supported editors read the repository-level files bootstrap emits (`AGENTS.md`, `.cursor/`, `.windsurfrules`, `.github/copilot-instructions.md`) directly — those tools require no additional plugin install. Pick the section for your tool.
 
 ### Claude Code
 
@@ -91,7 +97,7 @@ Bootstrap walks the target repo's merge settings (via `gh api`, `curl`, or visua
 2. Install Bootstrap:
 
    ```text
-   /plugin install bootstrap@patinaproject
+   /plugin install bootstrap@patinaproject-skills
    ```
 
 3. Open the target repo in Claude Code (or a GitHub issue in the target repo) and invoke:
@@ -129,6 +135,90 @@ Bootstrap walks the target repo's merge settings (via `gh api`, `curl`, or visua
    ```text
    Use $bootstrap to scaffold or realign this repository.
    ```
+
+### GitHub Copilot
+
+No plugin install required. Bootstrap-scaffolded repos ship `.github/copilot-instructions.md`, which Copilot Chat reads automatically when the repo is open in your editor.
+
+1. Clone the bootstrap-scaffolded repo and open it.
+2. Invoke Bootstrap from Copilot Chat:
+
+   ```text
+   @workspace Use the bootstrap skill to scaffold or realign this repository.
+   ```
+
+Personal Copilot preferences belong in your user-scoped Copilot settings, not in the emitted `.github/copilot-instructions.md`.
+
+### Cursor
+
+No plugin install required. Bootstrap emits `.cursor/rules/<repo>.mdc`, which Cursor loads as a project rule whenever the repo is open.
+
+1. Clone the bootstrap-scaffolded repo and open it in Cursor.
+2. Ask the Cursor agent to apply Bootstrap:
+
+   ```text
+   Use the bootstrap skill to scaffold or realign this repository.
+   ```
+
+Personal Cursor rules belong in your user-scoped Cursor settings, not in the emitted `.cursor/rules/`.
+
+### Windsurf
+
+No plugin install required. Bootstrap emits `.windsurfrules`, which Windsurf reads natively when the repo is open.
+
+1. Clone the bootstrap-scaffolded repo and open it in Windsurf.
+2. Ask Cascade to apply Bootstrap:
+
+   ```text
+   Use the bootstrap skill to scaffold or realign this repository.
+   ```
+
+### Aider
+
+No plugin install required. Aider reads `AGENTS.md` natively.
+
+1. Clone the bootstrap-scaffolded repo.
+2. Run `aider` from inside the repo and ask it to apply the bootstrap workflow described in `AGENTS.md`.
+
+### Zed
+
+No plugin install required. Zed's assistant reads `AGENTS.md` natively.
+
+1. Clone the bootstrap-scaffolded repo and open it in Zed.
+2. Ask the assistant to apply the bootstrap workflow described in `AGENTS.md`.
+
+### Cline
+
+No plugin install required. Cline reads `AGENTS.md` natively when the repo is open in VS Code.
+
+1. Clone the bootstrap-scaffolded repo and open it in VS Code with the Cline extension active.
+2. Ask Cline to apply the bootstrap workflow described in `AGENTS.md`.
+
+### Opencode
+
+No plugin install required. Opencode reads `AGENTS.md` natively.
+
+1. Clone the bootstrap-scaffolded repo and open it in Opencode.
+2. Ask Opencode to apply the bootstrap workflow described in `AGENTS.md`.
+
+### Continue.dev
+
+Continue.dev support is opt-in. Add the following entry to your `.continue/config.json` (project-scoped or user-scoped) so Continue picks up the bootstrap context:
+
+```jsonc
+{
+  "context": [
+    {
+      "provider": "file",
+      "params": {
+        "files": ["AGENTS.md", ".github/copilot-instructions.md"]
+      }
+    }
+  ]
+}
+```
+
+Then ask Continue to apply the bootstrap workflow described in `AGENTS.md`.
 
 ## First use
 

--- a/docs/superpowers/plans/2026-04-24-1-create-bootstrap-claude-skill-for-repo-scaffolding-plan.md
+++ b/docs/superpowers/plans/2026-04-24-1-create-bootstrap-claude-skill-for-repo-scaffolding-plan.md
@@ -71,7 +71,7 @@ Verification (T1.3): `ls AGENTS.md CLAUDE.md CONTRIBUTING.md SECURITY.md README.
   ```jsonc
   {
     "enabledPlugins": {
-      "superteam@patinaproject": true,
+      "superteam@patinaproject-skills": true,
       "superpowers@claude-plugins-official": true
     }
   }

--- a/docs/superpowers/plans/2026-04-24-3-align-marketplace-id-and-add-per-tool-install-docs-for-every-supported-editor-plan.md
+++ b/docs/superpowers/plans/2026-04-24-3-align-marketplace-id-and-add-per-tool-install-docs-for-every-supported-editor-plan.md
@@ -1,0 +1,64 @@
+# Plan: Align marketplace id and add per-tool install docs for every supported editor [#3](https://github.com/patinaproject/bootstrap/issues/3)
+
+## Workstream A — Marketplace id rename
+
+Replace every plugin-id literal `@patinaproject` with `@patinaproject-skills`. Preserve email addresses (`ted@patinaproject.com`) and bare GitHub paths (`patinaproject/skills`) untouched.
+
+**Files**:
+
+- `.claude/settings.json` → `superteam@patinaproject-skills`
+- `skills/bootstrap/templates/core/.claude/settings.json` → same
+- `README.md` → `/plugin install bootstrap@patinaproject-skills`
+- `skills/bootstrap/SKILL.md` → "Plugin enablement" snippet
+- `skills/bootstrap/audit-checklist.md` → Area 4 expected-keys note
+- `skills/bootstrap/templates/agent-plugin/README.md.tmpl` → `/plugin install {{repo}}@patinaproject-skills`
+- `docs/superpowers/specs/2026-04-24-1-create-bootstrap-claude-skill-for-repo-scaffolding-design.md` (3 occurrences)
+- `docs/superpowers/plans/2026-04-24-1-create-bootstrap-claude-skill-for-repo-scaffolding-plan.md` (1 occurrence)
+
+**Tasks**:
+
+- **T-A1**: Update `.claude/settings.json` and `skills/bootstrap/templates/core/.claude/settings.json` (AC-3-1, AC-3-2).
+- **T-A2**: Update `skills/bootstrap/SKILL.md` (AC-3-3).
+- **T-A3**: Update `skills/bootstrap/audit-checklist.md` (AC-3-4).
+- **T-A4**: Update `skills/bootstrap/templates/agent-plugin/README.md.tmpl` install snippet (id half).
+- **T-A5**: Update prior superpowers spec + plan to keep their snippets accurate.
+
+**Verification**: `rg '@patinaproject(?!-skills|\.com)'` returns zero matches.
+
+## Workstream B — Per-tool install docs
+
+Rewrite `## Installation` in `README.md` and mirror the structure in `skills/bootstrap/templates/agent-plugin/README.md.tmpl`. Update the "Supported AI coding tools" table to link rows to the new subsections via in-document anchors.
+
+**Subsection plan (order matches the table)**:
+
+| # | Tool | Category | Content |
+|---|------|----------|---------|
+| 1 | Claude Code | Marketplace | `marketplace add` + `install` + invoke command (id-corrected) |
+| 2 | OpenAI Codex CLI | Marketplace | `codex plugin marketplace add` + invoke |
+| 3 | OpenAI Codex App | Marketplace | enable + invoke |
+| 4 | GitHub Copilot | Emitted file | `.github/copilot-instructions.md` is read natively; clone and use Copilot Chat |
+| 5 | Cursor | Emitted file | `.cursor/rules/<repo>.mdc` rule file; clone, no extra config; personal rules go in user-scoped Cursor settings |
+| 6 | Windsurf | Emitted file | `.windsurfrules` is read natively; clone, no extra config |
+| 7 | Aider | AGENTS.md | Aider reads `AGENTS.md`; clone and run `aider` in repo |
+| 8 | Zed | AGENTS.md | Zed's assistant reads `AGENTS.md`; clone and open |
+| 9 | Cline | AGENTS.md | Cline reads `AGENTS.md`; clone and open in VS Code |
+| 10 | Opencode | AGENTS.md | Opencode reads `AGENTS.md`; clone and open |
+| 11 | Continue.dev | Opt-in | exact `.continue/config.json` snippet enabling the plugin |
+
+**Table edits**: split the combined "Aider, Zed, Cline, Codex CLI, Opencode" row into one row per tool (Codex CLI already has its own row — don't duplicate; just anchor each row). Anchor every tool name with `[Name](#anchor-slug)`.
+
+**Tasks**:
+
+- **T-B1**: Rewrite `README.md` "Supported AI coding tools" table with anchored, split rows (AC-3-7).
+- **T-B2**: Rewrite `README.md` `## Installation` section with all 11 subsections (AC-3-6, AC-3-9, AC-3-10).
+- **T-B3**: Mirror the same `## Installation` structure in `skills/bootstrap/templates/agent-plugin/README.md.tmpl` with `{{repo}}` / `{{owner}}` placeholders (AC-3-8).
+
+**Verification**: every table row anchor resolves to an `<h3>` in the same file; each AGENTS.md-only subsection contains explicit "no additional config" wording with no install commands; Continue.dev subsection shows a `.continue/config.json` snippet; `pnpm lint:md` passes.
+
+## Order
+
+A then B. Workstream A is mechanical and can land first; Workstream B is a larger rewrite. Each workstream is a single Executor commit.
+
+## Blockers
+
+None.

--- a/docs/superpowers/specs/2026-04-24-1-create-bootstrap-claude-skill-for-repo-scaffolding-design.md
+++ b/docs/superpowers/specs/2026-04-24-1-create-bootstrap-claude-skill-for-repo-scaffolding-design.md
@@ -125,7 +125,7 @@ The emitted `.claude/settings.json` declares the canonical Patina plugins as ena
 ```jsonc
 {
   "enabledPlugins": {
-    "superteam@patinaproject": true,
+    "superteam@patinaproject-skills": true,
     "superpowers@claude-plugins-official": true
   }
 }
@@ -137,7 +137,7 @@ The Patina marketplace itself is typically user-level. The emitted `README.md` a
 /plugin marketplace add patinaproject/skills
 ```
 
-So the first-time-on-machine flow is one command; cloning a bootstrap-scaffolded repo afterward requires no further action. The marketplace id is `patinaproject` (from `patinaproject/skills`).
+So the first-time-on-machine flow is one command; cloning a bootstrap-scaffolded repo afterward requires no further action. The marketplace id is `patinaproject-skills` (Claude Code derives it from the `patinaproject/skills` repo name).
 
 Planner task: verify the exact `enabledPlugins` schema and whether Claude Code supports project-level marketplace declaration (e.g. `extraKnownMarketplaces`) against current Claude Code docs before templating.
 
@@ -197,7 +197,7 @@ Behavior:
 - **AC-1-9** — Public vs. private selection produces the documented README shape differences; `SECURITY.md` is emitted only for public.
 - **AC-1-10** — Scaffolded `markdownlint-cli2` config lints all emitted `*.md` files without errors; `pnpm lint:md` script exits 0 on a fresh scaffold.
 - **AC-1-11** — Husky `pre-commit` hook runs markdown linting on staged `*.md` files and blocks commits with markdownlint violations.
-- **AC-1-12** — Emitted `.claude/settings.json` enables `superteam@patinaproject` and `superpowers@claude-plugins-official`. The skill does not print a post-install step or marketplace-add prompt.
+- **AC-1-12** — Emitted `.claude/settings.json` enables `superteam@patinaproject-skills` and `superpowers@claude-plugins-official`. The skill does not print a post-install step or marketplace-add prompt.
 - **AC-1-13** — When `<is-agent-plugin>` is yes, the skill emits plugin surfaces for Claude Code, Codex, Opencode, Copilot, Cursor, and Windsurf, plus `skills/.gitkeep`. When no, none of those surfaces are emitted.
 - **AC-1-14** — Realignment mode, run against an existing agent plugin that is missing one or more currently-supported platform surfaces, reports the missing platforms and recommends adding them, bringing the plugin up to the current supported-platform set.
 - **AC-1-15** — Realignment mode, run against an existing agent plugin that already covers every currently-supported platform, reports zero platform-coverage gaps.
@@ -224,7 +224,7 @@ Behavior:
 13. Emit `.github/CODEOWNERS` (with a prompted default owner) for all repos.
 14. Emit `SECURITY.md` for public repos only.
 15. Wire `markdownlint-cli2` into PNPM devDeps, expose a `pnpm lint:md` script, and block commits with markdown violations via a husky `pre-commit` hook.
-16. Enable `superteam@patinaproject` and `superpowers@claude-plugins-official` directly in the emitted `.claude/settings.json` under `enabledPlugins`. Do not print or document a marketplace-add command — enablement is declarative.
+16. Enable `superteam@patinaproject-skills` and `superpowers@claude-plugins-official` directly in the emitted `.claude/settings.json` under `enabledPlugins`. Do not print or document a marketplace-add command — enablement is declarative.
 17. Do not emit `.github/workflows/` files or a Dependabot config.
 18. Derive `<author-name>`, `<author-email>`, and the `SECURITY.md` `<security-contact>` default from the user's local `git config user.name` / `git config user.email`. Halt with a blocker if those are unset.
 19. Provide an `<is-agent-plugin>` prompt (default no). When yes, emit plugin surfaces for Claude Code, Codex, Opencode, Copilot, Cursor, and Windsurf, plus `skills/.gitkeep`. Cover Aider, Zed, and Cline through the baseline `AGENTS.md` rather than dedicated rule files.

--- a/docs/superpowers/specs/2026-04-24-3-align-marketplace-id-and-add-per-tool-install-docs-for-every-supported-editor-design.md
+++ b/docs/superpowers/specs/2026-04-24-3-align-marketplace-id-and-add-per-tool-install-docs-for-every-supported-editor-design.md
@@ -1,0 +1,74 @@
+# Design: Align marketplace id and add per-tool install docs for every supported editor [#3](https://github.com/patinaproject/bootstrap/issues/3)
+
+## Intent
+
+Make a fresh-clone install of `bootstrap` actually work end-to-end on every supported editor. Two install-time alignment gaps were discovered closing out [#2](https://github.com/patinaproject/bootstrap/pull/2):
+
+1. The Claude Code marketplace id used in `enabledPlugins` and install snippets (`@patinaproject`) does not match the id Claude Code derives from the marketplace repo name (`patinaproject-skills`). Unresolved entries are silently ignored, so the plugin never enables on a fresh machine.
+2. `README.md` and `skills/bootstrap/templates/agent-plugin/README.md.tmpl` list every supported tool in a "Supported AI coding tools" table but only document install steps for Claude Code, Codex CLI, and Codex App. Eight tools are named without guidance.
+
+These two gaps must land together: a correct install requires both a resolvable id and discoverable per-tool steps.
+
+## Background
+
+`patinaproject/bootstrap` is the reference Claude Code + Codex plugin distributed via `patinaproject/skills`. Claude Code's `/plugin marketplace add patinaproject/skills` registers the marketplace under the id `patinaproject-skills` (derived from the repo name), but the project's own `enabledPlugins` and the bootstrap-emitted templates still reference the older `@patinaproject` literal. Because Claude Code silently ignores unresolved entries, the failure mode is invisible until a user notices that the plugin never enabled.
+
+The same templates also under-document the long tail of supported editors. The README's "Supported AI coding tools" table promises support for 11 tools but only the first 3 have install instructions, leaving GitHub Copilot, Cursor, Windsurf, Aider, Zed, Cline, Opencode, and Continue.dev users guessing.
+
+## Non-goals
+
+- The `patinaproject/skills` marketplace itself (tracked separately).
+- Renaming the marketplace repo.
+- Publishing plugins to npm or other non-marketplace distribution.
+- Release workflow misfiring on every push to `main` and `RELEASING.md` correctness — carved out into [#4](https://github.com/patinaproject/bootstrap/issues/4).
+
+## Decisions
+
+### Marketplace id
+
+Replace every `superteam@patinaproject` and `bootstrap@patinaproject` literal with the `-skills` suffix (`superteam@patinaproject-skills`, `bootstrap@patinaproject-skills`). Apply across:
+
+- `.claude/settings.json`
+- `skills/bootstrap/templates/core/.claude/settings.json`
+- `README.md` install snippet
+- `skills/bootstrap/SKILL.md` Plugin enablement snippet
+- `skills/bootstrap/audit-checklist.md` Area 4 expected-keys note
+- `skills/bootstrap/templates/agent-plugin/README.md.tmpl` install snippet
+- Both prior `docs/superpowers/{specs,plans}/2026-04-24-1-…` artifacts that quote the old id
+
+Preserve `ted@patinaproject.com` (email) in `SECURITY.md` and `package.json` — these are not marketplace ids.
+
+### Per-tool docs
+
+Restructure the README's `## Installation` section into one named subsection per supported tool, in the same order as the "Supported AI coding tools" table. Anchor every table row to its subsection so a reader can click directly to install steps.
+
+Categorize each tool by what bootstrap actually does for it:
+
+- **Plugin marketplace** (Claude Code, Codex CLI, Codex App): exact `marketplace add` + `install` commands.
+- **Emitted instructions file, no extra config** (GitHub Copilot, Cursor, Windsurf): name the file bootstrap emits, point to where the user adds personal overrides.
+- **AGENTS.md alone, no extra config** (Aider, Zed, Cline, Opencode): explicit "clone the repo and open it — `AGENTS.md` is read natively" — no phantom commands.
+- **Opt-in** (Continue.dev): exact `.continue/config.json` snippet to enable the plugin.
+
+Mirror the same structure in `skills/bootstrap/templates/agent-plugin/README.md.tmpl` using `{{repo}}` / `{{owner}}` placeholders so every scaffolded plugin ships per-tool install instructions for free.
+
+The combined table row for `Aider, Zed, Cline, Codex CLI, Opencode` splits into one row per tool so each can anchor to its own subsection (Codex CLI keeps its plugin-marketplace row).
+
+## Acceptance criteria
+
+- **AC-3-1**: `enabledPlugins` in this repo's `.claude/settings.json` uses `superteam@patinaproject-skills`.
+- **AC-3-2**: `skills/bootstrap/templates/core/.claude/settings.json` uses the same id.
+- **AC-3-3**: `skills/bootstrap/SKILL.md` "Plugin enablement" snippet uses the same id.
+- **AC-3-4**: `skills/bootstrap/audit-checklist.md` Area 4 expected-keys check uses the same id.
+- **AC-3-5**: On a fresh machine, `/plugin marketplace add patinaproject/skills` followed by opening this repo in Claude Code enables `superteam` and `bootstrap` without additional steps.
+- **AC-3-6**: `README.md` has an `## Installation` section with a subsection per supported tool: Claude Code, Codex CLI, Codex App, GitHub Copilot, Cursor, Windsurf, Aider, Zed, Cline, Opencode, Continue.dev.
+- **AC-3-7**: The "Supported AI coding tools" table rows link to those subsections via in-document anchors.
+- **AC-3-8**: `skills/bootstrap/templates/agent-plugin/README.md.tmpl` has the same per-tool structure with `{{repo}}` / `{{owner}}` placeholders.
+- **AC-3-9**: Tools covered by `AGENTS.md` alone have sections that say so explicitly, with no phantom install commands.
+- **AC-3-10**: Continue.dev section shows the exact `.continue/config.json` change required to enable the plugin.
+
+## Verification
+
+- `rg '@patinaproject(?!-skills|\.com)'` returns zero matches.
+- `pnpm lint:md` passes.
+- README's table rows anchor-link to real `<h3>` subsections in the same file.
+- Manual fresh-machine walkthrough per AC-3-5 succeeds (operator-driven, post-merge).

--- a/skills/bootstrap/SKILL.md
+++ b/skills/bootstrap/SKILL.md
@@ -130,7 +130,7 @@ The emitted `.claude/settings.json` enables the canonical Patina plugins at the 
 ```jsonc
 {
   "enabledPlugins": {
-    "superteam@patinaproject": true,
+    "superteam@patinaproject-skills": true,
     "superpowers@claude-plugins-official": true
   }
 }

--- a/skills/bootstrap/audit-checklist.md
+++ b/skills/bootstrap/audit-checklist.md
@@ -60,7 +60,7 @@ For every gap, produce a concrete recommendation and show a diff preview. Never 
 |---|---|---|
 | `.claude/settings.json` | yes | present; parses as valid JSONC; `enabledPlugins` declared |
 
-For agent plugins, `enabledPlugins` should include `superteam@patinaproject` and `superpowers@claude-plugins-official` unless the user has explicitly opted out.
+For agent plugins, `enabledPlugins` should include `superteam@patinaproject-skills` and `superpowers@claude-plugins-official` unless the user has explicitly opted out.
 
 ## Area 5 — AI agent plugin surfaces
 

--- a/skills/bootstrap/templates/agent-plugin/README.md.tmpl
+++ b/skills/bootstrap/templates/agent-plugin/README.md.tmpl
@@ -13,6 +13,8 @@
 
 ## Installation
 
+`{{repo}}` ships as a Claude Code + Codex plugin. Other supported editors read the repository-level files this plugin emits (`AGENTS.md`, `.cursor/`, `.windsurfrules`, `.github/copilot-instructions.md`) directly — those tools require no additional plugin install. Pick the section for your tool.
+
 ### Claude Code
 
 1. Register the Patina marketplace:
@@ -24,7 +26,7 @@
 2. Install the plugin:
 
    ```text
-   /plugin install {{repo}}@patinaproject
+   /plugin install {{repo}}@patinaproject-skills
    ```
 
 3. Open a target repository (or an issue in one) in Claude Code and invoke:
@@ -62,6 +64,90 @@
    ```text
    Use ${{repo}} for the workflow described above.
    ```
+
+### GitHub Copilot
+
+No plugin install required. This repo ships `.github/copilot-instructions.md`, which Copilot Chat reads automatically when the repo is open in your editor.
+
+1. Clone the repo and open it.
+2. Invoke `{{repo}}` from Copilot Chat:
+
+   ```text
+   @workspace Use the {{repo}} skill for the workflow described above.
+   ```
+
+Personal Copilot preferences belong in your user-scoped Copilot settings, not in the emitted `.github/copilot-instructions.md`.
+
+### Cursor
+
+No plugin install required. This repo ships `.cursor/rules/{{repo}}.mdc`, which Cursor loads as a project rule whenever the repo is open.
+
+1. Clone the repo and open it in Cursor.
+2. Ask the Cursor agent to apply `{{repo}}`:
+
+   ```text
+   Use the {{repo}} skill for the workflow described above.
+   ```
+
+Personal Cursor rules belong in your user-scoped Cursor settings, not in the emitted `.cursor/rules/`.
+
+### Windsurf
+
+No plugin install required. This repo ships `.windsurfrules`, which Windsurf reads natively when the repo is open.
+
+1. Clone the repo and open it in Windsurf.
+2. Ask Cascade to apply `{{repo}}`:
+
+   ```text
+   Use the {{repo}} skill for the workflow described above.
+   ```
+
+### Aider
+
+No plugin install required. Aider reads `AGENTS.md` natively.
+
+1. Clone the repo.
+2. Run `aider` from inside the repo and ask it to apply the `{{repo}}` workflow described in `AGENTS.md`.
+
+### Zed
+
+No plugin install required. Zed's assistant reads `AGENTS.md` natively.
+
+1. Clone the repo and open it in Zed.
+2. Ask the assistant to apply the `{{repo}}` workflow described in `AGENTS.md`.
+
+### Cline
+
+No plugin install required. Cline reads `AGENTS.md` natively when the repo is open in VS Code.
+
+1. Clone the repo and open it in VS Code with the Cline extension active.
+2. Ask Cline to apply the `{{repo}}` workflow described in `AGENTS.md`.
+
+### Opencode
+
+No plugin install required. Opencode reads `AGENTS.md` natively.
+
+1. Clone the repo and open it in Opencode.
+2. Ask Opencode to apply the `{{repo}}` workflow described in `AGENTS.md`.
+
+### Continue.dev
+
+Continue.dev support is opt-in. Add the following entry to your `.continue/config.json` (project-scoped or user-scoped) so Continue picks up the `{{repo}}` context:
+
+```jsonc
+{
+  "context": [
+    {
+      "provider": "file",
+      "params": {
+        "files": ["AGENTS.md", ".github/copilot-instructions.md"]
+      }
+    }
+  ]
+}
+```
+
+Then ask Continue to apply the `{{repo}}` workflow described in `AGENTS.md`.
 
 ## Usage
 

--- a/skills/bootstrap/templates/core/.claude/settings.json
+++ b/skills/bootstrap/templates/core/.claude/settings.json
@@ -1,6 +1,6 @@
 {
   "enabledPlugins": {
-    "superteam@patinaproject": true,
+    "superteam@patinaproject-skills": true,
     "superpowers@claude-plugins-official": true
   }
 }


### PR DESCRIPTION
## Summary

- Replace `superteam@patinaproject` / `bootstrap@patinaproject` with `superteam@patinaproject-skills` / `bootstrap@patinaproject-skills` everywhere it appears. Claude Code derives the marketplace id from the `patinaproject/skills` repo name when running `/plugin marketplace add patinaproject/skills`, so the old id silently failed to resolve and the plugin never enabled on a fresh install.
- Expand `README.md` and `skills/bootstrap/templates/agent-plugin/README.md.tmpl` so every tool listed in the "Supported AI coding tools" table has its own install subsection, anchored from the table. AGENTS.md-only tools get explicit "no extra config" sections; Continue.dev gets its opt-in `.continue/config.json` snippet.
- The release-workflow misfire-on-every-push problem and `RELEASING.md` correctness are tracked separately in #4.

## Linked issue

Closes #3

## Acceptance criteria

### AC-3-1

`enabledPlugins` in this repo's `.claude/settings.json` uses `superteam@patinaproject-skills`.

- [ ] `rg '"superteam@patinaproject-skills": true' .claude/settings.json`

### AC-3-2

Emitted core template uses the same id.

- [ ] `rg '"superteam@patinaproject-skills": true' skills/bootstrap/templates/core/.claude/settings.json`

### AC-3-3

`SKILL.md` "Plugin enablement" snippet uses the same id.

- [ ] `rg 'superteam@patinaproject-skills' skills/bootstrap/SKILL.md`

### AC-3-4

`audit-checklist.md` Area 4 expected-keys check uses the same id.

- [ ] `rg 'superteam@patinaproject-skills' skills/bootstrap/audit-checklist.md`

### AC-3-5

On a fresh machine, `/plugin marketplace add patinaproject/skills` followed by opening this repo enables `superteam` and `bootstrap` without additional steps.

- [ ] Operator-driven verification post-merge: run the two-step flow on a fresh Claude Code profile and confirm both plugins enable.

### AC-3-6

`README.md` has an `## Installation` section with one subsection per supported tool.

- [ ] `rg -n '^### ' README.md` lists subsections for Claude Code, OpenAI Codex CLI, OpenAI Codex App, GitHub Copilot, Cursor, Windsurf, Aider, Zed, Cline, Opencode, Continue.dev.

### AC-3-7

"Supported AI coding tools" table rows link to those subsections via in-document anchors.

- [ ] Render README on GitHub and click each tool name in the table — each must scroll to the matching install section.

### AC-3-8

`skills/bootstrap/templates/agent-plugin/README.md.tmpl` has the same per-tool structure with `{{repo}}` / `{{owner}}` placeholders.

- [ ] `rg -n '^### ' skills/bootstrap/templates/agent-plugin/README.md.tmpl` matches the same 11 subsections; placeholders untouched.

### AC-3-9

AGENTS.md-only tools have sections that say so explicitly, with no phantom install commands.

- [ ] Aider, Zed, Cline, Opencode subsections in both README files contain "No plugin install required" wording and zero `marketplace add` / `install` commands.

### AC-3-10

Continue.dev section shows the exact `.continue/config.json` change required.

- [ ] Continue.dev subsection in both README files contains a `.continue/config.json` JSONC code block.

## Validation

- [x] `rg '@patinaproject(?!-skills|\.com|/maintainers)'` returns zero matches across the tree.
- [x] `pnpm lint:md` exits 0.
- [x] All required CI checks green on the latest pushed head (`markdownlint-cli2`, `Validate PR title`, `Require closing keyword`, `Mark breaking change`, Socket Security x2).

## Docs updated

- [ ] Not needed
- [x] Updated in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)