### PR TITLE
fix: #18 add issues: write to release workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: write
+  issues: write
   pull-requests: write
 
 jobs:
@@ -19,9 +20,13 @@ jobs:
     # presents to GitHub when release-please calls POST /repos/.../releases.
     # Some org policies cap the workflow default below the workflow-level
     # declaration, so setting job-level permissions explicitly removes the
-    # ambiguity that caused issue #18.
+    # ambiguity that caused issue #18. `issues: write` is required because PR
+    # labels are on the Issues API: release-please relabels the release PR from
+    # `autorelease: pending` to `autorelease: tagged` as part of release
+    # creation, and without this scope the whole step 403s.
     permissions:
       contents: write
+      issues: write
       pull-requests: write
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -16,7 +16,16 @@ Releases are driven by [release-please](https://github.com/googleapis/release-pl
 
 ### Workflow permissions: read and write
 
-`release-please` writes to the repo — it creates tags and publishes GitHub Releases via `POST /repos/.../releases`. That call requires the workflow's `GITHUB_TOKEN` to carry `contents: write`. The repo-level default of `read` causes `release-please-action` to fail with `Resource not accessible by integration` on the release step, even when the workflow file declares `permissions: contents: write` — workflow-level declarations are capped by the repo default.
+`release-please` writes to the repo — it creates tags, publishes GitHub Releases via `POST /repos/.../releases`, relabels the release PR (`autorelease: pending` → `autorelease: tagged`), and comments on issues referenced in the changelog. The full canonical [permissions set from the release-please-action README](https://github.com/googleapis/release-please-action#workflow-permissions) is three scopes:
+
+```yaml
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+```
+
+`issues: write` is easy to miss — PR labels live on the Issues API, so relabeling the release PR needs it even though the target is a PR. Omitting any of the three causes `release-please-action` to fail with `Resource not accessible by integration` on the release step, regardless of how `contents: write` is declared elsewhere. The repo-level default of `read` additionally caps the workflow-level declarations, so both the repo toggle and the workflow YAML must agree.
 
 Enable the read + write default:
 
@@ -50,6 +59,7 @@ Use this path when org policy caps repo-level workflow permissions below read + 
 Required token scopes:
 
 - `contents: write` — to create tags and publish releases.
+- `issues: write` — to relabel the release PR (PR labels are on the Issues API) and to comment on issues referenced in the changelog.
 - `pull-requests: write` — to open and update the standing release PR.
 
 A fine-grained PAT or a GitHub App installation token both work. Store it as an **org-level secret** (preferred, so every plugin repo inherits it) or a **repo-level secret**. Suggested name: `RELEASE_PLEASE_TOKEN`.

--- a/skills/bootstrap/templates/agent-plugin/.github/workflows/release.yml
+++ b/skills/bootstrap/templates/agent-plugin/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: write
+  issues: write
   pull-requests: write
 
 jobs:
@@ -19,9 +20,13 @@ jobs:
     # presents to GitHub when release-please calls POST /repos/.../releases.
     # Some org policies cap the workflow default below the workflow-level
     # declaration, so setting job-level permissions explicitly removes the
-    # ambiguity that caused issue #18.
+    # ambiguity that caused issue #18. `issues: write` is required because PR
+    # labels are on the Issues API: release-please relabels the release PR from
+    # `autorelease: pending` to `autorelease: tagged` as part of release
+    # creation, and without this scope the whole step 403s.
     permissions:
       contents: write
+      issues: write
       pull-requests: write
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}

--- a/skills/bootstrap/templates/core/RELEASING.md
+++ b/skills/bootstrap/templates/core/RELEASING.md
@@ -16,7 +16,16 @@ Releases are driven by [release-please](https://github.com/googleapis/release-pl
 
 ### Workflow permissions: read and write
 
-`release-please` writes to the repo — it creates tags and publishes GitHub Releases via `POST /repos/.../releases`. That call requires the workflow's `GITHUB_TOKEN` to carry `contents: write`. The repo-level default of `read` causes `release-please-action` to fail with `Resource not accessible by integration` on the release step, even when the workflow file declares `permissions: contents: write` — workflow-level declarations are capped by the repo default.
+`release-please` writes to the repo — it creates tags, publishes GitHub Releases via `POST /repos/.../releases`, relabels the release PR (`autorelease: pending` → `autorelease: tagged`), and comments on issues referenced in the changelog. The full canonical [permissions set from the release-please-action README](https://github.com/googleapis/release-please-action#workflow-permissions) is three scopes:
+
+```yaml
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+```
+
+`issues: write` is easy to miss — PR labels live on the Issues API, so relabeling the release PR needs it even though the target is a PR. Omitting any of the three causes `release-please-action` to fail with `Resource not accessible by integration` on the release step, regardless of how `contents: write` is declared elsewhere. The repo-level default of `read` additionally caps the workflow-level declarations, so both the repo toggle and the workflow YAML must agree.
 
 Enable the read + write default:
 
@@ -50,6 +59,7 @@ Use this path when org policy caps repo-level workflow permissions below read + 
 Required token scopes:
 
 - `contents: write` — to create tags and publish releases.
+- `issues: write` — to relabel the release PR (PR labels are on the Issues API) and to comment on issues referenced in the changelog.
 - `pull-requests: write` — to open and update the standing release PR.
 
 A fine-grained PAT or a GitHub App installation token both work. Store it as an **org-level secret** (preferred, so every plugin repo inherits it) or a **repo-level secret**. Suggested name: `RELEASE_PLEASE_TOKEN`.

--- a/skills/bootstrap/templates/patinaproject-supplement/.github/workflows/release.yml
+++ b/skills/bootstrap/templates/patinaproject-supplement/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: write
+  issues: write
   pull-requests: write
 
 jobs:
@@ -19,9 +20,13 @@ jobs:
     # presents to GitHub when release-please calls POST /repos/.../releases.
     # Some org policies cap the workflow default below the workflow-level
     # declaration, so setting job-level permissions explicitly removes the
-    # ambiguity that caused issue #18.
+    # ambiguity that caused issue #18. `issues: write` is required because PR
+    # labels are on the Issues API: release-please relabels the release PR from
+    # `autorelease: pending` to `autorelease: tagged` as part of release
+    # creation, and without this scope the whole step 403s.
     permissions:
       contents: write
+      issues: write
       pull-requests: write
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}

--- a/skills/bootstrap/templates/patinaproject-supplement/RELEASING.md
+++ b/skills/bootstrap/templates/patinaproject-supplement/RELEASING.md
@@ -16,7 +16,16 @@ Releases are driven by [release-please](https://github.com/googleapis/release-pl
 
 ### Workflow permissions: read and write
 
-`release-please` writes to the repo — it creates tags and publishes GitHub Releases via `POST /repos/.../releases`. That call requires the workflow's `GITHUB_TOKEN` to carry `contents: write`. The repo-level default of `read` causes `release-please-action` to fail with `Resource not accessible by integration` on the release step, even when the workflow file declares `permissions: contents: write` — workflow-level declarations are capped by the repo default.
+`release-please` writes to the repo — it creates tags, publishes GitHub Releases via `POST /repos/.../releases`, relabels the release PR (`autorelease: pending` → `autorelease: tagged`), and comments on issues referenced in the changelog. The full canonical [permissions set from the release-please-action README](https://github.com/googleapis/release-please-action#workflow-permissions) is three scopes:
+
+```yaml
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+```
+
+`issues: write` is easy to miss — PR labels live on the Issues API, so relabeling the release PR needs it even though the target is a PR. Omitting any of the three causes `release-please-action` to fail with `Resource not accessible by integration` on the release step, regardless of how `contents: write` is declared elsewhere. The repo-level default of `read` additionally caps the workflow-level declarations, so both the repo toggle and the workflow YAML must agree.
 
 Enable the read + write default:
 
@@ -50,6 +59,7 @@ Use this path when org policy caps repo-level workflow permissions below read + 
 Required token scopes:
 
 - `contents: write` — to create tags and publish releases.
+- `issues: write` — to relabel the release PR (PR labels are on the Issues API) and to comment on issues referenced in the changelog.
 - `pull-requests: write` — to open and update the standing release PR.
 
 A fine-grained PAT or a GitHub App installation token both work. Store it as an **org-level secret** (preferred, so every plugin repo inherits it) or a **repo-level secret**. Suggested name: `RELEASE_PLEASE_TOKEN`.


### PR DESCRIPTION
## Summary

- The [release-please-action README](https://github.com/googleapis/release-please-action#workflow-permissions) specifies **three** required `GITHUB_TOKEN` scopes for a working release: `contents: write`, **`issues: write`**, and `pull-requests: write`. The prior pass on #18 shipped only two of the three, so the release-please step still 403s with `Resource not accessible by integration` after merge — the underlying failing call is the PR relabel (`autorelease: pending` → `autorelease: tagged`), because PR labels live on the Issues API, not the Pull Requests API.
- Adds `issues: write` to both workflow-level and job-level `permissions:` in both template `release.yml` variants and the mirrored root, with an inline comment explaining the Issues-API-for-PR-labels quirk.
- Updates the `Workflow permissions: read and write` and `PAT / GitHub App token fallback` sections of `RELEASING.md` (template + root) to name all three required scopes and explain why `issues: write` is required even though the target is a PR.
- This is a **pure repo-config fix** — no PAT, no GitHub App, no secret rotation. Works for any OSS community member bootstrapping a repo from this skill.

## Linked issue

- `Closes #18`

## Acceptance criteria

### AC-18-1

After this PR merges, the `Release` workflow cuts `v1.0.0` (tag + GitHub Release + `autorelease: tagged` relabel on PR #9) on the next run. For the already-stuck 1.0.0 (release-please manifest pinned), the recovery runbook from the prior #18 PR still applies — it only needed the permissions fix to reach success.

- [ ] Post-merge: trigger `Release` via `workflow_dispatch` once, or push any `fix:`/`feat:` commit to `main`; confirm a tag and GitHub Release land without the 403.

### AC-18-3

`skills/bootstrap/templates/core/RELEASING.md` and the mirrored `patinaproject-supplement/RELEASING.md` now name all three required `GITHUB_TOKEN` scopes and call out the Issues-API-for-PR-labels quirk so future consumers don't repeat the mistake.

- [ ] Reviewer check: `skills/bootstrap/templates/core/RELEASING.md` → "Workflow permissions: read and write" section lists `contents: write`, `issues: write`, `pull-requests: write`.

### AC-18-4

Both template `release.yml` variants and the mirrored root declare `issues: write` at both workflow and job level, with a comment explaining the requirement.

- [ ] Reviewer check: `grep -n "issues: write"` on all three files returns two matches each (workflow + job level).

## Validation

- `pnpm lint:md` on the branch: 0 errors across 41 files.
- `diff skills/bootstrap/templates/patinaproject-supplement/.github/workflows/release.yml .github/workflows/release.yml` is empty (byte-identical, template-first mirror preserved).
- `diff skills/bootstrap/templates/patinaproject-supplement/RELEASING.md RELEASING.md` is empty.
- Post-merge end-to-end verification (the actual proof this fixes #18) is captured in AC-18-1 above — merging this PR is what unblocks the stuck `v1.0.0`.

## Docs updated

- [ ] Not needed
- [x] Updated in this PR
