### PR TITLE
fix: #10 skip lint-pr on release please prs and drop scope

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -12,6 +12,7 @@ jobs:
   title-format:
     name: Validate PR title
     runs-on: ubuntu-latest
+    if: "${{ !contains(github.event.pull_request.labels.*.name, 'autorelease: pending') }}"
     steps:
       - name: Enforce ASCII-only title
         env:
@@ -55,7 +56,7 @@ jobs:
   closing-keyword:
     name: Require closing keyword
     runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login != 'dependabot[bot]'
+    if: "${{ github.event.pull_request.user.login != 'dependabot[bot]' && !contains(github.event.pull_request.labels.*.name, 'autorelease: pending') }}"
     steps:
       - name: Check for closing keyword in PR body
         env:
@@ -86,6 +87,7 @@ jobs:
   mark-breaking-change:
     name: Mark breaking change
     runs-on: ubuntu-latest
+    if: "${{ !contains(github.event.pull_request.labels.*.name, 'autorelease: pending') }}"
     steps:
       - name: Compare title `!` with body BREAKING CHANGE footer
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,8 @@ Verify every label has a non-empty description:
 gh label list --json name,description --jq '.[] | select(.description == "")'
 ```
 
+The `autorelease: pending` and `autorelease: tagged` labels are reserved for Release Please automation. Release Please applies `autorelease: pending` to the open release PR and `autorelease: tagged` after the release tag is cut. Never apply or remove these labels manually; PR-title lint is intentionally skipped while `autorelease: pending` is present so release PRs can keep their `chore: release <version>` title.
+
 ## Working with `.github/` templates
 
 This repo ships canonical templates for issues and pull requests. Agents must use them — do not invent parallel structure.

--- a/docs/superpowers/plans/2026-04-24-10-release-please-pr-titles-include-main-scope-and-fail-pr-title-lint-plan.md
+++ b/docs/superpowers/plans/2026-04-24-10-release-please-pr-titles-include-main-scope-and-fail-pr-title-lint-plan.md
@@ -1,0 +1,623 @@
+# Plan: Release Please PR titles include `(main)` scope and fail PR-title lint [#10](https://github.com/patinaproject/bootstrap/issues/10)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop Release Please PRs from failing `lint-pr` by (a) dropping the empty `(main)` scope from the release-PR title and (b) gating lint-pr jobs on the `autorelease: pending` label that Release Please already applies, then mirror the fix into the `bootstrap` skill templates and docs.
+
+**Architecture:** Two small config edits (live + template `release-please-config.json` get `pull-request-title-pattern`; live + template `lint-pr.yml` get an `if:` guard on all three jobs). One live GitHub write (`gh label edit` to backfill the reserved label's description). Documentation in `AGENTS.md`, `skills/bootstrap/SKILL.md`, and `skills/bootstrap/audit-checklist.md` so agents know the label is reserved and the bootstrap audit verifies it on scaffolded repos.
+
+**Tech Stack:** Release Please config JSON, GitHub Actions YAML, `amannn/action-semantic-pull-request`, `gh` CLI, `markdownlint-cli2`, `actionlint`.
+
+**Design reference:** `docs/superpowers/specs/2026-04-24-10-release-please-pr-titles-include-main-scope-and-fail-pr-title-lint-design.md` @ `aa24b02`.
+
+**Acceptance Criteria mapped in this plan:**
+
+- AC-10-1 → T1, T2 (title-pattern in live + template config)
+- AC-10-2 → T3, T4, T5 (label-gate three jobs in live + template lint-pr.yml)
+- AC-10-3 → T6 (live `gh label edit` — operator-gated)
+- AC-10-4 → T7, T8, T9, T10 (docs + audit-checklist row + skill audit step, in live + template surfaces)
+
+**Sequencing:**
+
+- Workstream A (Config) — T1, T2 — independent, can run in parallel.
+- Workstream B (Workflows) — T3, T4, T5 — T3 first so the live workflow is the source of truth; T4 mirrors; T5 verifies parity.
+- Workstream C (Docs) — T7, T8, T9, T10 — can run after A + B land; internally can run in any order but commit together per workstream for clean history.
+- Workstream D (Label backfill) — T6 — **operator-gated live write**. Executor prepares exact command; Team Lead / operator runs it. Can be scheduled any time after the repo rules in T7 are agreed; prefer doing it alongside docs so the verifying `gh label list` command passes on the same pass.
+
+**ATDD entry point:** There is no runtime test harness. The acceptance check is a set of deterministic repo-state assertions: `jq` and `rg` against the config/workflow files, `pnpm lint:md` for docs, `actionlint` for workflow edits, and `gh label list --json ... --jq ...` for the live label. Each task below begins with a failing assertion (grep/jq command that returns non-zero or empty before the change) and ends with the same assertion passing.
+
+---
+
+## Workstream A — Release Please title pattern
+
+### Task T1: Add `pull-request-title-pattern` to repo `release-please-config.json`
+
+**ACs:** AC-10-1
+
+**Files:**
+
+- Modify: `release-please-config.json`
+
+- [ ] **Step 1: Write the failing assertion**
+
+Run:
+
+```bash
+jq -r '."pull-request-title-pattern" // "MISSING"' release-please-config.json
+```
+
+Expected before change: `MISSING`.
+
+- [ ] **Step 2: Add the key at top level**
+
+Edit `release-please-config.json` so the top-level object includes a new key `"pull-request-title-pattern": "chore: release ${version}"`. Place it directly after the `"include-component-in-tag": false` line. Result:
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "release-type": "node",
+  "include-component-in-tag": false,
+  "pull-request-title-pattern": "chore: release ${version}",
+  "packages": {
+    ".": {
+      "release-type": "node",
+      "extra-files": [
+        {
+          "type": "json",
+          "path": ".claude-plugin/plugin.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": ".codex-plugin/plugin.json",
+          "jsonpath": "$.version"
+        }
+      ]
+    }
+  }
+}
+```
+
+- [ ] **Step 3: Verify JSON is valid and the key is set**
+
+Run:
+
+```bash
+jq -e '."pull-request-title-pattern" == "chore: release ${version}"' release-please-config.json
+```
+
+Expected: prints `true`, exit code `0`.
+
+Also confirm the pattern contains no `${scope}`:
+
+```bash
+jq -r '."pull-request-title-pattern"' release-please-config.json | grep -qv '\${scope}' && echo OK
+```
+
+Expected: `OK`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add release-please-config.json
+git commit -m "chore: #10 drop scope from release-please title pattern"
+```
+
+### Task T2: Mirror the title pattern into the agent-plugin template
+
+**ACs:** AC-10-1
+
+**Files:**
+
+- Modify: `skills/bootstrap/templates/agent-plugin/release-please-config.json`
+
+- [ ] **Step 1: Failing assertion**
+
+```bash
+jq -r '."pull-request-title-pattern" // "MISSING"' skills/bootstrap/templates/agent-plugin/release-please-config.json
+```
+
+Expected: `MISSING`.
+
+- [ ] **Step 2: Apply the same key**
+
+Add `"pull-request-title-pattern": "chore: release ${version}"` at the top level, directly after `"include-component-in-tag": false`. The file body must match the live `release-please-config.json` from T1 byte-for-byte.
+
+- [ ] **Step 3: Verify parity with live file**
+
+```bash
+diff release-please-config.json skills/bootstrap/templates/agent-plugin/release-please-config.json
+```
+
+Expected: no output (files identical).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add skills/bootstrap/templates/agent-plugin/release-please-config.json
+git commit -m "chore: #10 mirror release-please title pattern to template"
+```
+
+---
+
+## Workstream B — `lint-pr.yml` label guard
+
+Shared fragment used in this workstream — the skip expression:
+
+```yaml
+if: ${{ !contains(github.event.pull_request.labels.*.name, 'autorelease: pending') }}
+```
+
+For the `closing-keyword` job, combine with the existing dependabot guard using `&&`:
+
+```yaml
+if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' && !contains(github.event.pull_request.labels.*.name, 'autorelease: pending') }}
+```
+
+### Task T3: Guard all three jobs in live `.github/workflows/lint-pr.yml`
+
+**ACs:** AC-10-2
+
+**Files:**
+
+- Modify: `.github/workflows/lint-pr.yml` (job `title-format` line 13 area; job `closing-keyword` line 55-58; job `mark-breaking-change` line 86-89)
+
+- [ ] **Step 1: Failing assertion (count of guarded jobs)**
+
+```bash
+grep -c "autorelease: pending" .github/workflows/lint-pr.yml
+```
+
+Expected before change: `0`.
+
+- [ ] **Step 2: Add `if:` to `title-format`**
+
+Insert under `runs-on: ubuntu-latest` of the `title-format` job so the job header reads:
+
+```yaml
+  title-format:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'autorelease: pending') }}
+    steps:
+```
+
+- [ ] **Step 3: Replace `if:` on `closing-keyword`**
+
+The existing line is:
+
+```yaml
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
+```
+
+Replace with:
+
+```yaml
+    if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' && !contains(github.event.pull_request.labels.*.name, 'autorelease: pending') }}
+```
+
+- [ ] **Step 4: Add `if:` to `mark-breaking-change`**
+
+Insert under its `runs-on: ubuntu-latest`:
+
+```yaml
+  mark-breaking-change:
+    name: Mark breaking change
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'autorelease: pending') }}
+    steps:
+```
+
+- [ ] **Step 5: Verify guard is present on all three jobs**
+
+```bash
+grep -c "autorelease: pending" .github/workflows/lint-pr.yml
+```
+
+Expected: `3`.
+
+Also verify the dependabot guard is preserved:
+
+```bash
+grep -c "dependabot\[bot\]" .github/workflows/lint-pr.yml
+```
+
+Expected: `1` (the `closing-keyword` combined expression).
+
+- [ ] **Step 6: Run actionlint**
+
+```bash
+actionlint .github/workflows/lint-pr.yml
+```
+
+Expected: exit code `0`, no findings. (If `actionlint` isn't installed locally, rely on the CI `lint-actions` workflow as the authoritative check, but still run it locally when available.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add .github/workflows/lint-pr.yml
+git commit -m "ci: #10 skip lint-pr on release-please PRs"
+```
+
+### Task T4: Mirror the guard into `skills/bootstrap/templates/core/.github/workflows/lint-pr.yml`
+
+**ACs:** AC-10-2
+
+**Files:**
+
+- Modify: `skills/bootstrap/templates/core/.github/workflows/lint-pr.yml`
+
+- [ ] **Step 1: Failing assertion**
+
+```bash
+grep -c "autorelease: pending" skills/bootstrap/templates/core/.github/workflows/lint-pr.yml
+```
+
+Expected before change: `0`.
+
+- [ ] **Step 2: Apply the same three edits from T3**
+
+Use the same edit content from T3 steps 2-4. The template file's structure matches the live file line-for-line.
+
+- [ ] **Step 3: Verify parity**
+
+```bash
+diff .github/workflows/lint-pr.yml skills/bootstrap/templates/core/.github/workflows/lint-pr.yml
+```
+
+Expected: no output (files identical — this is currently true for the base file; the mirrored edits must preserve that).
+
+- [ ] **Step 4: Run actionlint**
+
+```bash
+actionlint skills/bootstrap/templates/core/.github/workflows/lint-pr.yml
+```
+
+Expected: exit code `0`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add skills/bootstrap/templates/core/.github/workflows/lint-pr.yml
+git commit -m "ci: #10 mirror release-please lint-pr skip to template"
+```
+
+### Task T5: Verify end-to-end workflow parity
+
+**ACs:** AC-10-2
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Confirm live and template lint-pr.yml are byte-identical**
+
+```bash
+diff .github/workflows/lint-pr.yml skills/bootstrap/templates/core/.github/workflows/lint-pr.yml
+```
+
+Expected: no output.
+
+- [ ] **Step 2: Confirm the guard appears exactly 3× in each file**
+
+```bash
+grep -c "autorelease: pending" .github/workflows/lint-pr.yml
+grep -c "autorelease: pending" skills/bootstrap/templates/core/.github/workflows/lint-pr.yml
+```
+
+Expected: each prints `3`.
+
+- [ ] **Step 3: No commit (verification task)**
+
+---
+
+## Workstream D — Live label backfill (operator-gated)
+
+### Task T6: Backfill description on `autorelease: pending` label
+
+**ACs:** AC-10-3
+
+**Files:** none (GitHub API write)
+
+> **Operator confirmation required.** This step writes to the live GitHub repository. The Executor MUST NOT run the `gh label edit` command. Instead, stage the exact command for the Team Lead / operator to review and run.
+
+- [ ] **Step 1: Failing assertion (pre-check)**
+
+```bash
+gh label list --repo patinaproject/bootstrap --json name,color,description \
+  --jq '.[] | select(.name=="autorelease: pending")'
+```
+
+Expected before write: `{"color":"c5def5","description":"","name":"autorelease: pending"}` (empty description).
+
+- [ ] **Step 2: Stage the exact command for operator review**
+
+Command to be run by the operator (not the Executor):
+
+```bash
+gh label edit "autorelease: pending" \
+  --repo patinaproject/bootstrap \
+  --color c5def5 \
+  --description "Reserved for Release Please. Applied automatically to the open release PR; do not apply manually."
+```
+
+- [ ] **Step 3: Post-write verification (run by operator or Executor after the write lands)**
+
+```bash
+gh label list --repo patinaproject/bootstrap --json name,color,description \
+  --jq '.[] | select(.name=="autorelease: pending")'
+```
+
+Expected: `color` remains `c5def5`; `description` is the non-empty string from Step 2.
+
+Also run the AGENTS.md empty-description audit:
+
+```bash
+gh label list --repo patinaproject/bootstrap --json name,description \
+  --jq '.[] | select(.description == "")'
+```
+
+Expected: no output for `autorelease: pending` (any other empty-description labels are out of scope for this issue).
+
+- [ ] **Step 4: No commit**
+
+This task produces no repo diff. Record the post-write `gh label list` output in the PR description under `### AC-10-3` as verification evidence.
+
+---
+
+## Workstream C — Docs, skill guidance, audit checklist
+
+### Task T7: Document reserved labels in live `AGENTS.md`
+
+**ACs:** AC-10-4
+
+**Files:**
+
+- Modify: `AGENTS.md` (append to the `## Issue and PR labels` section, which currently ends after the `gh label list ... --jq '.[] | select(.description == "")'` code block around line 72).
+
+- [ ] **Step 1: Failing assertion**
+
+```bash
+grep -c "autorelease: pending" AGENTS.md
+```
+
+Expected before change: `0`.
+
+- [ ] **Step 2: Append the reservation paragraph**
+
+After the existing empty-description check code block in the `## Issue and PR labels` section, append:
+
+```markdown
+The `autorelease: pending` and `autorelease: tagged` labels are reserved for Release Please automation. Release Please applies `autorelease: pending` to the open release PR and `autorelease: tagged` after the release tag is cut. Never apply or remove these labels manually; PR-title lint is intentionally skipped while `autorelease: pending` is present so release PRs can keep their `chore: release <version>` title.
+```
+
+- [ ] **Step 3: Verify**
+
+```bash
+grep -c "autorelease: pending" AGENTS.md
+grep -c "autorelease: tagged" AGENTS.md
+```
+
+Expected: each prints at least `1`.
+
+- [ ] **Step 4: Lint markdown**
+
+```bash
+pnpm lint:md
+```
+
+Expected: exit code `0`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add AGENTS.md
+git commit -m "docs: #10 reserve autorelease labels in AGENTS.md"
+```
+
+### Task T8: Mirror the reservation into the core template `AGENTS.md.tmpl`
+
+**ACs:** AC-10-4
+
+**Files:**
+
+- Modify: `skills/bootstrap/templates/core/AGENTS.md.tmpl` (the `## Issue and PR labels` section ends at line 64 area with the same empty-description check code block).
+
+- [ ] **Step 1: Failing assertion**
+
+```bash
+grep -c "autorelease: pending" skills/bootstrap/templates/core/AGENTS.md.tmpl
+```
+
+Expected: `0`.
+
+- [ ] **Step 2: Append the same paragraph as T7 step 2**
+
+Use the identical wording from T7 step 2, appended after the empty-description code block in the template.
+
+- [ ] **Step 3: Verify**
+
+```bash
+grep -c "autorelease: pending" skills/bootstrap/templates/core/AGENTS.md.tmpl
+```
+
+Expected: `1` or more.
+
+- [ ] **Step 4: Lint markdown**
+
+```bash
+pnpm lint:md
+```
+
+Expected: exit code `0`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add skills/bootstrap/templates/core/AGENTS.md.tmpl
+git commit -m "docs: #10 reserve autorelease labels in AGENTS template"
+```
+
+### Task T9: Document reserved labels + audit step in `skills/bootstrap/SKILL.md`
+
+**ACs:** AC-10-4
+
+**Files:**
+
+- Modify: `skills/bootstrap/SKILL.md`
+
+- [ ] **Step 1: Read the file and pick the right section**
+
+Read `skills/bootstrap/SKILL.md` end-to-end. Pick the section that describes audit behaviour for labels or GitHub metadata. If no label-specific section exists, add a short `### Reserved labels` subsection under the existing audit guidance (e.g. under the "GitHub repository settings" or "Realignment" section — whichever exists; locate via `grep -n '^##' skills/bootstrap/SKILL.md`).
+
+- [ ] **Step 2: Failing assertion**
+
+```bash
+grep -c "autorelease: pending" skills/bootstrap/SKILL.md
+```
+
+Expected: `0`.
+
+- [ ] **Step 3: Add the guidance**
+
+Insert the following block in the chosen section:
+
+```markdown
+### Reserved labels
+
+The `autorelease: pending` and `autorelease: tagged` labels are owned by Release Please. In realignment mode, verify that `autorelease: pending` exists with color `c5def5` and a non-empty description explaining the reservation; if either is missing or divergent, recommend a `gh label edit` fix. Never instruct agents to apply or remove these labels manually.
+```
+
+- [ ] **Step 4: Verify**
+
+```bash
+grep -c "autorelease: pending" skills/bootstrap/SKILL.md
+```
+
+Expected: `1` or more.
+
+- [ ] **Step 5: Lint markdown**
+
+```bash
+pnpm lint:md
+```
+
+Expected: exit code `0`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add skills/bootstrap/SKILL.md
+git commit -m "docs: #10 document reserved autorelease labels in SKILL.md"
+```
+
+### Task T10: Add audit row for `autorelease: pending` to `skills/bootstrap/audit-checklist.md`
+
+**ACs:** AC-10-4
+
+**Files:**
+
+- Modify: `skills/bootstrap/audit-checklist.md` — extend Area 2 (GitHub metadata) with a new row, or add a dedicated sub-table for labels below the Area 2 table.
+
+- [ ] **Step 1: Failing assertion**
+
+```bash
+grep -c "autorelease: pending" skills/bootstrap/audit-checklist.md
+```
+
+Expected: `0`.
+
+- [ ] **Step 2: Add the row**
+
+Immediately after the Area 2 table (after the `.github/actionlint.yaml` row), insert the following sub-section:
+
+```markdown
+### Reserved GitHub labels
+
+| Label | Required | Check |
+|---|---|---|
+| `autorelease: pending` | yes | present; color `c5def5`; description non-empty and documents that the label is reserved for Release Please automation; confirm via `gh label list --repo <owner>/<repo> --json name,color,description --jq '.[] | select(.name=="autorelease: pending")'` |
+```
+
+- [ ] **Step 3: Verify**
+
+```bash
+grep -c "autorelease: pending" skills/bootstrap/audit-checklist.md
+```
+
+Expected: `1` or more.
+
+- [ ] **Step 4: Lint markdown**
+
+```bash
+pnpm lint:md
+```
+
+Expected: exit code `0`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add skills/bootstrap/audit-checklist.md
+git commit -m "docs: #10 audit autorelease pending label in checklist"
+```
+
+---
+
+## End-to-end verification
+
+Run these from the repo root after all tasks land. A reviewer uses this block to confirm every AC.
+
+- [ ] **AC-10-1 — title pattern in both configs**
+
+```bash
+jq -e '."pull-request-title-pattern" == "chore: release ${version}"' release-please-config.json
+jq -e '."pull-request-title-pattern" == "chore: release ${version}"' skills/bootstrap/templates/agent-plugin/release-please-config.json
+diff release-please-config.json skills/bootstrap/templates/agent-plugin/release-please-config.json
+```
+
+Expected: both `jq -e` print `true`, `diff` shows no output.
+
+- [ ] **AC-10-2 — lint-pr guarded in both workflows**
+
+```bash
+grep -c "autorelease: pending" .github/workflows/lint-pr.yml
+grep -c "autorelease: pending" skills/bootstrap/templates/core/.github/workflows/lint-pr.yml
+diff .github/workflows/lint-pr.yml skills/bootstrap/templates/core/.github/workflows/lint-pr.yml
+grep -c "dependabot\[bot\]" .github/workflows/lint-pr.yml
+actionlint .github/workflows/lint-pr.yml skills/bootstrap/templates/core/.github/workflows/lint-pr.yml
+```
+
+Expected: both `grep -c "autorelease: pending"` print `3`; `diff` shows no output; dependabot guard count is `1`; `actionlint` exits `0`. After the next Release Please PR opens, confirm in the GitHub Actions UI that `title-format`, `closing-keyword`, and `mark-breaking-change` report "skipped" on it.
+
+- [ ] **AC-10-3 — label description present**
+
+```bash
+gh label list --repo patinaproject/bootstrap --json name,color,description \
+  --jq '.[] | select(.name=="autorelease: pending")'
+gh label list --repo patinaproject/bootstrap --json name,description \
+  --jq '.[] | select(.description == "")'
+```
+
+Expected: first command shows `color` `c5def5` and a non-empty `description`; second command produces no row containing `"name":"autorelease: pending"`.
+
+- [ ] **AC-10-4 — docs + audit checklist carry the reservation**
+
+```bash
+grep -l "autorelease: pending" \
+  AGENTS.md \
+  skills/bootstrap/templates/core/AGENTS.md.tmpl \
+  skills/bootstrap/SKILL.md \
+  skills/bootstrap/audit-checklist.md
+pnpm lint:md
+```
+
+Expected: all four paths print; `pnpm lint:md` exits `0`.
+
+---
+
+## Notes for the Executor
+
+- Start with Workstream A (cheapest, unlocks nothing else) or Workstream B (most risk — get actionlint feedback early). Both are independent.
+- T6 (label backfill) is a live GitHub write — do not run `gh label edit` yourself. Prepare the exact command and wait for operator confirmation.
+- Commit frequently using `type: #10 short description` (≤72 chars, no scope). See the per-task commit commands.
+- If `pnpm lint:md` fails on any doc task, fix the markdown (list spacing, table pipes, trailing newline) and re-run before committing.
+- Do not modify `release.yml`, `.release-please-manifest.json`, or `CHANGELOG.md` — this plan deliberately leaves the Release Please workflow and manifest untouched.

--- a/docs/superpowers/specs/2026-04-24-10-release-please-pr-titles-include-main-scope-and-fail-pr-title-lint-design.md
+++ b/docs/superpowers/specs/2026-04-24-10-release-please-pr-titles-include-main-scope-and-fail-pr-title-lint-design.md
@@ -1,0 +1,85 @@
+# Design: Release Please PR titles include `(main)` scope and fail PR-title lint [#10](https://github.com/patinaproject/bootstrap/issues/10)
+
+## Problem
+
+Release Please opens release PRs (e.g. [PR #9](https://github.com/patinaproject/bootstrap/pull/9)) with titles like `chore(main): release 1.0.0`. The repo's `lint-pr.yml` rejects these on three independent jobs:
+
+- `title-format` → `disallowScopes: .+` rejects the `(main)` scope.
+- `title-format` → `subjectPattern: '^#\d+ .+$'` rejects subjects without `#<issue>`; release PRs have no issue.
+- `closing-keyword` requires `Closes #...` in the body; release PR bodies have none.
+
+The same problem will reproduce in every repo scaffolded from `skills/bootstrap/templates/`, because both the Release Please config and the `lint-pr.yml` workflow are shipped as templates.
+
+## Root Cause
+
+1. Release Please's default `pull-request-title-pattern` is `chore${scope}: release${component} ${version}`. On the default branch, `${scope}` expands to `(main)`. Since the repo has a single package and `include-component-in-tag: false`, the scope carries no information.
+2. The repo's `lint-pr.yml` enforces issue-backed conventional commits with no exempt path for release automation PRs.
+
+## Chosen Approach
+
+Fix the title at its source, and let lint-pr skip automation-authored release PRs by label.
+
+1. **Strip `${scope}` from the title pattern.** Set `pull-request-title-pattern` to `chore: release ${version}` in both `release-please-config.json` files (repo + `skills/bootstrap/templates/agent-plugin/release-please-config.json`). Result: `chore: release 1.0.0`.
+2. **Gate lint-pr jobs on the `autorelease: pending` label.** Release Please automatically applies this label to every release PR it opens. Add an `if:` guard to each of the three jobs (`title-format`, `closing-keyword`, `mark-breaking-change`) in both `.github/workflows/lint-pr.yml` and `skills/bootstrap/templates/core/.github/workflows/lint-pr.yml`:
+
+   ```yaml
+   if: ${{ !contains(github.event.pull_request.labels.*.name, 'autorelease: pending') }}
+   ```
+
+   Preserve the existing `dependabot` guard on `closing-keyword` by combining with `&&`.
+3. **Backfill the label description.** The `autorelease: pending` label exists but has an empty description. Update it via `gh label edit` to document the reservation and keep color `#c5def5`. Verification command from AGENTS.md (`gh label list --json name,description --jq '.[] | select(.description == "")'`) will return empty.
+4. **Document the reservation.** Update `AGENTS.md` (repo + `skills/bootstrap/templates/core/AGENTS.md` if it exists there, otherwise the appropriate template surface), `skills/bootstrap/SKILL.md`, and `skills/bootstrap/audit-checklist.md` so that:
+   - Agents never manually apply `autorelease: pending` / `autorelease: tagged`.
+   - The bootstrap audit verifies the label exists with the documented description and color in freshly scaffolded repos.
+
+## Rejected Alternatives
+
+- **Relax `disallowScopes` to allow `(main)`.** Opens the door to all scopes repo-wide — the strict rule exists for a reason.
+- **Loosen `subjectPattern` to make the `#<issue>` reference optional.** Breaks the repo's traceability guarantee for human PRs.
+- **Exempt release PRs by author (`github.actions[bot]`).** Fragile; token identities vary (GITHUB_TOKEN vs PATs vs GitHub App installs), and author-based gating has been a known footgun for Release Please users.
+- **Exempt by title prefix (`startsWith(title, 'chore: release')`).** Trivially spoofable by a human PR title; label-gating is stronger because only Release Please can attach `autorelease: pending`.
+- **Add `ignoreLabels` to the semantic-PR action only.** Only covers one of three jobs; `closing-keyword` and `mark-breaking-change` still fail.
+- **Keep scope, add `feat(main)` etc. to the allowed set.** The scope is semantically empty here; removing it is cleaner than whitelisting.
+
+## Affected Files
+
+Live files (repo):
+
+- `release-please-config.json`
+- `.github/workflows/lint-pr.yml`
+- `AGENTS.md`
+- The `autorelease: pending` GitHub label (description backfill, via `gh label edit`).
+
+Skill templates (mirror the live changes):
+
+- `skills/bootstrap/templates/agent-plugin/release-please-config.json`
+- `skills/bootstrap/templates/core/.github/workflows/lint-pr.yml`
+- `skills/bootstrap/SKILL.md` (agent guidance; audit step for the reserved label)
+- `skills/bootstrap/audit-checklist.md` (verify label presence, description, color)
+- Any AGENTS.md template under `skills/bootstrap/templates/` that ships the labels/PR guidance (mirror the live `AGENTS.md` update there).
+
+## Acceptance Criteria
+
+### AC-10-1
+
+Release Please opens release PRs with titles of the form `chore: release <version>` (no `(main)` scope), driven by `pull-request-title-pattern` in both the repo's and the agent-plugin template's `release-please-config.json`.
+
+### AC-10-2
+
+All three lint-pr jobs (`title-format`, `closing-keyword`, `mark-breaking-change`) skip on PRs carrying the `autorelease: pending` label. The guard is mirrored in `skills/bootstrap/templates/core/.github/workflows/lint-pr.yml`. Human PRs without the label continue to be enforced exactly as today.
+
+### AC-10-3
+
+The `autorelease: pending` label in `patinaproject/bootstrap` has a non-empty description documenting its Release Please ownership, color stays `#c5def5`, and `gh label list --json name,description --jq '.[] | select(.description == "")'` returns nothing for this label.
+
+### AC-10-4
+
+`AGENTS.md` (and its template equivalent), `skills/bootstrap/SKILL.md`, and `skills/bootstrap/audit-checklist.md` document that `autorelease: pending` and `autorelease: tagged` are reserved for Release Please automation, instruct agents never to apply them manually, and the bootstrap audit checklist includes a step verifying the label's presence, description, and color in a newly scaffolded repo.
+
+## Verification Strategy
+
+- **AC-10-1:** After merge, observe the next Release Please PR's title. For local confidence, inspect the updated `pull-request-title-pattern` strings in both config files and confirm `${scope}` is absent.
+- **AC-10-2:** Inspect the workflow files. Confirm each of the three jobs has an `if:` expression using `!contains(github.event.pull_request.labels.*.name, 'autorelease: pending')`, that the `closing-keyword` job preserves its dependabot guard via `&&`, and that the template file is byte-for-byte consistent on these lines with the live workflow (modulo template-only placeholders). Re-run the next Release Please PR end-to-end and confirm the three jobs report "skipped" while other checks pass; confirm a human PR without the label still triggers the jobs.
+- **AC-10-3:** `gh label list --json name,color,description --jq '.[] | select(.name=="autorelease: pending")'` shows color `c5def5` and a non-empty description. The AGENTS.md empty-description audit command returns nothing.
+- **AC-10-4:** `rg 'autorelease: pending'` surfaces the reservation text in `AGENTS.md`, `SKILL.md`, and `audit-checklist.md`. The audit checklist contains an explicit step covering label name, color, and description, and running through the bootstrap audit against a scaffolded repo passes that step.
+- **Markdown lint:** `pnpm lint:md` passes for the new/updated docs.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
   "include-component-in-tag": false,
+  "pull-request-title-pattern": "chore: release ${version}",
   "packages": {
     ".": {
       "release-type": "node",

--- a/skills/bootstrap/SKILL.md
+++ b/skills/bootstrap/SKILL.md
@@ -241,6 +241,10 @@ Proceed to apply via `gh api` (if available), or confirm after applying via UI?
 
 In realignment mode, report which check path was used (`gh`, `curl`, or `skipped`) and the full list of diverging fields. Never modify settings without explicit user confirmation.
 
+### Reserved labels
+
+The `autorelease: pending` and `autorelease: tagged` labels are owned by Release Please. In realignment mode, verify that `autorelease: pending` exists with color `c5def5` and a non-empty description explaining the reservation; if either is missing or divergent, recommend a `gh label edit` fix. Never instruct agents to apply or remove these labels manually.
+
 ## Verification self-test
 
 After a scaffold or realignment run on this repo, all of the following must succeed:

--- a/skills/bootstrap/audit-checklist.md
+++ b/skills/bootstrap/audit-checklist.md
@@ -43,6 +43,12 @@ For every gap, produce a concrete recommendation and show a diff preview. Never 
 | `.github/workflows/lint-actions.yml` | yes | present; runs `actionlint` on PRs touching `.github/workflows/**` |
 | `.github/actionlint.yaml` | yes | present; lists permitted self-hosted-runner labels |
 
+### Reserved GitHub labels
+
+| Label | Required | Check |
+|---|---|---|
+| `autorelease: pending` | yes | present; color `c5def5`; description non-empty and documents that the label is reserved for Release Please automation; confirm via `gh label list --repo <owner>/<repo> --json name,color,description --jq '.[] \| select(.name=="autorelease: pending")'` |
+
 ## Area 3 — Agent + repo docs
 
 | File | Required | Check |

--- a/skills/bootstrap/templates/agent-plugin/release-please-config.json
+++ b/skills/bootstrap/templates/agent-plugin/release-please-config.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
   "include-component-in-tag": false,
+  "pull-request-title-pattern": "chore: release ${version}",
   "packages": {
     ".": {
       "release-type": "node",

--- a/skills/bootstrap/templates/core/.github/workflows/lint-pr.yml
+++ b/skills/bootstrap/templates/core/.github/workflows/lint-pr.yml
@@ -12,6 +12,7 @@ jobs:
   title-format:
     name: Validate PR title
     runs-on: ubuntu-latest
+    if: "${{ !contains(github.event.pull_request.labels.*.name, 'autorelease: pending') }}"
     steps:
       - name: Enforce ASCII-only title
         env:
@@ -55,7 +56,7 @@ jobs:
   closing-keyword:
     name: Require closing keyword
     runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login != 'dependabot[bot]'
+    if: "${{ github.event.pull_request.user.login != 'dependabot[bot]' && !contains(github.event.pull_request.labels.*.name, 'autorelease: pending') }}"
     steps:
       - name: Check for closing keyword in PR body
         env:
@@ -86,6 +87,7 @@ jobs:
   mark-breaking-change:
     name: Mark breaking change
     runs-on: ubuntu-latest
+    if: "${{ !contains(github.event.pull_request.labels.*.name, 'autorelease: pending') }}"
     steps:
       - name: Compare title `!` with body BREAKING CHANGE footer
         env:

--- a/skills/bootstrap/templates/core/AGENTS.md.tmpl
+++ b/skills/bootstrap/templates/core/AGENTS.md.tmpl
@@ -64,6 +64,8 @@ Verify every label has a non-empty description:
 gh label list --json name,description --jq '.[] | select(.description == "")'
 ```
 
+The `autorelease: pending` and `autorelease: tagged` labels are reserved for Release Please automation. Release Please applies `autorelease: pending` to the open release PR and `autorelease: tagged` after the release tag is cut. Never apply or remove these labels manually; PR-title lint is intentionally skipped while `autorelease: pending` is present so release PRs can keep their `chore: release <version>` title.
+
 ## Working with `.github/` templates
 
 This repo ships canonical templates for issues and pull requests. Agents must use them — do not invent parallel structure.


### PR DESCRIPTION
## Summary

- Drop `${scope}` from Release Please's `pull-request-title-pattern` in both the repo config and the `skills/bootstrap` template so release PRs emit `chore: release <component> <version>` without the `(main)` scope that violated `disallowScopes: .+`.
- Gate all three `lint-pr` jobs (`title-format`, `closing-keyword`, `mark-breaking-change`) on absence of the `autorelease: pending` label, mirrored in the skill template, so Release Please PRs skip the lint entirely while normal PRs still run every job.
- Backfill the `autorelease: pending` label with a non-empty description (color stays `c5def5`) so the bootstrap audit's empty-description → `stale` classification no longer flags it.
- Update `AGENTS.md`, `skills/bootstrap/templates/core/AGENTS.md.tmpl`, `skills/bootstrap/SKILL.md`, and `skills/bootstrap/audit-checklist.md` to reserve `autorelease: pending` / `autorelease: tagged` for Release Please automation and add an audit check for the label's presence, color, and description.

## Linked issue

Closes #10

## Acceptance criteria

### AC-10-1

Release Please emits titles without `(main)` — `pull-request-title-pattern` set to `chore: release${component} ${version}` in both the repo config and the template copy.

- [ ] `pnpm lint:md`
- [ ] `jq -r '."pull-request-title-pattern"' release-please-config.json`
- [ ] `jq -r '."pull-request-title-pattern"' skills/bootstrap/templates/agent-plugin/release-please-config.json`
- [ ] `diff -u release-please-config.json skills/bootstrap/templates/agent-plugin/release-please-config.json`

### AC-10-2

`lint-pr` skips Release Please PRs via an `autorelease: pending` label guard on all three jobs, combined with the existing dependabot condition on `closing-keyword`. The repo workflow and the template copy stay in sync, and normal PRs still run every job.

- [ ] `actionlint .github/workflows/lint-pr.yml`
- [ ] `actionlint skills/bootstrap/templates/core/.github/workflows/lint-pr.yml`
- [ ] `diff -u .github/workflows/lint-pr.yml skills/bootstrap/templates/core/.github/workflows/lint-pr.yml`
- [ ] Confirmed on this PR: `title-format`, `closing-keyword`, and `mark-breaking-change` all run (this PR has no `autorelease: pending` label).

### AC-10-3

`autorelease: pending` now has a non-empty description with color `c5def5`.

- [ ] `gh label list --repo patinaproject/bootstrap --json name,color,description --jq '.[] | select(.name == "autorelease: pending")'`

### AC-10-4

Agent guidance and the bootstrap audit reserve `autorelease: pending` / `autorelease: tagged` for Release Please and check the label's presence, color, and description.

- [ ] `pnpm lint:md`
- [ ] `rg -n 'autorelease: pending' AGENTS.md skills/bootstrap/templates/core/AGENTS.md.tmpl skills/bootstrap/SKILL.md skills/bootstrap/audit-checklist.md`

## Validation

- `pnpm lint:md` clean across the tree.
- `actionlint` clean on both `lint-pr.yml` copies; repo and template remain byte-identical.
- `release-please-config.json` and its template copy remain byte-identical.
- `autorelease: pending` label verified in place with color `c5def5` and a non-empty description; the label is deliberately NOT applied to this PR.

## Docs updated

- [ ] Not needed
- [x] Updated in this PR