### PR TITLE
docs: #11 incorporate issue filing style into templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -5,13 +5,13 @@ title: ""
 labels: bug
 ---
 
+<!-- Title: plain-language summary (no `fix:` prefix). Labels: see .github/LABELS.md. -->
+
 ## Summary
 
-A clear, plain-language description of what's wrong.
+Plain-language description of what's wrong.
 
 ## Reproduction
-
-Minimal steps to reproduce the issue.
 
 1.
 2.
@@ -19,11 +19,9 @@ Minimal steps to reproduce the issue.
 
 ## Expected behavior
 
-What you expected to happen.
-
 ## Actual behavior
 
-What actually happened. Include error messages, logs, or screenshots when relevant.
+Include error messages, logs, or screenshots when relevant.
 
 ## Environment
 
@@ -31,6 +29,6 @@ What actually happened. Include error messages, logs, or screenshots when releva
 - Runtime / tool version:
 - Repo commit or release:
 
-## Additional context
+## Relationships
 
-Anything else that would help diagnose the issue.
+Linked issues, PRs, or prior reports.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -5,6 +5,8 @@ title: ""
 labels: enhancement
 ---
 
+<!-- Title: plain-language summary (no `feat:` prefix). Labels: see .github/LABELS.md. -->
+
 ## Problem
 
 What problem does this solve? Who is affected?
@@ -13,10 +15,21 @@ What problem does this solve? Who is affected?
 
 What should change. Be concrete about behavior, file layout, or user-visible impact.
 
-## Alternatives considered
+## Non-Goals (optional)
 
-Other approaches and why they were rejected.
+What is explicitly out of scope.
 
-## Additional context
+## Implementation Notes (optional)
 
-Links, prior discussions, or related issues.
+Constraints, risks, or pointers that help the implementer.
+
+## Acceptance Criteria
+
+<!-- Use AC-<issue-number>-<n> IDs and Given/When/Then phrasing.
+     See docs/ac-traceability.md for the full convention. -->
+
+- AC-<issue>-1: Given ..., when ..., then ...
+
+## Relationships
+
+Linked issues, PRs, or discussions (e.g. `Relates to #123`, `Blocks #456`).

--- a/.github/LABELS.md
+++ b/.github/LABELS.md
@@ -1,0 +1,20 @@
+# Labels
+
+This file is the source of truth for when to apply each issue and pull-request label in this repository. It exists so reporters and agents can pick labels without guessing, and so label drift stays visible in review. For the authoritative runtime inventory, run `gh label list --json name,description`.
+
+## Current labels
+
+- `bug`: Apply when the report describes a defect, regression, or unexpected behavior in shipped code or docs.
+- `documentation`: Apply when the change is primarily to Markdown, in-repo docs, or comments that describe behavior.
+- `duplicate`: Apply when another open or closed issue already tracks the same problem; link the canonical issue in the body.
+- `enhancement`: Apply when the report proposes a new capability or improves an existing one without fixing a defect.
+- `good first issue`: Apply when the work is small, well-scoped, and safe for a first-time contributor to pick up.
+- `help wanted`: Apply when maintainers are actively soliciting outside contributions on the issue.
+- `invalid`: Apply when the report is not actionable as filed (wrong repo, not reproducible, out of scope) and cannot be salvaged by editing.
+- `question`: Apply when the issue is a support request or clarification rather than a change request.
+- `wontfix`: Apply when the behavior described is intentional or the maintainers have decided not to act on it; leave a short rationale before closing.
+- `autorelease: pending`: Tool-managed by release-please; do not apply manually. Its GitHub description is currently empty, which is a known gap tracked for follow-up.
+
+## Adding or changing labels
+
+Use `gh label list --json name,description` as the canonical inventory and follow the label-hygiene rule in [`AGENTS.md`](../AGENTS.md) (every label must have a non-empty description). Do not introduce new labels in an issue or PR without first updating the repository label set and this file.

--- a/docs/ac-traceability.md
+++ b/docs/ac-traceability.md
@@ -1,0 +1,23 @@
+# Acceptance criteria traceability
+
+This doc defines the acceptance-criteria (AC) convention used in issues and pull requests. Keeping AC IDs stable across the issue, design, plan, and PR lets reviewers trace a requirement end to end.
+
+## AC-ID format
+
+Use `AC-<issue-number>-<integer>`, numbered from 1 within a single issue. Examples: `AC-11-1`, `AC-11-2`, `AC-123-7`. The issue number is the GitHub issue the ACs belong to, not the PR number.
+
+## Given/When/Then phrasing
+
+Write each AC as a single sentence in Given/When/Then form so the precondition, trigger, and observable outcome are explicit.
+
+Example:
+
+- AC-11-1: Given a reporter opens the feature request template, when they fill every required section, then the rendered issue contains Problem, Proposal, Acceptance Criteria, and Relationships in that order.
+
+## Outcome, not artifact
+
+ACs describe observable behavior, not implementation steps. Prefer "the template renders section X" over "edit file Y"; prefer "`gh issue view` shows AC-11-1" over "run sed on the body". Implementation choices belong in the design or plan, not in the AC.
+
+## From issue to PR
+
+The PR body mirrors the issue's ACs using the `### AC-<issue>-<n>` heading-per-AC format specified in [`AGENTS.md`](../AGENTS.md). One heading per relevant AC, a short outcome summary, and checkboxes only for verification steps. Do not restate those rules here — extend `AGENTS.md` if they need to change.

--- a/docs/superpowers/plans/2026-04-24-11-incorporate-issue-filing-style-into-issue-templates-plan.md
+++ b/docs/superpowers/plans/2026-04-24-11-incorporate-issue-filing-style-into-issue-templates-plan.md
@@ -1,0 +1,88 @@
+# Plan: Incorporate issue filing style into issue templates [#11](https://github.com/patinaproject/bootstrap/issues/11)
+
+## Context
+
+The design at `docs/superpowers/specs/2026-04-24-11-incorporate-issue-filing-style-into-issue-templates-design.md` (commit `6c8a55b`) is authoritative. The goal is to align `.github/ISSUE_TEMPLATE/feature_request.md` and `.github/ISSUE_TEMPLATE/bug_report.md` with the repository's issue filing style (title conventions, label taxonomy, AC-ID format, relationships) without bloating the templates.
+
+Operator constraint: templates must stay short. They are skeletons with HTML-comment hints that link to source-of-truth docs (`.github/LABELS.md`, `docs/ac-traceability.md`). Prose lives in those docs and `AGENTS.md`, not in the templates.
+
+## Workstreams
+
+### T-11-1: Add `.github/LABELS.md` (AC-11-3)
+
+Create `.github/LABELS.md` documenting the canonical label set. Contents:
+
+- One-paragraph purpose statement explaining the file is the source of truth for when to apply each label.
+- Enumerated entries for the 10 current labels: `bug`, `documentation`, `duplicate`, `enhancement`, `good first issue`, `help wanted`, `invalid`, `question`, `wontfix`, `autorelease: pending`. Each entry gets a single "when to apply" sentence.
+- "Adding or changing labels" section that points back to the `gh label list --json name,description` invariant in `AGENTS.md` rather than restating it.
+
+### T-11-2: Add `docs/ac-traceability.md` (AC-11-3)
+
+Create `docs/ac-traceability.md` documenting AC conventions. Contents:
+
+- AC-ID format: `AC-<issue-number>-<integer>` with examples (`AC-11-1`, `AC-11-2`).
+- Given/When/Then phrasing guidance with a short example.
+- Outcome-not-artifact principle: ACs describe observable behavior, not implementation artifacts.
+- How ACs flow from the issue body into the PR body (point at the existing PR-body AC rules in `AGENTS.md`; do not duplicate them).
+
+### T-11-3: Rewrite `.github/ISSUE_TEMPLATE/feature_request.md` (AC-11-1)
+
+Replace the current feature request template with the skeleton from the design's §Section skeletons. Required sections in order:
+
+1. Front matter (`name: Feature request`, `about`, `title: ""`, `labels: enhancement`).
+2. HTML-comment header pointing at `.github/LABELS.md` and noting the plain-language title convention.
+3. `## Problem`
+4. `## Proposal`
+5. `## Non-Goals (optional)`
+6. `## Implementation Notes (optional)`
+7. `## Acceptance Criteria` with an HTML comment pointing at `docs/ac-traceability.md` and a single `AC-<issue>-1` seed bullet using Given/When/Then.
+8. `## Relationships` with example wording (`Relates to #123`, `Blocks #456`).
+
+Target: roughly 30 rendered lines.
+
+### T-11-4: Rewrite `.github/ISSUE_TEMPLATE/bug_report.md` (AC-11-2)
+
+Replace the current bug template with the bug skeleton from the design. Required sections in order:
+
+1. Front matter (`name: Bug report`, `about`, `title: ""`, `labels: bug`).
+2. HTML-comment header pointing at `.github/LABELS.md` and noting the plain-language title convention.
+3. `## Summary`
+4. `## Reproduction` (numbered list scaffold).
+5. `## Expected behavior`
+6. `## Actual behavior` with a line reminding reporters to include logs or screenshots.
+7. `## Environment` with `OS`, `Runtime / tool version`, `Repo commit or release` bullets.
+8. `## Relationships`.
+
+Target: roughly 25 rendered lines.
+
+### T-11-5: Patch issue #11 AC IDs (operator cleanup)
+
+Issue #11's body uses `AC-<this>-N` placeholders. Run `gh issue view 11 --json body --jq .body` to capture the current body, replace every `AC-<this>-` with `AC-11-`, and apply with `gh issue edit 11 --body-file <file>`. Verify with `gh issue view 11` afterward. No AC maps to this directly; it is operator-requested cleanup in service of AC-11-3's AC-ID format invariant.
+
+### T-11-6: Cross-check templates and `AGENTS.md` for contradictions (AC-11-4)
+
+After T-11-3 and T-11-4, diff the template text against `AGENTS.md` sections on title conventions, label guidance, and relationship wording. Only adjust a file if a contradiction exists; the default is no edit. Record the cross-check result in the PR validation notes. Do not broaden `AGENTS.md` prose beyond what is strictly required for template cross-references (per the design's Out of scope).
+
+## Ordering and dependencies
+
+1. T-11-1 and T-11-2 land first (or in the same commit as the templates) so the template links resolve on first render.
+2. T-11-3 and T-11-4 land next; they depend on T-11-1 and T-11-2 for link targets.
+3. T-11-5 can run independently at any point.
+4. T-11-6 runs after T-11-3 and T-11-4.
+
+All template and docs work can land in a single PR. T-11-5 is an issue-body edit and does not require a commit.
+
+## Verification
+
+- `pnpm lint:md` passes on the working tree.
+- `find .github/ISSUE_TEMPLATE .github/LABELS.md docs/ac-traceability.md -type f` lists the feature template, bug template, labels doc, and AC traceability doc.
+- `wc -l .github/ISSUE_TEMPLATE/feature_request.md .github/ISSUE_TEMPLATE/bug_report.md` reports roughly <=35 lines each. Cite the counts in the PR validation notes as evidence of the "short" constraint.
+- `rg -n '\.github/LABELS\.md' .github/ISSUE_TEMPLATE` returns at least one match per template.
+- `rg -n 'docs/ac-traceability\.md' .github/ISSUE_TEMPLATE/feature_request.md` returns at least one match.
+- `gh issue view 11` body shows `AC-11-1` through `AC-11-4` with no remaining `<this>` placeholders.
+- Manual render check: open both templates on GitHub's "New issue" UI (or inspect the raw Markdown) and confirm HTML comments are invisible in the preview while section headings remain in the documented order.
+- `rg -n 'feat:|fix:' .github/ISSUE_TEMPLATE` returns no matches outside HTML comments that explicitly forbid those prefixes (guards against accidental reintroduction of conventional-commit prefixes in titles).
+
+## Blockers
+
+None.

--- a/docs/superpowers/specs/2026-04-24-11-incorporate-issue-filing-style-into-issue-templates-design.md
+++ b/docs/superpowers/specs/2026-04-24-11-incorporate-issue-filing-style-into-issue-templates-design.md
@@ -1,0 +1,146 @@
+# Design: Incorporate issue filing style into issue templates [#11](https://github.com/patinaproject/bootstrap/issues/11)
+
+## Context
+
+The repository has a documented issue-filing style (title conventions, label guidance, acceptance-criteria format, relationship wording), but the canonical GitHub issue templates under `.github/ISSUE_TEMPLATE/` do not reflect it. Reporters relying on the templates produce issues that miss `Acceptance Criteria` sections, use inconsistent AC-ID formats, or pick labels ad-hoc. This forces reviewers to rewrite issues after the fact and creates drift between `AGENTS.md` (which governs agent behavior) and the human-facing templates (which govern reporter behavior).
+
+The fix is to teach the templates the filing style without bloating them. Long templates discourage filing and hide the signal. The canonical prose belongs in dedicated source-of-truth docs (`.github/LABELS.md` for label taxonomy, `docs/ac-traceability.md` for AC-ID conventions) that `AGENTS.md` and the templates both reference. Templates then become short skeletons with pointers.
+
+## Requirements
+
+### AC-11-1
+
+The feature request template renders the following sections in order: **Problem**, **Proposal**, optional **Non-Goals**, optional **Implementation Notes**, **Acceptance Criteria** (with Given/When/Then phrasing guidance and an AC-ID reference), **Relationships**. The template links to `docs/ac-traceability.md` for AC-ID details rather than inlining the rules.
+
+### AC-11-2
+
+The bug report template reflects the same shared guidance on titles, labels, and relationships as the feature template. Bug-specific sections (Summary, Reproduction, Expected/Actual, Environment) remain, and the template links to `.github/LABELS.md` and any shared filing-style anchor rather than duplicating prose.
+
+### AC-11-3
+
+`.github/LABELS.md` and `docs/ac-traceability.md` exist and document the canonical guidance the templates reference. `.github/LABELS.md` enumerates the current label set (`bug`, `documentation`, `duplicate`, `enhancement`, `good first issue`, `help wanted`, `invalid`, `question`, `wontfix`, `autorelease: pending`) with when-to-apply guidance for each. `docs/ac-traceability.md` specifies the `AC-<issue-number>-<integer>` format, Given/When/Then phrasing, and the outcome-not-artifact principle.
+
+### AC-11-4
+
+The issue templates and `AGENTS.md` agree on title conventions (plain-language issue titles; no conventional-commit prefixes), label guidance (defer to `.github/LABELS.md`; do not invent labels), and relationship wording (link related issues/PRs explicitly). No section in either template contradicts `AGENTS.md`.
+
+## Design decisions
+
+### Keep templates short; push prose to source-of-truth docs
+
+Each template body targets roughly 15 to 30 lines of rendered Markdown. Prose that belongs to the repository's filing style (label taxonomy, AC-ID convention, traceability expectations) lives in `.github/LABELS.md` and `docs/ac-traceability.md`. The templates link to those docs in a short header blurb and, where helpful, in a section-level pointer.
+
+### Use HTML comments for filing hints, not visible placeholder prose
+
+GitHub renders `<!-- ... -->` as invisible text in the final issue, so reporters see instructions while editing but the filed issue stays clean. This lets us pack more guidance into the template without bloating the rendered issue. Visible placeholder prose is kept to short phrases that frame each section ("What problem does this solve?"). Detailed filing rules go in HTML comments with a link to the source-of-truth doc.
+
+### Section skeletons
+
+**Feature request skeleton:**
+
+```markdown
+---
+name: Feature request
+about: Propose a change or new capability
+title: ""
+labels: enhancement
+---
+
+<!-- Title: plain-language summary (no `feat:` prefix). Labels: see .github/LABELS.md. -->
+
+## Problem
+
+What problem does this solve? Who is affected?
+
+## Proposal
+
+What should change. Be concrete about behavior, file layout, or user-visible impact.
+
+## Non-Goals (optional)
+
+What is explicitly out of scope.
+
+## Implementation Notes (optional)
+
+Constraints, risks, or pointers that help the implementer.
+
+## Acceptance Criteria
+
+<!-- Use AC-<issue-number>-<n> IDs and Given/When/Then phrasing.
+     See docs/ac-traceability.md for the full convention. -->
+
+- AC-<issue>-1: Given ..., when ..., then ...
+
+## Relationships
+
+Linked issues, PRs, or discussions (e.g. `Relates to #123`, `Blocks #456`).
+```
+
+**Bug report skeleton:**
+
+```markdown
+---
+name: Bug report
+about: Report a defect or unexpected behavior
+title: ""
+labels: bug
+---
+
+<!-- Title: plain-language summary (no `fix:` prefix). Labels: see .github/LABELS.md. -->
+
+## Summary
+
+Plain-language description of what's wrong.
+
+## Reproduction
+
+1.
+2.
+3.
+
+## Expected behavior
+
+## Actual behavior
+
+Include error messages, logs, or screenshots when relevant.
+
+## Environment
+
+- OS:
+- Runtime / tool version:
+- Repo commit or release:
+
+## Relationships
+
+Linked issues, PRs, or prior reports.
+```
+
+### Source-of-truth doc outlines
+
+`.github/LABELS.md`:
+
+- One-paragraph purpose statement.
+- Table or bullet list: each current label with a "when to apply" sentence.
+- Short "Adding or changing labels" section: describes the `gh label list --json name,description` check from `AGENTS.md` and points back to it.
+
+`docs/ac-traceability.md`:
+
+- AC-ID format: `AC-<issue-number>-<integer>`, examples.
+- Given/When/Then phrasing guidance.
+- Outcome-not-artifact principle (ACs describe observable behavior, not implementation artifacts).
+- How ACs flow from issue to PR body (points at the `AGENTS.md` PR-body AC rules).
+
+### Consistency with `AGENTS.md`
+
+`AGENTS.md` already specifies the title convention, PR-body AC formatting, and label-description invariant. Templates defer to `AGENTS.md` by reference rather than restating rules, so the templates stay short and drift risk is low.
+
+## Out of scope / Non-Goals
+
+- Fixing the empty description on the `autorelease: pending` label. Record as a follow-up issue; do not bundle into this change.
+- Adding new labels or renaming existing ones.
+- Converting templates from Markdown front-matter to GitHub issue forms (YAML). Issue forms are a larger UX change with separate tradeoffs; out of scope here.
+- Editing `AGENTS.md` prose beyond what is strictly required for template cross-references (the PR-body AC rules already live there and are the source of truth).
+
+## Open questions / concerns
+
+Remaining concerns: None.


### PR DESCRIPTION
## Summary

- Add `.github/LABELS.md` and `docs/ac-traceability.md` as sources of truth for label taxonomy and AC-ID conventions.
- Rewrite `.github/ISSUE_TEMPLATE/feature_request.md` and `bug_report.md` as short skeletons that link to those docs.
- Patch issue #11 body in place to replace `AC-<this>-N` placeholders with `AC-11-N`.

## Linked issue

Closes #11

## Acceptance criteria

### AC-11-1

Feature template renders Problem, Proposal, optional Non-Goals, optional Implementation Notes, Acceptance Criteria (Given/When/Then with AC-ID pointer), and Relationships — in that order.

- [x] Inspect rendered template: `cat .github/ISSUE_TEMPLATE/feature_request.md`
- [x] Confirm section order matches `## Problem`, `## Proposal`, `## Non-Goals (optional)`, `## Implementation Notes (optional)`, `## Acceptance Criteria`, `## Relationships`
- [x] Confirm AC comment links to `docs/ac-traceability.md`

### AC-11-2

Bug template reflects shared title, labels, and relationships guidance without forcing feature-style AC structure.

- [x] Inspect rendered template: `cat .github/ISSUE_TEMPLATE/bug_report.md`
- [x] Confirm title-and-labels HTML comment is present and defers to `.github/LABELS.md`
- [x] Confirm `## Relationships` section is present

### AC-11-3

`.github/LABELS.md` and `docs/ac-traceability.md` exist and document the canonical guidance the templates reference.

- [x] `test -f .github/LABELS.md && test -f docs/ac-traceability.md`
- [x] Templates grep positive: `grep -l LABELS.md .github/ISSUE_TEMPLATE/*.md` and `grep -l ac-traceability.md .github/ISSUE_TEMPLATE/*.md`

### AC-11-4

Templates and `AGENTS.md` agree on title conventions, label guidance, and relationship wording.

- [x] Cross-check performed; no contradictions found. Templates defer to `AGENTS.md` via reference rather than duplicating rules.

## Validation

- [x] `pnpm lint:md` passes (run locally: 32 files, 0 errors)
- [x] `wc -l .github/ISSUE_TEMPLATE/*.md .github/LABELS.md docs/ac-traceability.md` — templates are short (feature=35, bug=34, LABELS=20, ac-traceability=23)
- [x] Issue #11 body has 0 `<this>` placeholders: `gh issue view 11 --json body --jq .body | grep -c '<this>'`

## Docs updated

- [x] Updated in this PR
