### PR TITLE
fix: #31 run release workflow only on manual dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,16 @@
 name: Release
 
-# release-please requires a run on push to main to cut the tag after
-# the release PR merges. workflow_dispatch is kept as a manual escape hatch.
+# Triggered only when (a) a maintainer manually dispatches the workflow to
+# open or refresh the standing release PR, or (b) a release-please-managed
+# PR (label `autorelease: pending`) is merged — the second event auto-cuts
+# the tag, publishes the release, and dispatches the marketplace bump on
+# patinaproject/skills. Regular PR merges do NOT trigger this workflow.
+# See RELEASING.md.
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
+  pull_request:
+    types: [closed]
+    branches: [main]
 
 permissions:
   contents: write
@@ -14,6 +19,15 @@ permissions:
 
 jobs:
   release-please:
+    # On `pull_request: closed`, only run when the PR was actually merged AND
+    # carries the `autorelease: pending` label that release-please attaches
+    # to its standing release PR. This skips the job for regular feature/fix
+    # PR merges, so no Release workflow run shows up against them. The job
+    # always runs on `workflow_dispatch`.
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true &&
+       contains(github.event.pull_request.labels.*.name, 'autorelease: pending'))
     runs-on: ubuntu-latest
     # Declared at both workflow and job level. The workflow-level block is the
     # upper bound for any job; the job-level block is what the runner actually

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,13 +4,23 @@ Releases are driven by [release-please](https://github.com/googleapis/release-pl
 
 ## How it works
 
-1. On every push to `main`, the `Release` workflow runs `release-please`. The same workflow can also be triggered manually from **Actions → Release → Run workflow** as an escape hatch — use it to seed the very first release PR before any push to `main`, or to re-run after a transient failure.
-2. `release-please` scans Conventional Commits since the last tag.
-3. It opens (or updates) a standing **"chore: release X.Y.Z"** PR that:
+The `Release` workflow does **not** auto-run on every PR merge. Its triggers are:
+
+- `workflow_dispatch` — for opening or refreshing the standing release PR on demand.
+- `pull_request: types: [closed]` — but the job only runs when the closed PR was **merged** *and* carries the `autorelease: pending` label. Regular feature/fix PR merges therefore produce no Release workflow run.
+
+Cutting a release is a two-step flow:
+
+1. **Open or refresh the release PR (manual).** Trigger the workflow via **Actions → Release → Run workflow** (or `gh workflow run Release --repo <owner>/<repo>`). `release-please` scans Conventional Commits since the last tag and opens — or updates — a standing **"chore: release X.Y.Z"** PR that:
    - Bumps `package.json` version.
    - Syncs `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json` to the new version (configured in `release-please-config.json`).
    - Appends generated entries to `CHANGELOG.md`.
-4. **Clicking Merge on that PR** is the release action. It tags `vX.Y.Z` and publishes a GitHub Release with notes generated from the same commits.
+
+   Release-please attaches the `autorelease: pending` label to this PR.
+
+2. **Merge the release PR (auto-fires step 3).** Squash-merging the PR closes it with the `autorelease: pending` label still attached. The `pull_request: closed` event fires the `Release` workflow automatically; release-please runs against `main`, sees the merged release PR, creates the tag `vX.Y.Z`, publishes the GitHub Release with the same Conventional-Commit-derived notes, and (on `patinaproject` plugin repos) dispatches the marketplace bump on `patinaproject/skills`. The PR's label flips to `autorelease: tagged`.
+
+The result: regular PRs trigger nothing release-related; the only auto-fire is the release-PR merge that you just authored.
 
 ## Prerequisites (one-time settings)
 

--- a/skills/bootstrap/templates/agent-plugin/.github/workflows/release.yml
+++ b/skills/bootstrap/templates/agent-plugin/.github/workflows/release.yml
@@ -1,11 +1,15 @@
 name: Release
 
-# release-please requires a run on push to main to cut the tag after
-# the release PR merges. workflow_dispatch is kept as a manual escape hatch.
+# Triggered only when (a) a maintainer manually dispatches the workflow to
+# open or refresh the standing release PR, or (b) a release-please-managed
+# PR (label `autorelease: pending`) is merged — the second event auto-cuts
+# the tag and publishes the release. Regular PR merges do NOT trigger this
+# workflow. See RELEASING.md.
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
+  pull_request:
+    types: [closed]
+    branches: [main]
 
 permissions:
   contents: write
@@ -14,6 +18,15 @@ permissions:
 
 jobs:
   release-please:
+    # On `pull_request: closed`, only run when the PR was actually merged AND
+    # carries the `autorelease: pending` label that release-please attaches
+    # to its standing release PR. This skips the job for regular feature/fix
+    # PR merges, so no Release workflow run shows up against them. The job
+    # always runs on `workflow_dispatch`.
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true &&
+       contains(github.event.pull_request.labels.*.name, 'autorelease: pending'))
     runs-on: ubuntu-latest
     # Declared at both workflow and job level. The workflow-level block is the
     # upper bound for any job; the job-level block is what the runner actually

--- a/skills/bootstrap/templates/core/RELEASING.md
+++ b/skills/bootstrap/templates/core/RELEASING.md
@@ -4,13 +4,23 @@ Releases are driven by [release-please](https://github.com/googleapis/release-pl
 
 ## How it works
 
-1. On every push to `main`, the `Release` workflow runs `release-please`. The same workflow can also be triggered manually from **Actions → Release → Run workflow** as an escape hatch — use it to seed the very first release PR before any push to `main`, or to re-run after a transient failure.
-2. `release-please` scans Conventional Commits since the last tag.
-3. It opens (or updates) a standing **"chore: release X.Y.Z"** PR that:
+The `Release` workflow does **not** auto-run on every PR merge. Its triggers are:
+
+- `workflow_dispatch` — for opening or refreshing the standing release PR on demand.
+- `pull_request: types: [closed]` — but the job only runs when the closed PR was **merged** *and* carries the `autorelease: pending` label. Regular feature/fix PR merges therefore produce no Release workflow run.
+
+Cutting a release is a two-step flow:
+
+1. **Open or refresh the release PR (manual).** Trigger the workflow via **Actions → Release → Run workflow** (or `gh workflow run Release --repo <owner>/<repo>`). `release-please` scans Conventional Commits since the last tag and opens — or updates — a standing **"chore: release X.Y.Z"** PR that:
    - Bumps `package.json` version.
    - Syncs `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json` to the new version (configured in `release-please-config.json`).
    - Appends generated entries to `CHANGELOG.md`.
-4. **Clicking Merge on that PR** is the release action. It tags `vX.Y.Z` and publishes a GitHub Release with notes generated from the same commits.
+
+   Release-please attaches the `autorelease: pending` label to this PR.
+
+2. **Merge the release PR (auto-fires step 3).** Squash-merging the PR closes it with the `autorelease: pending` label still attached. The `pull_request: closed` event fires the `Release` workflow automatically; release-please runs against `main`, sees the merged release PR, creates the tag `vX.Y.Z`, publishes the GitHub Release with the same Conventional-Commit-derived notes, and (when configured) dispatches the marketplace bump. The PR's label flips to `autorelease: tagged`.
+
+The result: regular PRs trigger nothing release-related; the only auto-fire is the release-PR merge that you just authored.
 
 ## Prerequisites (one-time settings)
 

--- a/skills/bootstrap/templates/patinaproject-supplement/.github/workflows/release.yml
+++ b/skills/bootstrap/templates/patinaproject-supplement/.github/workflows/release.yml
@@ -1,11 +1,16 @@
 name: Release
 
-# release-please requires a run on push to main to cut the tag after
-# the release PR merges. workflow_dispatch is kept as a manual escape hatch.
+# Triggered only when (a) a maintainer manually dispatches the workflow to
+# open or refresh the standing release PR, or (b) a release-please-managed
+# PR (label `autorelease: pending`) is merged — the second event auto-cuts
+# the tag, publishes the release, and dispatches the marketplace bump on
+# patinaproject/skills. Regular PR merges do NOT trigger this workflow.
+# See RELEASING.md.
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
+  pull_request:
+    types: [closed]
+    branches: [main]
 
 permissions:
   contents: write
@@ -14,6 +19,15 @@ permissions:
 
 jobs:
   release-please:
+    # On `pull_request: closed`, only run when the PR was actually merged AND
+    # carries the `autorelease: pending` label that release-please attaches
+    # to its standing release PR. This skips the job for regular feature/fix
+    # PR merges, so no Release workflow run shows up against them. The job
+    # always runs on `workflow_dispatch`.
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true &&
+       contains(github.event.pull_request.labels.*.name, 'autorelease: pending'))
     runs-on: ubuntu-latest
     # Declared at both workflow and job level. The workflow-level block is the
     # upper bound for any job; the job-level block is what the runner actually

--- a/skills/bootstrap/templates/patinaproject-supplement/RELEASING.md
+++ b/skills/bootstrap/templates/patinaproject-supplement/RELEASING.md
@@ -4,13 +4,23 @@ Releases are driven by [release-please](https://github.com/googleapis/release-pl
 
 ## How it works
 
-1. On every push to `main`, the `Release` workflow runs `release-please`. The same workflow can also be triggered manually from **Actions → Release → Run workflow** as an escape hatch — use it to seed the very first release PR before any push to `main`, or to re-run after a transient failure.
-2. `release-please` scans Conventional Commits since the last tag.
-3. It opens (or updates) a standing **"chore: release X.Y.Z"** PR that:
+The `Release` workflow does **not** auto-run on every PR merge. Its triggers are:
+
+- `workflow_dispatch` — for opening or refreshing the standing release PR on demand.
+- `pull_request: types: [closed]` — but the job only runs when the closed PR was **merged** *and* carries the `autorelease: pending` label. Regular feature/fix PR merges therefore produce no Release workflow run.
+
+Cutting a release is a two-step flow:
+
+1. **Open or refresh the release PR (manual).** Trigger the workflow via **Actions → Release → Run workflow** (or `gh workflow run Release --repo <owner>/<repo>`). `release-please` scans Conventional Commits since the last tag and opens — or updates — a standing **"chore: release X.Y.Z"** PR that:
    - Bumps `package.json` version.
    - Syncs `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json` to the new version (configured in `release-please-config.json`).
    - Appends generated entries to `CHANGELOG.md`.
-4. **Clicking Merge on that PR** is the release action. It tags `vX.Y.Z` and publishes a GitHub Release with notes generated from the same commits.
+
+   Release-please attaches the `autorelease: pending` label to this PR.
+
+2. **Merge the release PR (auto-fires step 3).** Squash-merging the PR closes it with the `autorelease: pending` label still attached. The `pull_request: closed` event fires the `Release` workflow automatically; release-please runs against `main`, sees the merged release PR, creates the tag `vX.Y.Z`, publishes the GitHub Release with the same Conventional-Commit-derived notes, and (on `patinaproject` plugin repos) dispatches the marketplace bump on `patinaproject/skills`. The PR's label flips to `autorelease: tagged`.
+
+The result: regular PRs trigger nothing release-related; the only auto-fire is the release-PR merge that you just authored.
 
 ## Prerequisites (one-time settings)
 


### PR DESCRIPTION
## Summary

- Reworks the `Release` workflow trigger so regular PR merges produce no Release workflow run, while a release-please PR merge auto-fires the tag-cutting step.
- Triggers (templates + mirrored root): `workflow_dispatch` + `pull_request: types: [closed]` filtered at the job level on `merged == true && contains(labels.*.name, 'autorelease: pending')`. The label is the durable marker release-please applies to its standing release PR; only that PR's merge satisfies the gate.
- Rewrites the `RELEASING.md` "How it works" section (template + supplement + root) to document the two-step flow: dispatch once to open/refresh the release PR; merging it auto-fires the tag.

## Linked issue

- Closes #31

## Acceptance criteria

### AC-31-1

Regular feature / fix / docs PR merges do **not** trigger the `Release` workflow.

- [ ] Post-merge: merge any non-release PR (or this one); confirm no `Release` workflow run is queued or executed against the merge commit.

### AC-31-2

Merging a release-please-managed PR (label `autorelease: pending`) **does** auto-fire the `Release` workflow, which cuts the tag, publishes the GitHub Release, and (on `patinaproject` repos) dispatches the marketplace bump.

- [ ] Post-merge end-to-end: dispatch `Release` once → release-please opens or refreshes the `chore: release X.Y.Z` PR with `autorelease: pending`; merge that PR; confirm a `Release` run fires automatically (triggered by `pull_request: closed`); confirm tag `vX.Y.Z`, GitHub Release, label flip to `autorelease: tagged`, and `patinaproject/skills` marketplace bump PR.

### AC-31-3

The change ships through the templates-first source-of-truth loop. Both template variants and the mirrored root carry identical workflow content; both `RELEASING.md` variants and the mirrored root carry the new "How it works" section.

- [x] `diff skills/bootstrap/templates/patinaproject-supplement/.github/workflows/release.yml .github/workflows/release.yml` is empty.
- [x] `diff skills/bootstrap/templates/patinaproject-supplement/RELEASING.md RELEASING.md` is empty.

## Validation

- `pnpm lint:md` on the branch: `0 error(s)` across 56 files.
- `actionlint` will run in CI on the workflow change. Both triggers are valid GitHub Actions syntax.
- SHA-pinning preserved; only the trigger block, the job-level `if:`, and the leading comments changed.

## Docs updated

- [ ] Not needed
- [x] Updated in this PR
