### PR TITLE
docs: #7 instruct agents to follow .github/ templates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,20 @@ Verify every label has a non-empty description:
 gh label list --json name,description --jq '.[] | select(.description == "")'
 ```
 
+## Working with `.github/` templates
+
+This repo ships canonical templates for issues and pull requests. Agents must use them — do not invent parallel structure.
+
+- Pull requests: `.github/pull_request_template.md`. Read it before running `gh pr create`. The PR body must use the template's section headings (`Summary`, `Linked issue`, `Acceptance criteria`, `Validation`, `Docs updated`) in the order the template defines, even when the body is passed inline via `--body`.
+- Issues: `.github/ISSUE_TEMPLATE/bug_report.md` and `.github/ISSUE_TEMPLATE/feature_request.md`. Pick the one that matches the report and reproduce its sections in order.
+
+Recommended `gh` patterns:
+
+- PRs: `gh pr create --body-file <path-to-rendered-body>` is the safest path. The rendered body must already follow the template. If you pass `--body` inline, copy every template section name and order verbatim before filling them in.
+- Issues: `gh issue create --template bug_report.md` or `--template feature_request.md` lets `gh` start from the canonical file. If you pass `--body` inline, mirror the template's headings the same way.
+
+Do not invent alternative section names (e.g. `Out of scope`, `Verification`, `Notes`) when the template uses different ones — extend an existing section instead, or open a follow-up to update the template itself. The PR-body acceptance-criteria rules under [Commit & Pull Request Guidelines](#commit--pull-request-guidelines) are a refinement of the template's `Acceptance criteria` section, not a replacement for it.
+
 ## GitHub Actions pinning
 
 Pin every action reference to a full 40-character commit SHA, not a tag. Tags are mutable; SHAs are not. Above each `uses:` line, leave a comment naming the action and version the SHA corresponds to, so updates remain reviewable.

--- a/docs/superpowers/plans/2026-04-24-7-agents-should-explicitly-read-and-follow-github-templates-plan.md
+++ b/docs/superpowers/plans/2026-04-24-7-agents-should-explicitly-read-and-follow-github-templates-plan.md
@@ -1,0 +1,32 @@
+# Plan: Agents should explicitly read and follow .github templates when filing issues and PRs [#7](https://github.com/patinaproject/bootstrap/issues/7)
+
+## Workstream — single batch
+
+One commit covering both surfaces.
+
+### T-1 — Add the section to `AGENTS.md` (AC-7-1, AC-7-2, AC-7-4)
+
+Insert a new `## Working with .github/ templates` section in [AGENTS.md](AGENTS.md) immediately after `## Issue and PR labels` (line 64–72) and before `## GitHub Actions pinning` (line 74). The section explains:
+
+- Where the templates live: `.github/pull_request_template.md`, `.github/ISSUE_TEMPLATE/bug_report.md`, `.github/ISSUE_TEMPLATE/feature_request.md`.
+- The rule: read the relevant template first; the body's section names and order must match it verbatim.
+- Recommended `gh` invocation: `gh pr create --body-file <(cat <<'EOF' ... EOF)` or `gh pr create --template pull_request_template.md` patterns. Acceptable fallback: pass `--body` inline as long as every template section is present in order.
+- A "do not invent" line: do not introduce alternative section names like `Out of scope`, `Verification`, etc. when the template uses different ones (e.g. `Validation`, `Docs updated`).
+- Cross-reference: the existing PR-body acceptance-criteria rules under `## Commit & Pull Request Guidelines` are a refinement of the template's `Acceptance criteria` section.
+
+### T-2 — Mirror the section into `skills/bootstrap/templates/core/AGENTS.md.tmpl` (AC-7-3, AC-7-4)
+
+Insert a parallel section into [skills/bootstrap/templates/core/AGENTS.md.tmpl](skills/bootstrap/templates/core/AGENTS.md.tmpl) at the same logical position (after `## Issue and PR labels`, before `## GitHub Actions pinning`). Wording matches the AGENTS.md change, but uses generic references that hold for any scaffolded repo (no `patinaproject`-specific examples).
+
+### T-3 — Verify (AC-7-5)
+
+- `rg` checks per the design's verification list.
+- `pnpm lint:md`.
+
+## Order
+
+T-1 → T-2 → T-3, single commit.
+
+## Blockers
+
+None.

--- a/docs/superpowers/specs/2026-04-24-7-agents-should-explicitly-read-and-follow-github-templates-design.md
+++ b/docs/superpowers/specs/2026-04-24-7-agents-should-explicitly-read-and-follow-github-templates-design.md
@@ -1,0 +1,50 @@
+# Design: Agents should explicitly read and follow .github templates when filing issues and PRs [#7](https://github.com/patinaproject/bootstrap/issues/7)
+
+## Intent
+
+Add explicit, hard-to-miss instructions in `AGENTS.md` (and the bootstrap-emitted `AGENTS.md` template) telling AI agents to read and follow `.github/pull_request_template.md` and `.github/ISSUE_TEMPLATE/*.md` before creating PRs or issues. The current PR-body guidance in `AGENTS.md` describes content rules but never points at the template file as the source of truth, so agents reach for `gh ... --body "..."` with their own structure and silently bypass the template.
+
+## Background
+
+Discovered while closing out [#3](https://github.com/patinaproject/bootstrap/issues/3) / [#5](https://github.com/patinaproject/bootstrap/pull/5): the PR was opened with sections `Summary` / `Out of scope` / `Acceptance Criteria` / `Verification` instead of the template's `Summary` / `Linked issue` / `Acceptance criteria` / `Validation` / `Docs updated`. The fix had to come after the fact when the operator noticed.
+
+The root cause is a documentation gap, not a tooling gap. `AGENTS.md` is the contract every agent reads first. Once it explicitly says "read the template file and structure your body to match," the bypass becomes a contract violation rather than an honest miss.
+
+## Non-goals
+
+- Updating the `superteam` skill itself in `patinaproject/skills` (separate cross-repo change).
+- Adding new issue templates or restructuring existing ones.
+- Programmatic enforcement (CI diff against the template).
+
+## Decisions
+
+### Add a dedicated `## Working with .github/ templates` section to `AGENTS.md`
+
+Add the section between the existing `## Issue and PR labels` section and `## GitHub Actions pinning` so it sits inside the "things every contributor must do for issues/PRs" cluster. It must:
+
+1. Name the exact file paths an agent should read first: `.github/pull_request_template.md` and `.github/ISSUE_TEMPLATE/*.md`.
+2. State the rule: a PR/issue body must use the template's section names and order verbatim, even when the body is passed inline via `--body`.
+3. Recommend `gh ... --body-file <path>` workflow as the default; show the inline-body fallback as acceptable only when every template section is reproduced verbatim.
+4. Cross-reference the existing PR-body acceptance-criteria rules so they read as a refinement of the template, not a parallel contract.
+
+### Mirror the section into `skills/bootstrap/templates/core/AGENTS.md.tmpl`
+
+Identical structure, same wording, so every scaffolded repo inherits the rule on day one. The template's wording must not reference repo-specific filenames that may not exist in a freshly-scaffolded repo (e.g. `bug_report.md` is part of the core baseline, but the wording should still degrade gracefully if a future scaffold removes one of the issue templates).
+
+## Acceptance criteria
+
+- **AC-7-1**: `AGENTS.md` has a `## Working with .github/ templates` section that explicitly tells agents to read `.github/pull_request_template.md` before creating a PR and the matching `.github/ISSUE_TEMPLATE/*.md` before creating an issue.
+- **AC-7-2**: The section recommends `gh ... --body-file` (or a body that mirrors the template structure verbatim) and warns against inventing alternative section names.
+- **AC-7-3**: The same section is present, with parallel wording, in `skills/bootstrap/templates/core/AGENTS.md.tmpl`.
+- **AC-7-4**: No phantom file references — the section only names files that exist in the core baseline (`.github/pull_request_template.md`, `.github/ISSUE_TEMPLATE/bug_report.md`, `.github/ISSUE_TEMPLATE/feature_request.md`).
+- **AC-7-5**: `pnpm lint:md` passes.
+
+## Verification
+
+- `rg -n '## Working with' AGENTS.md skills/bootstrap/templates/core/AGENTS.md.tmpl` returns one match in each file.
+- `rg -n 'pull_request_template.md' AGENTS.md skills/bootstrap/templates/core/AGENTS.md.tmpl` returns at least one match in each file.
+- `rg -n 'ISSUE_TEMPLATE' AGENTS.md skills/bootstrap/templates/core/AGENTS.md.tmpl` returns at least one match in each file.
+- `pnpm lint:md` exits 0.
+- Manual readthrough: the new section's tone matches the surrounding `AGENTS.md` voice (terse, imperative).
+
+Remaining concerns: None.

--- a/skills/bootstrap/templates/core/AGENTS.md.tmpl
+++ b/skills/bootstrap/templates/core/AGENTS.md.tmpl
@@ -64,6 +64,20 @@ Verify every label has a non-empty description:
 gh label list --json name,description --jq '.[] | select(.description == "")'
 ```
 
+## Working with `.github/` templates
+
+This repo ships canonical templates for issues and pull requests. Agents must use them — do not invent parallel structure.
+
+- Pull requests: `.github/pull_request_template.md`. Read it before running `gh pr create`. The PR body must use the template's section headings in the order the template defines, even when the body is passed inline via `--body`.
+- Issues: `.github/ISSUE_TEMPLATE/bug_report.md` and `.github/ISSUE_TEMPLATE/feature_request.md`. Pick the one that matches the report and reproduce its sections in order.
+
+Recommended `gh` patterns:
+
+- PRs: `gh pr create --body-file <path-to-rendered-body>` is the safest path. The rendered body must already follow the template. If you pass `--body` inline, copy every template section name and order verbatim before filling them in.
+- Issues: `gh issue create --template bug_report.md` or `--template feature_request.md` lets `gh` start from the canonical file. If you pass `--body` inline, mirror the template's headings the same way.
+
+Do not invent alternative section names when the template uses different ones — extend an existing section instead, or open a follow-up to update the template itself. The PR-body acceptance-criteria rules under [Commit & Pull Request Guidelines](#commit--pull-request-guidelines) are a refinement of the template's `Acceptance criteria` section, not a replacement for it.
+
 ## GitHub Actions pinning
 
 Pin every action reference to a full 40-character commit SHA, not a tag. Tags are mutable; SHAs are not. Above each `uses:` line, leave a comment naming the action and version the SHA corresponds to, so updates remain reviewable.


### PR DESCRIPTION
## Summary

- Add a `## Working with .github/ templates` section to `AGENTS.md` that explicitly tells agents to read `.github/pull_request_template.md` and `.github/ISSUE_TEMPLATE/*.md` before running `gh pr create` / `gh issue create`, and to use `--body-file` (or mirror the template's section names verbatim) instead of inventing alternative structure.
- Mirror the same section into `skills/bootstrap/templates/core/AGENTS.md.tmpl` so every scaffolded repo inherits the rule on day one.
- Cross-reference the existing PR-body acceptance-criteria rules so they read as a refinement of the template, not a parallel contract.

## Linked issue

Closes #7

## Acceptance criteria

### AC-7-1

`AGENTS.md` has a `## Working with .github/ templates` section explicitly directing agents to the PR and issue templates.

- [ ] `rg -n '## Working with `.github/` templates' AGENTS.md`

### AC-7-2

The section recommends `gh ... --body-file` and warns against inventing alternative section names.

- [ ] `rg -n -- '--body-file' AGENTS.md`
- [ ] `rg -n 'Do not invent' AGENTS.md`

### AC-7-3

The same section is present, with parallel wording, in `skills/bootstrap/templates/core/AGENTS.md.tmpl`.

- [ ] `rg -n '## Working with `.github/` templates' skills/bootstrap/templates/core/AGENTS.md.tmpl`

### AC-7-4

Section names only files that exist in the core baseline.

- [ ] Only `.github/pull_request_template.md`, `.github/ISSUE_TEMPLATE/bug_report.md`, `.github/ISSUE_TEMPLATE/feature_request.md` are referenced.

### AC-7-5

`pnpm lint:md` passes.

- [x] `pnpm lint:md` exits 0 on the latest pushed head.

## Validation

- [x] `pnpm lint:md` exits 0.
- [x] `rg '## Working with' AGENTS.md skills/bootstrap/templates/core/AGENTS.md.tmpl` returns one match in each file.
- [x] PR body itself was authored against `.github/pull_request_template.md` via `--body-file` (eating our own dog food).

## Docs updated

- [ ] Not needed
- [x] Updated in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
