### PR TITLE
docs: #14 align agents and pr template with source-of-truth docs

### DIFF
--- a/.github/LABELS.md
+++ b/.github/LABELS.md
@@ -13,7 +13,13 @@ This file is the source of truth for when to apply each issue and pull-request l
 - `invalid`: Apply when the report is not actionable as filed (wrong repo, not reproducible, out of scope) and cannot be salvaged by editing.
 - `question`: Apply when the issue is a support request or clarification rather than a change request.
 - `wontfix`: Apply when the behavior described is intentional or the maintainers have decided not to act on it; leave a short rationale before closing.
-- `autorelease: pending`: Tool-managed by release-please; do not apply manually. Its GitHub description is currently empty, which is a known gap tracked for follow-up.
+
+### Release-please (tool-managed)
+
+release-please creates/applies these automatically on the release PR; do not apply manually; labels are created on demand so may not appear in `gh label list` until the first release cycle runs.
+
+- `autorelease: pending`: Applied to the release PR while a release is in progress. Its GitHub description is currently empty, which is a known gap tracked for follow-up.
+- `autorelease: tagged`: Applied to the release PR once the release has been tagged.
 
 ## Adding or changing labels
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,6 +23,8 @@ This title rule applies to pull requests only. GitHub issue titles should stay p
 
 ## Acceptance criteria
 
+<!-- One heading per relevant AC. AC IDs follow the convention in docs/ac-traceability.md. -->
+
 ### AC-<issue>-<n>
 
 Short outcome summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ Use human-readable H1 titles inside those files:
 - Design docs: `# Design: <exact issue title> [#<issue>](<issue-url>)`
 - Plan docs: `# Plan: <exact issue title> [#<issue>](<issue-url>)`
 
-Format acceptance criteria IDs as `AC-<issue-number>-<integer>`, for example `AC-1-1`.
+Format acceptance criteria IDs as `AC-<issue-number>-<integer>`, for example `AC-1-1`. See [`docs/ac-traceability.md`](docs/ac-traceability.md) for the full convention (Given/When/Then phrasing, outcome-not-artifact, and the flow from issue to PR body).
 
 ## Build, Test, and Development Commands
 
@@ -63,7 +63,7 @@ If you add executable tooling later, document the exact verification command in 
 
 ## Issue and PR labels
 
-Use `gh label list` to see the repository's canonical label set. Each label's `description` documents when to apply it. Rely on those descriptions when selecting labels for issues and PRs — do not invent new labels without updating the repository's label set first.
+[.github/LABELS.md](.github/LABELS.md) is the source of truth for when to apply each label. Use `gh label list` for the authoritative runtime inventory and rely on each label's `description` when picking one. Do not invent new labels without updating the repository's label set and `.github/LABELS.md` first.
 
 Verify every label has a non-empty description:
 

--- a/docs/superpowers/plans/2026-04-24-14-align-agentsmd-and-pr-template-with-new-source-of-truth-docs-include-release-please-default-labels-plan.md
+++ b/docs/superpowers/plans/2026-04-24-14-align-agentsmd-and-pr-template-with-new-source-of-truth-docs-include-release-please-default-labels-plan.md
@@ -1,0 +1,65 @@
+# Plan: Align AGENTS.md and PR template with new source-of-truth docs; include release-please default labels [#14](https://github.com/patinaproject/bootstrap/issues/14)
+
+## Context
+
+Issue #14 requires aligning `AGENTS.md` and `.github/pull_request_template.md` with the two new source-of-truth documents introduced in prior work: `.github/LABELS.md` (canonical label catalog) and `docs/ac-traceability.md` (canonical AC-ID and traceability guidance). It also requires `.github/LABELS.md` to include the release-please default labels so the catalog matches the actual live label set.
+
+The approved design (`docs/superpowers/specs/2026-04-24-14-align-agentsmd-and-pr-template-with-new-source-of-truth-docs-include-release-please-default-labels-design.md`, commit `67bbb51`) is the authoritative reference. Scope is three surgical edits plus linting. No structural restructure of `AGENTS.md`.
+
+## Tasks
+
+### T-14-1: Add release-please default labels to `.github/LABELS.md`
+
+Add a dedicated "Release-please (tool-managed)" subsection to `.github/LABELS.md` that documents both release-please default labels:
+
+- `autorelease: pending` — relocate the existing entry into this subsection.
+- `autorelease: tagged` — new entry describing its role (applied by release-please once a release is tagged).
+
+Both entries must carry non-empty descriptions consistent with the rest of the catalog. No other label entries change. Maps to **AC-14-1**.
+
+### T-14-2: Defer label guidance in `AGENTS.md` to `.github/LABELS.md`
+
+Rewrite the body of the "Issue and PR labels" section in `AGENTS.md` so it is a single short paragraph that defers to `.github/LABELS.md` as the source of truth for label names, descriptions, and when to apply them. Keep the existing hygiene block verbatim:
+
+```bash
+gh label list --json name,description --jq '.[] | select(.description == "")'
+```
+
+Do not duplicate the label catalog inline. Maps to **AC-14-2**.
+
+### T-14-3: Link AC-ID guidance from `AGENTS.md` to `docs/ac-traceability.md`
+
+In the "Project Structure & Module Organization" section of `AGENTS.md`, append one sentence to the existing AC-ID formatting line that points readers to `docs/ac-traceability.md` for the canonical AC-ID rules and traceability guidance. Do not move or rewrite the surrounding Superpowers path guidance. Maps to **AC-14-3**.
+
+### T-14-4: Link AC-ID guidance from the PR template to `docs/ac-traceability.md`
+
+In `.github/pull_request_template.md`, add a single-line HTML comment directly under the `## Acceptance criteria` heading pointing contributors to `docs/ac-traceability.md`. The comment must not render in the submitted PR body and must not change any visible section headings, order, or content. Maps to **AC-14-3**.
+
+### T-14-5: Verification pass
+
+Run the verification commands before committing. Maps to **AC-14-4**.
+
+## Ordering and commits
+
+T-14-1 through T-14-4 are independent content edits and land in one commit. T-14-5 is a pre-commit verification step, not a separate commit.
+
+Commit message (conventional commits, no scope, required issue tag, subject <= 72 chars):
+
+```text
+docs: #14 align agents and pr template with source-of-truth docs
+```
+
+## Verification
+
+All commands run from the worktree root.
+
+- `pnpm lint:md` → exits 0 with no markdownlint errors.
+- `grep -l 'LABELS.md' AGENTS.md` → prints `AGENTS.md`.
+- `grep -l 'ac-traceability.md' AGENTS.md .github/pull_request_template.md` → prints both paths.
+- `grep 'autorelease: tagged' .github/LABELS.md` → one or more matches.
+- `gh label list --json name,description --jq '.[] | select(.description == "")'` → empty output (hygiene invariant preserved; informational, not gating for this PR).
+- Visual diff review of `AGENTS.md` and `.github/pull_request_template.md` to confirm no unintended edits outside the scoped sections.
+
+## Blockers
+
+None.

--- a/docs/superpowers/specs/2026-04-24-14-align-agentsmd-and-pr-template-with-new-source-of-truth-docs-include-release-please-default-labels-design.md
+++ b/docs/superpowers/specs/2026-04-24-14-align-agentsmd-and-pr-template-with-new-source-of-truth-docs-include-release-please-default-labels-design.md
@@ -1,0 +1,66 @@
+# Design: Align AGENTS.md and PR template with new source-of-truth docs; include release-please default labels [#14](https://github.com/patinaproject/bootstrap/issues/14)
+
+## Context
+
+Issue [#11](https://github.com/patinaproject/bootstrap/issues/11) and PR [#12](https://github.com/patinaproject/bootstrap/pull/12) established two sources of truth that older governance surfaces do not yet defer to:
+
+- `.github/LABELS.md` — canonical list of repo labels and their intent.
+- `docs/ac-traceability.md` — canonical AC-ID format and Given/When/Then convention.
+
+Three surfaces still inline or ignore these docs:
+
+- `AGENTS.md` "Issue and PR labels" points at `gh label list` but does not name `.github/LABELS.md`.
+- `AGENTS.md` "Project Structure & Module Organization" inlines the `AC-<issue-number>-<integer>` format without linking `docs/ac-traceability.md`.
+- `.github/pull_request_template.md` lists AC heading rules with no link to `docs/ac-traceability.md`.
+
+Separately, `.github/LABELS.md` documents only `autorelease: pending`, while release-please's default label set also includes `autorelease: tagged` — created on-demand when a release is cut — so contributors and agents have no documented guidance for the tagged variant.
+
+This design covers the surgical edits needed to close those gaps without duplicating rules or expanding scope.
+
+## Requirements
+
+Reproduced verbatim from issue #14 acceptance criteria:
+
+- AC-14-1: Given a contributor reads `.github/LABELS.md`, when they scan the current-labels list, then the release-please defaults (`autorelease: pending`, `autorelease: tagged`) are present with tool-managed guidance.
+- AC-14-2: Given an agent consults `AGENTS.md` for label guidance, when they read the "Issue and PR labels" section, then it defers to `.github/LABELS.md` as the source of truth while preserving the `gh label list --json name,description` hygiene check.
+- AC-14-3: Given a reader looks up AC-ID conventions, when they read `AGENTS.md` or `.github/pull_request_template.md`, then both surfaces link to `docs/ac-traceability.md` rather than redefining the format.
+- AC-14-4: Given `pnpm lint:md` runs on the updated files, when it finishes, then it reports zero errors.
+
+## Design decisions
+
+### `.github/LABELS.md` — add `autorelease: tagged` and group release-please labels
+
+Introduce a new "Release-please (tool-managed)" subsection under the existing Current labels list. Move the existing `autorelease: pending` entry into that subsection and add a new `autorelease: tagged` entry alongside it. The subsection's intro sentence must state that these labels are created and managed on-demand by release-please (not by `gh label create`) so contributors do not try to provision them manually. Keep the existing non-release-please labels in their current order and formatting; only the release-please entries move.
+
+Preserve the current description text for `autorelease: pending` — fixing its empty upstream description on GitHub is tracked separately (see Out of scope) and is not part of this change.
+
+### `AGENTS.md` "Issue and PR labels" — defer to `.github/LABELS.md`
+
+Rewrite the section's lead paragraph to a single short paragraph that:
+
+1. Names `.github/LABELS.md` as the source of truth for the repo's label set and when to apply each label.
+2. Keeps the existing instruction to verify every label has a non-empty description.
+
+Do not move or rewrite the existing `gh label list --json name,description --jq '.[] | select(.description == "")'` hygiene bash block — leave it in place immediately after the paragraph so agents still have the executable check.
+
+Drop the current sentence that says "Use `gh label list` to see the repository's canonical label set" and the follow-on "Each label's `description` documents when to apply it" — both are replaced by the `.github/LABELS.md` pointer. Keep the existing "do not invent new labels without updating the repository's label set first" guardrail, rephrased to point at `.github/LABELS.md` as the place to update.
+
+### `AGENTS.md` AC-ID line — link `docs/ac-traceability.md`
+
+The existing sentence "Format acceptance criteria IDs as `AC-<issue-number>-<integer>`, for example `AC-1-1`." stays. Append one sentence immediately after it that links `docs/ac-traceability.md` as the full convention (covering Given/When/Then phrasing, per-AC PR headings, and deferred-AC handling). Do not duplicate the Given/When/Then rules inline.
+
+### `.github/pull_request_template.md` — link `docs/ac-traceability.md` from Acceptance criteria
+
+Under the existing `## Acceptance criteria` heading, add a single HTML comment line pointing readers to `docs/ac-traceability.md` for the full convention. Using an HTML comment keeps the rendered PR body clean (the link hint is for authors, not reviewers) and avoids introducing a new visible section that diverges from the template's established headings. The existing AC heading rules in the template body remain unchanged — the link is additive.
+
+## Out of scope
+
+- Fixing the empty GitHub description on the `autorelease: pending` label (tracked separately; upstream label metadata edit via `gh label edit`, not a docs change).
+- Creating or editing GitHub labels via `gh label create` / `gh label edit` — release-please defaults are created by the tool on-demand.
+- Expanding the PR template beyond the single Acceptance-criteria link hint (no new sections, no reworded headings).
+- Any changes under `skills/**` — the `bootstrap` skill templates are not touched by this issue.
+- Restating AC format or label rules inline anywhere they can be replaced by a cross-link.
+
+## Concerns
+
+Remaining concerns: None.


### PR DESCRIPTION
## Summary

- Add the release-please default label set (`autorelease: pending`, `autorelease: tagged`) to `.github/LABELS.md` under a tool-managed subsection.
- Rewrite the `AGENTS.md` "Issue and PR labels" section to defer to `.github/LABELS.md`, preserving the `gh label list` hygiene check.
- Link `docs/ac-traceability.md` from `AGENTS.md` (AC-ID line) and from `.github/pull_request_template.md` (Acceptance criteria section).

## Linked issue

Closes #14

## Acceptance criteria

### AC-14-1

`.github/LABELS.md` documents both release-please defaults under a tool-managed subsection.

- [ ] `grep -A3 'Release-please (tool-managed)' .github/LABELS.md`
- [ ] `grep 'autorelease: tagged' .github/LABELS.md`

### AC-14-2

`AGENTS.md` "Issue and PR labels" defers to `.github/LABELS.md` and preserves the hygiene check.

- [ ] `grep 'LABELS.md' AGENTS.md` (expect match in the labels section)
- [ ] `grep "select(.description" AGENTS.md` (hygiene command still present)

### AC-14-3

Both `AGENTS.md` and `.github/pull_request_template.md` link `docs/ac-traceability.md`.

- [ ] `grep 'ac-traceability.md' AGENTS.md`
- [ ] `grep 'ac-traceability.md' .github/pull_request_template.md`

### AC-14-4

`pnpm lint:md` reports zero errors across the touched files.

- [ ] `pnpm lint:md` → 0 errors

## Validation

- Exactly three content files touched (`.github/LABELS.md`, `AGENTS.md`, `.github/pull_request_template.md`); commit is `+11/-3`.
- No workflow or build-tooling changes; GH Actions pinning rule not engaged.
- No new labels were created on the GitHub side — the release-please defaults are documented for when release-please creates them on the next release cycle.

## Docs updated

- [x] Updated in this PR
