### PR TITLE
fix: #16 restore push-triggered release flow

### DIFF
--- a/.github/workflows/lint-md.yml
+++ b/.github/workflows/lint-md.yml
@@ -21,3 +21,4 @@ jobs:
           globs: |
             **/*.md
             #node_modules
+            #CHANGELOG.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,10 @@
 name: Release
 
+# release-please requires a run on push to main to cut the tag after
+# the release PR merges. workflow_dispatch is kept as a manual escape hatch.
 on:
+  push:
+    branches: [main]
   workflow_dispatch:
 
 permissions:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -47,6 +47,8 @@ Determined from commit types — no human choice:
 
 `CHANGELOG.md` is owned by release-please. Do not hand-edit released sections.
 
+`CHANGELOG.md` is excluded from `pnpm lint:md` (see the `#CHANGELOG.md` glob in `package.json`). release-please emits double blank lines between sections, which violates `MD012/no-multiple-blanks`, and its generator has no knob to change that. Fighting the generator is not worth the churn — the released sections are machine-written and not meant to be hand-edited, so linting them adds no value.
+
 ## Distribution via `patinaproject/skills`
 
 When a release is published **and the repository owner is `patinaproject`**, the release workflow automatically dispatches `bump-plugin-tags.yml` on `patinaproject/skills`. That marketplace repo opens (or updates) a PR bumping this plugin's pinned `ref` across every Patina marketplace manifest.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,7 +4,7 @@ Releases are driven by [release-please](https://github.com/googleapis/release-pl
 
 ## How it works
 
-1. A maintainer manually triggers the `Release` workflow from **Actions → Release → Run workflow** on `main`. The workflow does not run on pushes.
+1. On every push to `main`, the `Release` workflow runs `release-please`. The same workflow can also be triggered manually from **Actions → Release → Run workflow** as an escape hatch — use it to seed the very first release PR before any push to `main`, or to re-run after a transient failure.
 2. `release-please` scans Conventional Commits since the last tag.
 3. It opens (or updates) a standing **"chore: release X.Y.Z"** PR that:
    - Bumps `package.json` version.

--- a/docs/superpowers/plans/2026-04-24-16-release-pr-merged-without-tag-release-or-dispatch-plan.md
+++ b/docs/superpowers/plans/2026-04-24-16-release-pr-merged-without-tag-release-or-dispatch-plan.md
@@ -1,0 +1,487 @@
+# Plan: v1.0.0 release PR merged but no tag, release, or marketplace dispatch occurred [#16](https://github.com/patinaproject/bootstrap/issues/16)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore the "merge the release-please PR = ship a release" flow by adding a `push: branches: [main]` trigger to `release.yml` (root + both templates), realign `RELEASING.md` (root + core template) to describe that flow, and emit the v1.0.0 stuck-state recovery runbook for the PR body.
+
+**Architecture:** Pure YAML + Markdown changes. Three workflow files gain a `push` trigger alongside the existing `workflow_dispatch`, each prefixed with an explanatory comment that documents why both triggers exist. Two `RELEASING.md` files have step 1 rewritten so the merge-triggered path is dominant and `workflow_dispatch` is described only as an escape hatch. The v1.0.0 recovery steps are not code — they are emitted as runbook text for the Finisher to paste into the PR body under `Validation`.
+
+**Tech Stack:** GitHub Actions YAML, Markdown, `actionlint` (run in CI on workflow changes), `markdownlint-cli2` (run via Husky / `pnpm lint:md`).
+
+---
+
+## ATDD execution order
+
+Each acceptance criterion has a manual verification command documented in the design doc. For every task below, run the verification command **first** (expect it to FAIL against the unedited file), then make the edit, then re-run to confirm PASS. This is the ATDD rhythm even though the "tests" are `grep`/`diff` invocations rather than a test runner.
+
+## File structure
+
+Files modified by this plan, each with a single responsibility:
+
+- `.github/workflows/release.yml` — root release workflow. Adds `push` trigger + comment. **AC-16-1.**
+- `skills/bootstrap/templates/agent-plugin/.github/workflows/release.yml` — template mirroring root triggers. **AC-16-2.**
+- `skills/bootstrap/templates/patinaproject-supplement/.github/workflows/release.yml` — template mirroring root triggers. **AC-16-3.**
+- `RELEASING.md` — root releasing doc. Rewrite step 1. **AC-16-4.**
+- `skills/bootstrap/templates/core/RELEASING.md` — templated releasing doc. Mirror step 1 rewrite. **AC-16-5.**
+
+No repo files are modified for **AC-16-6** — the runbook is emitted as text for `Finisher` to place in the PR body.
+
+---
+
+## Workstream 1: Workflow triggers
+
+Goal: every `release.yml` (root + both templates) triggers on `push: branches: [main]` and `workflow_dispatch`, with a comment explaining why both are present.
+
+### Task 1: Scope-check template references to release triggers
+
+**Files:**
+
+- Read-only scan of: `skills/**`, `.github/workflows/**`
+
+- [ ] **Step 1: Confirm the design's three-file assumption**
+
+Run:
+
+```bash
+grep -Rln 'workflow_dispatch' .github/workflows skills
+```
+
+Expected output (exactly these three files):
+
+```text
+.github/workflows/release.yml
+skills/bootstrap/templates/agent-plugin/.github/workflows/release.yml
+skills/bootstrap/templates/patinaproject-supplement/.github/workflows/release.yml
+```
+
+If any additional release-related workflow appears, halt and route back to `Brainstormer` — the design scoped only these three.
+
+- [ ] **Step 2: Confirm no other file documents the dispatch-only flow**
+
+Run:
+
+```bash
+grep -Rln 'does not run on pushes\|Actions → Release → Run workflow' .
+```
+
+Expected: matches only in `RELEASING.md` and `skills/bootstrap/templates/core/RELEASING.md` (and possibly this plan + design doc). No other docs teach the dispatch-only ritual.
+
+- [ ] **Step 3: No commit** — this is a scope check only.
+
+### Task 2: Add `push` trigger to root `.github/workflows/release.yml` (AC-16-1)
+
+**Files:**
+
+- Modify: `.github/workflows/release.yml` (lines 1-5)
+
+- [ ] **Step 1: Run the AC-16-1 verification command and expect FAIL**
+
+Run:
+
+```bash
+grep -A5 '^on:' .github/workflows/release.yml
+```
+
+Expected (current, failing): `on:` block contains only `workflow_dispatch:`, no comment, no `push:` block.
+
+- [ ] **Step 2: Edit the `on:` block**
+
+Replace:
+
+```yaml
+name: Release
+
+on:
+  workflow_dispatch:
+```
+
+With:
+
+```yaml
+name: Release
+
+# release-please requires a run on push to main to cut the tag after
+# the release PR merges. workflow_dispatch is kept as a manual escape hatch.
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+```
+
+- [ ] **Step 3: Re-run AC-16-1 verification and expect PASS**
+
+Run:
+
+```bash
+grep -B2 -A5 '^on:' .github/workflows/release.yml
+```
+
+Expected: the two-line comment appears immediately above `on:`, and the `on:` block lists both `push: branches: [main]` and `workflow_dispatch:`.
+
+- [ ] **Step 4: Lint the workflow**
+
+Run (if `actionlint` is available locally):
+
+```bash
+actionlint .github/workflows/release.yml
+```
+
+Expected: no output (no findings). If `actionlint` is not on `PATH`, note that CI's `actionlint` job (triggered by `.github/workflows/**` changes) will enforce this.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/release.yml
+git commit -m "fix: #16 trigger release workflow on push to main"
+```
+
+### Task 3: Mirror trigger change into agent-plugin template (AC-16-2)
+
+**Files:**
+
+- Modify: `skills/bootstrap/templates/agent-plugin/.github/workflows/release.yml` (lines 1-5)
+
+- [ ] **Step 1: Run the AC-16-2 verification command and expect FAIL**
+
+Run:
+
+```bash
+diff \
+  <(sed -n '/^on:/,/^$/p' .github/workflows/release.yml) \
+  <(sed -n '/^on:/,/^$/p' skills/bootstrap/templates/agent-plugin/.github/workflows/release.yml)
+```
+
+Expected (current, failing): a diff where the root file has `push:` and the template has only `workflow_dispatch:`.
+
+- [ ] **Step 2: Edit the template's `on:` block**
+
+Replace:
+
+```yaml
+name: Release
+
+on:
+  workflow_dispatch:
+```
+
+With:
+
+```yaml
+name: Release
+
+# release-please requires a run on push to main to cut the tag after
+# the release PR merges. workflow_dispatch is kept as a manual escape hatch.
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+```
+
+- [ ] **Step 3: Re-run AC-16-2 verification and expect PASS (empty diff)**
+
+Run the same `diff` command. Expected: no output.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add skills/bootstrap/templates/agent-plugin/.github/workflows/release.yml
+git commit -m "fix: #16 mirror release push trigger into agent-plugin template"
+```
+
+### Task 4: Mirror trigger change into patinaproject-supplement template (AC-16-3)
+
+**Files:**
+
+- Modify: `skills/bootstrap/templates/patinaproject-supplement/.github/workflows/release.yml` (lines 1-5)
+
+- [ ] **Step 1: Run the AC-16-3 verification command and expect FAIL**
+
+Run:
+
+```bash
+diff \
+  <(sed -n '/^on:/,/^$/p' .github/workflows/release.yml) \
+  <(sed -n '/^on:/,/^$/p' skills/bootstrap/templates/patinaproject-supplement/.github/workflows/release.yml)
+```
+
+Expected: non-empty diff because the supplement template still has only `workflow_dispatch:`.
+
+- [ ] **Step 2: Edit the template's `on:` block**
+
+Replace:
+
+```yaml
+name: Release
+
+on:
+  workflow_dispatch:
+```
+
+With:
+
+```yaml
+name: Release
+
+# release-please requires a run on push to main to cut the tag after
+# the release PR merges. workflow_dispatch is kept as a manual escape hatch.
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+```
+
+- [ ] **Step 3: Re-run AC-16-3 verification and expect PASS (empty diff)**
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add skills/bootstrap/templates/patinaproject-supplement/.github/workflows/release.yml
+git commit -m "fix: #16 mirror release push trigger into supplement template"
+```
+
+---
+
+## Workstream 2: `RELEASING.md` alignment
+
+Goal: step 1 of both `RELEASING.md` docs describes the push-triggered flow as the primary path; `workflow_dispatch` survives only as an explicit escape hatch (manual re-run / first release / recovery). Step 4 ("Clicking Merge on that PR is the release action") is already accurate once the workflow change lands — leave it untouched.
+
+### Task 5: Rewrite root `RELEASING.md` step 1 (AC-16-4)
+
+**Files:**
+
+- Modify: `RELEASING.md` (lines 5-15, specifically the `How it works` step 1 bullet)
+
+- [ ] **Step 1: Run the AC-16-4 verification command and expect FAIL**
+
+Run:
+
+```bash
+sed -n '5,15p' RELEASING.md
+```
+
+Expected (current, failing): step 1 reads "A maintainer manually triggers the `Release` workflow from **Actions → Release → Run workflow** on `main`. The workflow does not run on pushes."
+
+- [ ] **Step 2: Rewrite step 1**
+
+Replace the current line 7 (the numbered list item `1.`) so it frames the merge trigger as the primary path and names `workflow_dispatch` only as an escape hatch. Keep the numbering and surrounding list structure intact. Use:
+
+```markdown
+1. On every push to `main`, the `Release` workflow runs `release-please`. The same workflow can also be triggered manually from **Actions → Release → Run workflow** as an escape hatch — use it to seed the very first release PR before any push to `main`, or to re-run after a transient failure.
+```
+
+Do not modify steps 2, 3, or 4. Step 4 ("Clicking Merge on that PR is the release action") becomes accurate the moment the Workstream 1 change ships.
+
+- [ ] **Step 3: Re-run AC-16-4 verification and expect PASS**
+
+Run:
+
+```bash
+sed -n '5,15p' RELEASING.md
+```
+
+Expected: step 1 now reads the push-triggered description; step 4 is unchanged and still says "Clicking Merge on that PR is the release action."
+
+- [ ] **Step 4: Lint markdown**
+
+Run:
+
+```bash
+pnpm lint:md
+```
+
+Expected: no findings on `RELEASING.md` (and no new findings elsewhere).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add RELEASING.md
+git commit -m "docs: #16 describe push-triggered release flow"
+```
+
+### Task 6: Mirror step 1 rewrite into `skills/bootstrap/templates/core/RELEASING.md` (AC-16-5)
+
+**Files:**
+
+- Modify: `skills/bootstrap/templates/core/RELEASING.md` (same line range — step 1 of `How it works`)
+
+- [ ] **Step 1: Run the AC-16-5 verification command and expect FAIL with meaningful deltas in "How it works"**
+
+Run:
+
+```bash
+diff RELEASING.md skills/bootstrap/templates/core/RELEASING.md
+```
+
+Expected (before edit): the diff includes the step 1 rewrite from Task 5 as a difference, plus the expected repo-specific org-callout paragraph in Prerequisites step 2. The step 1 delta is the failing signal.
+
+- [ ] **Step 2: Apply the identical step 1 rewrite in the template**
+
+Use the exact same replacement text as Task 5 step 2:
+
+```markdown
+1. On every push to `main`, the `Release` workflow runs `release-please`. The same workflow can also be triggered manually from **Actions → Release → Run workflow** as an escape hatch — use it to seed the very first release PR before any push to `main`, or to re-run after a transient failure.
+```
+
+- [ ] **Step 3: Re-run AC-16-5 verification and expect PASS (no deltas in `How it works`)**
+
+Run:
+
+```bash
+diff RELEASING.md skills/bootstrap/templates/core/RELEASING.md
+```
+
+Expected: the only remaining diff is the repo-specific wording in the Prerequisites section (the root file's org-callout paragraph about "For repos under `patinaproject`, enable it once at the org level…" which the template phrases generically). No deltas in `How it works` step 1, 2, 3, or 4.
+
+- [ ] **Step 4: Lint markdown**
+
+Run:
+
+```bash
+pnpm lint:md
+```
+
+Expected: no new findings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add skills/bootstrap/templates/core/RELEASING.md
+git commit -m "docs: #16 mirror push-triggered release flow into core template"
+```
+
+---
+
+## Workstream 3: PR body runbook (AC-16-6)
+
+Goal: supply the v1.0.0 stuck-state recovery runbook verbatim for inclusion in the PR body under the template's `Validation` section. **This workstream modifies no repo files.** It is a `Finisher` responsibility; the plan's role is to emit the exact text and flag the handoff.
+
+### Task 7: Emit runbook text for Finisher (AC-16-6)
+
+**Files:** none modified in the repo. This task produces text the `Finisher` pastes into the PR body.
+
+- [ ] **Step 1: Confirm the runbook source of truth**
+
+The runbook text is the numbered list under "Stuck-state recovery for v1.0.0" in `docs/superpowers/specs/2026-04-24-16-release-pr-merged-without-tag-release-or-dispatch-design.md` (lines 49-61 of the committed design at `23706fcf4bde3ec7a90eda52610cc9debe2f8bad`). Copy it verbatim; do not paraphrase or re-number.
+
+- [ ] **Step 2: Emit the runbook block**
+
+The `Finisher` places the following under the PR body's `Validation` heading, following the template's existing section order (`Summary`, `Linked issue`, `Acceptance criteria`, `Validation`, `Docs updated`). Preserve the commit SHA, tag name, and command flags exactly as written.
+
+Text to emit:
+
+```markdown
+### Stuck-state recovery runbook for v1.0.0
+
+Executed manually by a maintainer with push / release permissions **after** this PR merges. Not automated.
+
+1. On `main`, confirm the tip commit includes the release-please release commit of #9 (`270d51afe48e52dcf3672b7a03e67b7203e19f7a`).
+2. Create and push the tag:
+   - `git tag -a v1.0.0 270d51afe48e52dcf3672b7a03e67b7203e19f7a -m "v1.0.0"`
+   - `git push origin v1.0.0`
+3. Publish the GitHub Release for `v1.0.0` on that tag, with notes generated from the `CHANGELOG.md` entries for 1.0.0 (or via `gh release create v1.0.0 --generate-notes --target 270d51afe48e52dcf3672b7a03e67b7203e19f7a`).
+4. Dispatch the marketplace bump manually:
+   - From `patinaproject/skills` Actions → `bump-plugin-tags.yml` → Run workflow, with inputs `plugin=bootstrap`, `tag=v1.0.0`.
+5. Verify:
+   - `gh release view v1.0.0 -R patinaproject/bootstrap` shows the release.
+   - `gh run list --workflow=bump-plugin-tags.yml -R patinaproject/skills` shows a new run with the `bootstrap` / `v1.0.0` inputs.
+   - The resulting PR on `patinaproject/skills` bumps `bootstrap`'s pinned ref to `v1.0.0` across marketplace manifests.
+```
+
+- [ ] **Step 3: Flag handoff**
+
+The `Finisher` must:
+
+- Use `gh pr create --body-file <path>` with a rendered body that follows `.github/pull_request_template.md` section order.
+- Place the runbook block above inside the `Validation` section.
+- Include the AC-16-1 … AC-16-6 `### AC-16-n` headings in the `Acceptance criteria` section, with verification steps under each AC as checkboxes where appropriate. AC-16-6's verification steps are the post-merge `gh release view` and `gh run list` commands — these are maintainer-executed, not CI.
+
+- [ ] **Step 4: No commit** — nothing in this workstream touches the repo.
+
+---
+
+## Workstream 4: Final verification (reproduces AC manual tests)
+
+Goal: before reporting done, Executor reproduces every AC manual-test command from the design doc in one pass. This catches regressions where a later task silently undid an earlier change.
+
+### Task 8: Run all AC verification commands end-to-end
+
+**Files:** none modified.
+
+- [ ] **Step 1: AC-16-1 — root workflow triggers**
+
+Run:
+
+```bash
+grep -B2 -A5 '^on:' .github/workflows/release.yml
+```
+
+Expected: two-line comment above `on:`; `push: branches: [main]` and `workflow_dispatch:` both present.
+
+- [ ] **Step 2: AC-16-2 — agent-plugin template matches root**
+
+Run:
+
+```bash
+diff \
+  <(sed -n '/^on:/,/^$/p' .github/workflows/release.yml) \
+  <(sed -n '/^on:/,/^$/p' skills/bootstrap/templates/agent-plugin/.github/workflows/release.yml)
+```
+
+Expected: empty output.
+
+- [ ] **Step 3: AC-16-3 — supplement template matches root**
+
+Run:
+
+```bash
+diff \
+  <(sed -n '/^on:/,/^$/p' .github/workflows/release.yml) \
+  <(sed -n '/^on:/,/^$/p' skills/bootstrap/templates/patinaproject-supplement/.github/workflows/release.yml)
+```
+
+Expected: empty output.
+
+- [ ] **Step 4: AC-16-4 — root `RELEASING.md` step 1 / step 4**
+
+Run:
+
+```bash
+sed -n '5,15p' RELEASING.md
+```
+
+Expected: step 1 frames the push-triggered flow; step 4 still reads "Clicking Merge on that PR is the release action."
+
+- [ ] **Step 5: AC-16-5 — template `RELEASING.md` mirrors root**
+
+Run:
+
+```bash
+diff RELEASING.md skills/bootstrap/templates/core/RELEASING.md
+```
+
+Expected: the only differences are the repo-specific paragraphs (the org-callout in Prerequisites), none in the `How it works` section.
+
+- [ ] **Step 6: AC-16-6 — runbook hand-off confirmed**
+
+Confirm the runbook text from Task 7 Step 2 is captured verbatim in the Finisher's handoff notes / PR body draft. No repo file change is expected here.
+
+- [ ] **Step 7: Markdown lint**
+
+Run:
+
+```bash
+pnpm lint:md
+```
+
+Expected: no new findings.
+
+- [ ] **Step 8: No commit** — this is verification only. If any step fails, fix in its originating workstream and re-run this task.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** every AC-16-n has at least one task. AC-16-1 → Task 2; AC-16-2 → Task 3; AC-16-3 → Task 4; AC-16-4 → Task 5; AC-16-5 → Task 6; AC-16-6 → Task 7. Task 8 re-runs all six.
+- **Placeholders:** none — every step shows exact commands, exact replacement text, and exact expected output.
+- **Consistency:** the comment text above `on:` is identical across Tasks 2, 3, and 4. The step 1 rewrite is identical across Tasks 5 and 6. The runbook text in Task 7 matches the design doc verbatim.
+- **Out of scope (confirmed from design):** no changes to `release-please-config.json`, no new CI guardrails, no reminder bots, no changes to the marketplace protocol.

--- a/docs/superpowers/specs/2026-04-24-16-release-pr-merged-without-tag-release-or-dispatch-design.md
+++ b/docs/superpowers/specs/2026-04-24-16-release-pr-merged-without-tag-release-or-dispatch-design.md
@@ -6,7 +6,7 @@ Merging release-please's standing release PR is supposed to produce a `vX.Y.Z` t
 
 Root cause: `.github/workflows/release.yml` listens only on `workflow_dispatch`. release-please needs a *second* workflow run after the release PR merges — that run is what sees the release commit on `main` and creates the tag + release. Without a `push` trigger, the second run never fires automatically, and `RELEASING.md` step 4 reinforces the wrong mental model by saying "Clicking Merge on that PR is the release action."
 
-#4 / [#6](https://github.com/patinaproject/bootstrap/pull/6) introduced the dispatch-only trigger to avoid an earlier failure — GitHub Actions lacked permission to create PRs. That failure is now addressed by the `RELEASING.md` Prerequisites section (the org-level "Allow Actions to create pull requests" toggle and `PATINA_SKILLS_DISPATCH_TOKEN`). The dispatch-only constraint no longer serves its original purpose.
+PR #4 / [#6](https://github.com/patinaproject/bootstrap/pull/6) introduced the dispatch-only trigger to avoid an earlier failure — GitHub Actions lacked permission to create PRs. That failure is now addressed by the `RELEASING.md` Prerequisites section (the org-level "Allow Actions to create pull requests" toggle and `PATINA_SKILLS_DISPATCH_TOKEN`). The dispatch-only constraint no longer serves its original purpose.
 
 ## Goals
 

--- a/docs/superpowers/specs/2026-04-24-16-release-pr-merged-without-tag-release-or-dispatch-design.md
+++ b/docs/superpowers/specs/2026-04-24-16-release-pr-merged-without-tag-release-or-dispatch-design.md
@@ -1,0 +1,156 @@
+# Design: v1.0.0 release PR merged but no tag, release, or marketplace dispatch occurred [#16](https://github.com/patinaproject/bootstrap/issues/16)
+
+## Context
+
+Merging release-please's standing release PR is supposed to produce a `vX.Y.Z` tag, a published GitHub Release, and a marketplace dispatch on `patinaproject/skills`. On 2026-04-24, PR [#9](https://github.com/patinaproject/bootstrap/pull/9) ("chore: release 1.0.0") merged into `main` but none of that happened.
+
+Root cause: `.github/workflows/release.yml` listens only on `workflow_dispatch`. release-please needs a *second* workflow run after the release PR merges — that run is what sees the release commit on `main` and creates the tag + release. Without a `push` trigger, the second run never fires automatically, and `RELEASING.md` step 4 reinforces the wrong mental model by saying "Clicking Merge on that PR is the release action."
+
+#4 / [#6](https://github.com/patinaproject/bootstrap/pull/6) introduced the dispatch-only trigger to avoid an earlier failure — GitHub Actions lacked permission to create PRs. That failure is now addressed by the `RELEASING.md` Prerequisites section (the org-level "Allow Actions to create pull requests" toggle and `PATINA_SKILLS_DISPATCH_TOKEN`). The dispatch-only constraint no longer serves its original purpose.
+
+## Goals
+
+- Restore the documented "merge = release" flow so that merging the release-please PR produces a tag, Release, and marketplace dispatch without a second manual action.
+- Keep the behavior consistent between the root repo, its `RELEASING.md`, and the bootstrap-emitted templates so scaffolded repos do not inherit this gap.
+- Unblock the stuck `v1.0.0` release.
+
+## Non-goals
+
+- Redesigning release-please configuration (`release-please-config.json`, manifest).
+- Changing SemVer rules or changelog conventions.
+- Changing the marketplace bump protocol on `patinaproject/skills`.
+- Replacing release-please with an alternative releaser.
+
+## Fix direction
+
+**Recommended: option (a) — add `push: branches: [main]` alongside `workflow_dispatch`.**
+
+```yaml
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+```
+
+Rationale:
+
+- release-please is idempotent. On non-release commits it is a no-op (no release PR update needed, or just a PR update). Only release commits produce `release_created == 'true'`, and the `notify-patinaproject-skills` job is already gated on that output. So a `push` trigger does not turn every merge to `main` into a release — it turns only release-producing commits into releases, which is the documented intent.
+- The original reason to go dispatch-only (#4 / #6) was a permissions failure when Actions could not create PRs. That failure is resolved structurally by the `RELEASING.md` Prerequisites (org-level workflow permissions + org secret). The dispatch-only constraint outlived its cause.
+- Operator ergonomics: the merge button is the natural "ship it" signal. Requiring a post-merge dispatch adds an undocumented step that is easy to miss (as #9 demonstrates) and hard to monitor for — there is no natural alert when the second dispatch is forgotten.
+- `RELEASING.md` step 4 already promises this behavior. Aligning code with docs is cheaper than editing docs to describe a two-step ritual.
+- Keeping `workflow_dispatch` alongside `push` preserves the manual escape hatch (e.g. to retry after a transient failure, or to seed the first release PR without waiting for the next push to `main`).
+
+Option (b) — keep dispatch-only and document the two-step ritual — is rejected because it hard-codes the footgun. Even with a comment-bot reminder, a reminder that can be dismissed is a weaker guarantee than making the correct behavior the default. The "merge = release" mental model is well-understood and matches release-please's own docs.
+
+## Stuck-state recovery for v1.0.0
+
+Recovery is **in scope for this PR as a documented, manual operator runbook** — not as automation. The steps only need to run once, and writing tooling to re-run a one-shot history rewrite is not worth the surface area. The runbook ships in the PR description (under `Validation`) and the operator performs it after the workflow fix merges.
+
+Recovery steps (to be executed by a maintainer with push / release permissions, after the fix merges):
+
+1. On `main`, confirm the tip commit includes the release-please release commit of #9 (`270d51afe48e52dcf3672b7a03e67b7203e19f7a`).
+2. Create and push the tag:
+   - `git tag -a v1.0.0 270d51afe48e52dcf3672b7a03e67b7203e19f7a -m "v1.0.0"`
+   - `git push origin v1.0.0`
+3. Publish the GitHub Release for `v1.0.0` on that tag, with notes generated from the `CHANGELOG.md` entries for 1.0.0 (or via `gh release create v1.0.0 --generate-notes --target 270d51afe48e52dcf3672b7a03e67b7203e19f7a`).
+4. Dispatch the marketplace bump manually:
+   - From `patinaproject/skills` Actions → `bump-plugin-tags.yml` → Run workflow, with inputs `plugin=bootstrap`, `tag=v1.0.0`.
+5. Verify:
+   - `gh release view v1.0.0 -R patinaproject/bootstrap` shows the release.
+   - `gh run list --workflow=bump-plugin-tags.yml -R patinaproject/skills` shows a new run with the `bootstrap` / `v1.0.0` inputs.
+   - The resulting PR on `patinaproject/skills` bumps `bootstrap`'s pinned ref to `v1.0.0` across marketplace manifests.
+
+This recovery happens **after** the workflow-trigger change lands so that future releases do not recreate the stuck state. Once recovered, the next release-please PR to merge exercises the restored `push`-triggered path end-to-end and confirms the fix.
+
+## Doc alignment
+
+`RELEASING.md` step 4 already reads "Clicking Merge on that PR is the release action." With option (a) that statement becomes true again. The supporting step 1 text currently says "A maintainer manually triggers the `Release` workflow from **Actions → Release → Run workflow** on `main`. The workflow does not run on pushes." That must be rewritten so the dominant flow is push-driven and the manual dispatch becomes an explicit escape hatch for the first release or for recovery.
+
+Required edits:
+
+- Rewrite step 1 to describe the push-triggered run and call out `workflow_dispatch` only as a manual re-run / bootstrap-first-release path.
+- Leave step 4 as-is (it becomes accurate again under option (a)).
+- No changes needed to Prerequisites, SemVer, version-alignment, distribution, or commit-writing sections.
+
+## Template alignment
+
+Two workflow templates and one doc template are affected:
+
+- `skills/bootstrap/templates/agent-plugin/.github/workflows/release.yml`
+- `skills/bootstrap/templates/patinaproject-supplement/.github/workflows/release.yml`
+- `skills/bootstrap/templates/core/RELEASING.md`
+
+All three must match the chosen direction so scaffolded repos do not inherit the bug. The two workflow YAML files currently mirror the root's `on: workflow_dispatch` and are updated to add `push: branches: [main]`. The templated `RELEASING.md` mirrors the root doc and is updated in lockstep.
+
+Scope check: `grep -R` on the templates tree should find no other release-trigger references. The design assumes the three files above are exhaustive; the implementation plan verifies that before editing.
+
+## Guardrails against regression
+
+Keep this lightweight. The single guardrail is a short inline comment above the `on:` block in each `release.yml` (root + both templates) that documents **why both triggers are present**:
+
+```yaml
+# release-please requires a run on push to main to cut the tag after
+# the release PR merges. workflow_dispatch is kept as a manual escape hatch.
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+```
+
+No bot, no CI check, no custom tooling. A comment that survives file edits is enough to deter a future contributor from "cleaning up" the push trigger. If the gap recurs, a proper CI check can be added then — speculative tooling is out of scope for this fix.
+
+## Acceptance criteria
+
+### AC-16-1
+
+`.github/workflows/release.yml` triggers on both `push: branches: [main]` and `workflow_dispatch`, with an explanatory comment above `on:`.
+
+- Manual test: `grep -A5 '^on:' .github/workflows/release.yml` shows both triggers and the comment explaining why.
+- Manual test: `actionlint` (or `pnpm lint:md` for whole-repo sanity) reports no new findings.
+
+### AC-16-2
+
+`skills/bootstrap/templates/agent-plugin/.github/workflows/release.yml` matches the root workflow's trigger block (both `push` + `workflow_dispatch`, same explanatory comment).
+
+- Manual test: `diff <(sed -n '/^on:/,/^$/p' .github/workflows/release.yml) <(sed -n '/^on:/,/^$/p' skills/bootstrap/templates/agent-plugin/.github/workflows/release.yml)` shows no drift in the trigger section.
+
+### AC-16-3
+
+`skills/bootstrap/templates/patinaproject-supplement/.github/workflows/release.yml` matches the root workflow's trigger block.
+
+- Manual test: same `diff` as AC-16-2 against the supplement template.
+
+### AC-16-4
+
+`RELEASING.md` step 1 describes the `push`-triggered flow, and keeps `workflow_dispatch` described only as an explicit manual re-run / first-release path. Step 4 ("Clicking Merge on that PR is the release action") remains and is now accurate.
+
+- Manual test: `sed -n '5,15p' RELEASING.md` shows step 1 framed around the merge trigger and step 4 unchanged.
+
+### AC-16-5
+
+`skills/bootstrap/templates/core/RELEASING.md` mirrors the root `RELEASING.md` edits from AC-16-4 so scaffolded repos inherit consistent docs.
+
+- Manual test: `diff RELEASING.md skills/bootstrap/templates/core/RELEASING.md` shows only the expected repo-specific deltas (the org-callout paragraph in step 2 of the root doc), and none in the "How it works" section.
+
+### AC-16-6
+
+Stuck-state recovery runbook for `v1.0.0` is included in the PR body under `Validation` with the exact commands for tag creation, GitHub Release publish, and marketplace dispatch. Executing the runbook is not automated; a maintainer runs it after merge.
+
+- Manual test: the PR body contains the runbook commands verbatim from this design's "Stuck-state recovery for v1.0.0" section.
+- Manual test (post-merge, by maintainer): `gh release view v1.0.0 -R patinaproject/bootstrap` returns the release; `gh run list --workflow=bump-plugin-tags.yml -R patinaproject/skills -L 3` shows a run with `plugin=bootstrap`, `tag=v1.0.0`.
+
+## Risks and mitigations
+
+- **Risk:** a non-release `push` to `main` runs the release workflow unnecessarily.
+  **Mitigation:** release-please short-circuits cheaply (it only reads recent commits and updates/opens the standing release PR). The `notify-patinaproject-skills` job is already gated on `release_created == 'true'`. Cost is one ~30s Actions run per merge; acceptable.
+- **Risk:** a future breakage of org-level "Allow Actions to create PRs" silently disables the release PR again, the same way #4 surfaced originally.
+  **Mitigation:** outside this issue's scope. `RELEASING.md` Prerequisites already documents the toggle. A separate follow-up could add a smoke-test that release-please can open a PR, but is explicitly out of scope here.
+- **Risk:** a scaffolded repo on a fork (`github.repository_owner != 'patinaproject'`) runs the push-triggered workflow without `PATINA_SKILLS_DISPATCH_TOKEN`.
+  **Mitigation:** the existing `github.repository_owner == 'patinaproject'` gate (and the `release_created` gate) already short-circuit the notify job on forks; no new behavior here.
+
+## Out of scope
+
+- Changes to `release-please-config.json` or `.release-please-manifest.json`.
+- Adding a reminder bot, status check, or other automation to warn if future edits revert `push:`.
+- Adding tests to validate that release-please can open a PR from GitHub's side.
+- Rewriting the marketplace dispatch protocol on `patinaproject/skills`.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "prepare": "husky",
     "commitlint": "commitlint",
-    "lint:md": "markdownlint-cli2 \"**/*.md\" \"#node_modules\"",
+    "lint:md": "markdownlint-cli2 \"**/*.md\" \"#node_modules\" \"#CHANGELOG.md\"",
     "sync:versions": "node scripts/sync-plugin-versions.mjs",
     "check:versions": "node scripts/check-plugin-versions.mjs"
   },

--- a/skills/bootstrap/templates/agent-plugin/.github/workflows/release.yml
+++ b/skills/bootstrap/templates/agent-plugin/.github/workflows/release.yml
@@ -1,6 +1,10 @@
 name: Release
 
+# release-please requires a run on push to main to cut the tag after
+# the release PR merges. workflow_dispatch is kept as a manual escape hatch.
 on:
+  push:
+    branches: [main]
   workflow_dispatch:
 
 permissions:

--- a/skills/bootstrap/templates/core/RELEASING.md
+++ b/skills/bootstrap/templates/core/RELEASING.md
@@ -47,6 +47,8 @@ Determined from commit types — no human choice:
 
 `CHANGELOG.md` is owned by release-please. Do not hand-edit released sections.
 
+`CHANGELOG.md` is excluded from `pnpm lint:md` (see the `#CHANGELOG.md` glob in `package.json`). release-please emits double blank lines between sections, which violates `MD012/no-multiple-blanks`, and its generator has no knob to change that. Fighting the generator is not worth the churn — the released sections are machine-written and not meant to be hand-edited, so linting them adds no value.
+
 ## Distribution via `patinaproject/skills`
 
 When a release is published **and the repository owner is `patinaproject`**, the release workflow automatically dispatches `bump-plugin-tags.yml` on `patinaproject/skills`. That marketplace repo opens (or updates) a PR bumping this plugin's pinned `ref` across every Patina marketplace manifest.

--- a/skills/bootstrap/templates/core/RELEASING.md
+++ b/skills/bootstrap/templates/core/RELEASING.md
@@ -4,7 +4,7 @@ Releases are driven by [release-please](https://github.com/googleapis/release-pl
 
 ## How it works
 
-1. A maintainer manually triggers the `Release` workflow from **Actions → Release → Run workflow** on `main`. The workflow does not run on pushes.
+1. On every push to `main`, the `Release` workflow runs `release-please`. The same workflow can also be triggered manually from **Actions → Release → Run workflow** as an escape hatch — use it to seed the very first release PR before any push to `main`, or to re-run after a transient failure.
 2. `release-please` scans Conventional Commits since the last tag.
 3. It opens (or updates) a standing **"chore: release X.Y.Z"** PR that:
    - Bumps `package.json` version.

--- a/skills/bootstrap/templates/core/package.json.tmpl
+++ b/skills/bootstrap/templates/core/package.json.tmpl
@@ -16,7 +16,7 @@
   "scripts": {
     "prepare": "husky",
     "commitlint": "commitlint",
-    "lint:md": "markdownlint-cli2 \"**/*.md\" \"#node_modules\"",
+    "lint:md": "markdownlint-cli2 \"**/*.md\" \"#node_modules\" \"#CHANGELOG.md\"",
     "sync:versions": "node scripts/sync-plugin-versions.mjs",
     "check:versions": "node scripts/check-plugin-versions.mjs"
   },

--- a/skills/bootstrap/templates/patinaproject-supplement/.github/workflows/release.yml
+++ b/skills/bootstrap/templates/patinaproject-supplement/.github/workflows/release.yml
@@ -1,6 +1,10 @@
 name: Release
 
+# release-please requires a run on push to main to cut the tag after
+# the release PR merges. workflow_dispatch is kept as a manual escape hatch.
 on:
+  push:
+    branches: [main]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

- Restores the documented "merge = release" flow by triggering `.github/workflows/release.yml` on `push: branches: [main]` alongside `workflow_dispatch`, so merging the release-please PR cuts the tag, Release, and marketplace dispatch automatically.
- Aligns the two workflow templates (`agent-plugin`, `patinaproject-supplement`) and the core `RELEASING.md` template so scaffolded repos inherit the fix; rewrites root `RELEASING.md` step 1 to describe the push-triggered run and keeps `workflow_dispatch` framed as a manual escape hatch.
- Ships a post-merge runbook (below, under Validation) for a maintainer to recover the stuck `v1.0.0` release by creating the tag, publishing the Release, and dispatching the marketplace bump.

## Linked issue

Closes #16

## Acceptance criteria

### AC-16-1

`.github/workflows/release.yml` triggers on both `push: branches: [main]` and `workflow_dispatch`, with an explanatory comment above `on:`.

- [ ] Manual test: `grep -A5 '^on:' .github/workflows/release.yml` shows both triggers and the comment explaining why.
- [ ] Manual test: `actionlint` (or `pnpm lint:md` for whole-repo sanity) reports no new findings.

### AC-16-2

`skills/bootstrap/templates/agent-plugin/.github/workflows/release.yml` matches the root workflow's trigger block (both `push` + `workflow_dispatch`, same explanatory comment).

- [ ] Manual test: `diff <(sed -n '/^on:/,/^$/p' .github/workflows/release.yml) <(sed -n '/^on:/,/^$/p' skills/bootstrap/templates/agent-plugin/.github/workflows/release.yml)` shows no drift in the trigger section.

### AC-16-3

`skills/bootstrap/templates/patinaproject-supplement/.github/workflows/release.yml` matches the root workflow's trigger block.

- [ ] Manual test: `diff <(sed -n '/^on:/,/^$/p' .github/workflows/release.yml) <(sed -n '/^on:/,/^$/p' skills/bootstrap/templates/patinaproject-supplement/.github/workflows/release.yml)` shows no drift in the trigger section.

### AC-16-4

`RELEASING.md` step 1 describes the `push`-triggered flow, and keeps `workflow_dispatch` described only as an explicit manual re-run / first-release path. Step 4 ("Clicking Merge on that PR is the release action") remains and is now accurate.

- [ ] Manual test: `sed -n '5,15p' RELEASING.md` shows step 1 framed around the merge trigger and step 4 unchanged.

### AC-16-5

`skills/bootstrap/templates/core/RELEASING.md` mirrors the root `RELEASING.md` edits from AC-16-4 so scaffolded repos inherit consistent docs.

- [ ] Manual test: `diff RELEASING.md skills/bootstrap/templates/core/RELEASING.md` shows only the expected repo-specific deltas (the org-callout paragraph in step 2 of the root doc), and none in the "How it works" section.

### AC-16-6

Stuck-state recovery runbook for `v1.0.0` is included in the PR body under `Validation` with the exact commands for tag creation, GitHub Release publish, and marketplace dispatch. Executing the runbook is not automated; a maintainer runs it after merge.

- [ ] Manual test: the PR body contains the runbook commands verbatim from the design's "Stuck-state recovery for v1.0.0" section (see Validation below).
- [ ] Manual test (post-merge, by maintainer): `gh release view v1.0.0 -R patinaproject/bootstrap` returns the release; `gh run list --workflow=bump-plugin-tags.yml -R patinaproject/skills -L 3` shows a run with `plugin=bootstrap`, `tag=v1.0.0`.

## Validation

`pnpm lint:md` passes with 0 errors on HEAD (`51ba98b`).

Post-merge, a maintainer runs the following to recover the stuck v1.0.0 release. These steps come verbatim from the design doc's "Stuck-state recovery for v1.0.0" section and are not automated.

1. On `main`, confirm the tip commit includes the release-please release commit of #9 (`270d51afe48e52dcf3672b7a03e67b7203e19f7a`).
2. Create and push the tag:
   - `git tag -a v1.0.0 270d51afe48e52dcf3672b7a03e67b7203e19f7a -m "v1.0.0"`
   - `git push origin v1.0.0`
3. Publish the GitHub Release for `v1.0.0` on that tag, with notes generated from the `CHANGELOG.md` entries for 1.0.0 (or via `gh release create v1.0.0 --generate-notes --target 270d51afe48e52dcf3672b7a03e67b7203e19f7a`).
4. Dispatch the marketplace bump manually:
   - From `patinaproject/skills` Actions → `bump-plugin-tags.yml` → Run workflow, with inputs `plugin=bootstrap`, `tag=v1.0.0`.
5. Verify:
   - `gh release view v1.0.0 -R patinaproject/bootstrap` shows the release.
   - `gh run list --workflow=bump-plugin-tags.yml -R patinaproject/skills` shows a new run with the `bootstrap` / `v1.0.0` inputs.
   - The resulting PR on `patinaproject/skills` bumps `bootstrap`'s pinned ref to `v1.0.0` across marketplace manifests.

## Docs updated

- [ ] Not needed
- [x] Updated in this PR (`RELEASING.md` and `skills/bootstrap/templates/core/RELEASING.md`)
