### PR TITLE
fix: #4 make release workflow manual-dispatch only

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,7 +27,7 @@ This title rule applies to pull requests only. GitHub issue titles should stay p
 
 Short outcome summary.
 
-- [ ] `verification command`
+- [ ] Manual test: `verification command`
 
 ### AC-<issue>-<n>
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,7 @@
 name: Release
 
 on:
-  push:
-    branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,8 @@ Pin every action reference to a full 40-character commit SHA, not a tag. Tags ar
 
 `actionlint` runs in CI on `.github/workflows/**` changes and enforces this convention as part of its other checks.
 
+Also enable **Settings → Actions → General → Require actions to be pinned to a full-length commit SHA** (at the repo or org level). GitHub then refuses to run any workflow that `uses:` an action by tag or branch, giving a hard gate on top of the CI check.
+
 ## Commit & Pull Request Guidelines
 
 Commits are enforced with Husky + commitlint. Use conventional commits with no scope and a required GitHub issue tag:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,13 +4,31 @@ Releases are driven by [release-please](https://github.com/googleapis/release-pl
 
 ## How it works
 
-1. Every push to `main` runs the `Release` workflow.
+1. A maintainer manually triggers the `Release` workflow from **Actions → Release → Run workflow** on `main`. The workflow does not run on pushes.
 2. `release-please` scans Conventional Commits since the last tag.
 3. It opens (or updates) a standing **"chore: release X.Y.Z"** PR that:
    - Bumps `package.json` version.
    - Syncs `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json` to the new version (configured in `release-please-config.json`).
    - Appends generated entries to `CHANGELOG.md`.
 4. **Clicking Merge on that PR** is the release action. It tags `vX.Y.Z` and publishes a GitHub Release with notes generated from the same commits.
+
+## Prerequisites (one-time settings)
+
+### Allow Actions to create pull requests
+
+`release-please` opens its standing release PR using `secrets.GITHUB_TOKEN`. This requires:
+
+- **Settings → Actions → General → Workflow permissions → Allow GitHub Actions to create and approve pull requests**.
+
+If the repo-level checkbox is greyed out, the setting is controlled by the organization. For repos under `patinaproject`, enable it once at the org level: **organization Settings → Actions → General → Workflow permissions**, then toggle the same option. Without it, the workflow fails with `GitHub Actions is not permitted to create or approve pull requests.`
+
+### Require SHA-pinned actions
+
+Also recommended (defense-in-depth, aligns with the SHA-pin convention in [`AGENTS.md`](AGENTS.md)):
+
+- **Settings → Actions → General → Require actions to be pinned to a full-length commit SHA** (available at repo or org level).
+
+When enabled, GitHub refuses to run workflows that `uses:` an action by tag or branch.
 
 ## Semver decision
 

--- a/skills/bootstrap/templates/agent-plugin/.github/workflows/release.yml
+++ b/skills/bootstrap/templates/agent-plugin/.github/workflows/release.yml
@@ -1,8 +1,7 @@
 name: Release
 
 on:
-  push:
-    branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/skills/bootstrap/templates/core/.github/pull_request_template.md
+++ b/skills/bootstrap/templates/core/.github/pull_request_template.md
@@ -27,7 +27,7 @@ This title rule applies to pull requests only. GitHub issue titles should stay p
 
 Short outcome summary.
 
-- [ ] `verification command`
+- [ ] Manual test: `verification command`
 
 ### AC-<issue>-<n>
 

--- a/skills/bootstrap/templates/core/AGENTS.md.tmpl
+++ b/skills/bootstrap/templates/core/AGENTS.md.tmpl
@@ -75,6 +75,8 @@ Pin every action reference to a full 40-character commit SHA, not a tag. Tags ar
 
 `actionlint` runs in CI on `.github/workflows/**` changes and enforces workflow hygiene as part of its other checks.
 
+Also enable **Settings → Actions → General → Require actions to be pinned to a full-length commit SHA** (at the repo or org level). GitHub then refuses to run any workflow that `uses:` an action by tag or branch, giving a hard gate on top of the CI check.
+
 ## Commit & Pull Request Guidelines
 
 Commits are enforced with Husky + commitlint. Use conventional commits with no scope and a required GitHub issue tag:

--- a/skills/bootstrap/templates/core/RELEASING.md
+++ b/skills/bootstrap/templates/core/RELEASING.md
@@ -4,13 +4,31 @@ Releases are driven by [release-please](https://github.com/googleapis/release-pl
 
 ## How it works
 
-1. Every push to `main` runs the `Release` workflow.
+1. A maintainer manually triggers the `Release` workflow from **Actions → Release → Run workflow** on `main`. The workflow does not run on pushes.
 2. `release-please` scans Conventional Commits since the last tag.
 3. It opens (or updates) a standing **"chore: release X.Y.Z"** PR that:
    - Bumps `package.json` version.
    - Syncs `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json` to the new version (configured in `release-please-config.json`).
    - Appends generated entries to `CHANGELOG.md`.
 4. **Clicking Merge on that PR** is the release action. It tags `vX.Y.Z` and publishes a GitHub Release with notes generated from the same commits.
+
+## Prerequisites (one-time settings)
+
+### Allow Actions to create pull requests
+
+`release-please` opens its standing release PR using `secrets.GITHUB_TOKEN`. This requires:
+
+- **Settings → Actions → General → Workflow permissions → Allow GitHub Actions to create and approve pull requests**.
+
+If the repo-level checkbox is greyed out, the setting is controlled by the organization. Enable it once at the org level: **organization Settings → Actions → General → Workflow permissions**, then toggle the same option. Without it, the workflow fails with `GitHub Actions is not permitted to create or approve pull requests.`
+
+### Require SHA-pinned actions
+
+Also recommended (defense-in-depth, aligns with the SHA-pin convention in [`AGENTS.md`](AGENTS.md)):
+
+- **Settings → Actions → General → Require actions to be pinned to a full-length commit SHA** (available at repo or org level).
+
+When enabled, GitHub refuses to run workflows that `uses:` an action by tag or branch.
 
 ## Semver decision
 

--- a/skills/bootstrap/templates/patinaproject-supplement/.github/workflows/release.yml
+++ b/skills/bootstrap/templates/patinaproject-supplement/.github/workflows/release.yml
@@ -1,8 +1,7 @@
 name: Release
 
 on:
-  push:
-    branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

- Switch the `Release` workflow trigger from `push: [main]` to `workflow_dispatch` in the root workflow, the agent-plugin bootstrap template, and the patinaproject supplement. No other workflows changed.
- Document the one-time GitHub settings prerequisites in `RELEASING.md` and the emitted template: (1) allow Actions to create PRs so `release-please` can open the standing release PR, (2) require actions to be pinned to a full-length commit SHA as defense-in-depth on top of `actionlint`.
- Mirror the SHA-pin setting recommendation in `AGENTS.md` and the emitted `AGENTS.md.tmpl`.

## Linked issue

Closes #4

## Acceptance criteria

### AC-4-1

`.github/workflows/release.yml` triggers only on `workflow_dispatch`.

- [ ] Manual test: `grep -A1 '^on:' .github/workflows/release.yml` shows `workflow_dispatch:` and no `push:` block

### AC-4-2

A manual run on `main` succeeds end-to-end (release-please opens or updates the standing release PR without permission errors).

- [ ] Manual test: after merge, run **Actions → Release → Run workflow** on `main` and confirm the `release-please` job is green and a `chore: release X.Y.Z` PR exists or is updated

### AC-4-3

`RELEASING.md` describes the manual-dispatch flow and the settings prerequisites.

- [ ] Manual test: review the updated `How it works` + `Prerequisites` sections

### AC-4-4

Bootstrap-emitted release workflow and `RELEASING.md` templates match the new model.

- [ ] Manual test: `grep -A1 '^on:' skills/bootstrap/templates/agent-plugin/.github/workflows/release.yml skills/bootstrap/templates/patinaproject-supplement/.github/workflows/release.yml` shows only `workflow_dispatch:`
- [ ] Manual test: `diff RELEASING.md skills/bootstrap/templates/core/RELEASING.md` only differs in the `patinaproject`-specific phrasing line

### AC-4-5

No other workflow regressions.

- [ ] Manual test: `git diff --name-only main -- .github/workflows/` lists only `release.yml`

## Validation

- `pnpm lint:md` — 0 errors on 24 files
- Org-level "Allow GitHub Actions to create and approve pull requests" toggle has been flipped (confirmed by issue author)

## Docs updated

- [x] Updated in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)