### PR TITLE
fix: #36 align markdown lint workflow template

### DIFF
--- a/docs/superpowers/plans/2026-04-26-36-bootstrap-markdown-lint-template-should-exclude-changelog-plan.md
+++ b/docs/superpowers/plans/2026-04-26-36-bootstrap-markdown-lint-template-should-exclude-changelog-plan.md
@@ -1,0 +1,135 @@
+# Bootstrap markdown lint template should exclude CHANGELOG Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the bootstrap core markdown lint workflow template exclude `CHANGELOG.md`, matching the repository root workflow and package lint script.
+
+**Architecture:** This is a baseline-template alignment change. The canonical source is `skills/bootstrap/templates/core/.github/workflows/lint-md.yml`; the root workflow is checked as the current generated mirror and only changes if verification shows drift.
+
+**Tech Stack:** GitHub Actions YAML, `markdownlint-cli2`, pnpm scripts, repository-owned bootstrap templates.
+
+---
+
+## Task 1: Capture the Current Mismatch
+
+**Files:**
+
+- Inspect: `skills/bootstrap/templates/core/.github/workflows/lint-md.yml`
+- Inspect: `.github/workflows/lint-md.yml`
+- Inspect: `package.json`
+- Inspect: `skills/bootstrap/templates/core/package.json.tmpl`
+
+- [ ] **Step 1: Verify the template is missing the exclusion**
+
+Run:
+
+```bash
+sed -n '1,80p' skills/bootstrap/templates/core/.github/workflows/lint-md.yml
+```
+
+Expected before implementation: the `globs` block contains `**/*.md` and `#node_modules`, but not `#CHANGELOG.md`.
+
+- [ ] **Step 2: Verify the root workflow already has the exclusion**
+
+Run:
+
+```bash
+sed -n '1,80p' .github/workflows/lint-md.yml
+```
+
+Expected before implementation: the `globs` block contains `#CHANGELOG.md`.
+
+- [ ] **Step 3: Verify package lint scripts already exclude CHANGELOG**
+
+Run:
+
+```bash
+rg -n '"lint:md"|#CHANGELOG.md' package.json skills/bootstrap/templates/core/package.json.tmpl
+```
+
+Expected before implementation: both package files contain `#CHANGELOG.md` in `lint:md`.
+
+## Task 2: Align the Core Template Workflow
+
+**Files:**
+
+- Modify: `skills/bootstrap/templates/core/.github/workflows/lint-md.yml`
+
+- [ ] **Step 1: Add the missing template glob exclusion**
+
+Change the `globs` block in `skills/bootstrap/templates/core/.github/workflows/lint-md.yml` to:
+
+```yaml
+          globs: |
+            **/*.md
+            #node_modules
+            #CHANGELOG.md
+```
+
+- [ ] **Step 2: Verify root realignment is not needed**
+
+Run:
+
+```bash
+diff -u skills/bootstrap/templates/core/.github/workflows/lint-md.yml .github/workflows/lint-md.yml
+```
+
+Expected after implementation: exit 0 and no output. If there is output, inspect whether it is a legitimate template-derived root drift; mirror only the required root workflow change and re-run this command.
+
+## Task 3: Verify Acceptance Criteria and Commit
+
+**Files:**
+
+- Verify: `skills/bootstrap/templates/core/.github/workflows/lint-md.yml`
+- Verify: `.github/workflows/lint-md.yml`
+- Verify: `package.json`
+- Verify: `skills/bootstrap/templates/core/package.json.tmpl`
+- Verify: `docs/superpowers/specs/2026-04-26-36-bootstrap-markdown-lint-template-should-exclude-changelog-design.md`
+- Verify: `docs/superpowers/plans/2026-04-26-36-bootstrap-markdown-lint-template-should-exclude-changelog-plan.md`
+
+- [ ] **Step 1: Verify all workflow and package exclusions are present**
+
+Run:
+
+```bash
+rg -n '#CHANGELOG.md|lint:md' skills/bootstrap/templates/core/.github/workflows/lint-md.yml .github/workflows/lint-md.yml package.json skills/bootstrap/templates/core/package.json.tmpl
+```
+
+Expected after implementation: output includes `#CHANGELOG.md` in both workflow files and both package lint scripts.
+
+- [ ] **Step 2: Run markdown lint**
+
+Run:
+
+```bash
+pnpm lint:md
+```
+
+Expected after implementation: exit 0 with `Summary: 0 error(s)`.
+
+- [ ] **Step 3: Review the diff**
+
+Run:
+
+```bash
+git diff -- skills/bootstrap/templates/core/.github/workflows/lint-md.yml docs/superpowers/plans/2026-04-26-36-bootstrap-markdown-lint-template-should-exclude-changelog-plan.md
+```
+
+Expected after implementation: the workflow template adds only `#CHANGELOG.md`, and the plan document is the only new planning artifact.
+
+- [ ] **Step 4: Commit implementation handoff**
+
+Run:
+
+```bash
+git add docs/superpowers/plans/2026-04-26-36-bootstrap-markdown-lint-template-should-exclude-changelog-plan.md skills/bootstrap/templates/core/.github/workflows/lint-md.yml
+git commit -m "fix: #36 align markdown lint workflow template"
+```
+
+Expected after implementation: commit succeeds, including the plan and template alignment changes.
+
+## Self-Review
+
+- Spec coverage: Task 2 satisfies AC-36-1; Task 3 Step 1 and Step 2 satisfy AC-36-2.
+- Placeholder scan: no deferred implementation work or ambiguous steps remain.
+- Scope check: the plan changes one baseline template and verifies existing mirrors; no decomposition is needed.

--- a/docs/superpowers/specs/2026-04-26-36-bootstrap-markdown-lint-template-should-exclude-changelog-design.md
+++ b/docs/superpowers/specs/2026-04-26-36-bootstrap-markdown-lint-template-should-exclude-changelog-design.md
@@ -1,0 +1,32 @@
+# Design: Bootstrap markdown lint template should exclude CHANGELOG [#36](https://github.com/patinaproject/bootstrap/issues/36)
+
+## Intent
+
+Keep the bootstrap template source of truth aligned with the repo baseline so newly scaffolded repositories do not inherit a markdown lint mismatch for generated `CHANGELOG.md` content.
+
+## Requirements
+
+- AC-36-1: Given a repo is scaffolded from the bootstrap core template, when the `Lint Markdown` workflow runs, then it excludes `CHANGELOG.md` from markdownlint globs.
+- AC-36-2: Given the bootstrap reference repo is checked, when template and root markdown lint workflow globs are compared, then both agree with the `package.json` `lint:md` exclusion for `CHANGELOG.md`.
+
+## Current State
+
+The root workflow at `.github/workflows/lint-md.yml` already excludes `CHANGELOG.md`, and `package.json` excludes the same file from `pnpm lint:md`. The core template at `skills/bootstrap/templates/core/.github/workflows/lint-md.yml` does not yet include that exclusion, so future bootstrapped repos can diverge from the intended baseline.
+
+## Approach
+
+Update the core template workflow to add `#CHANGELOG.md` to the `markdownlint-cli2-action` `globs` list. Then compare the generated root workflow, the core template workflow, and the `package.json` `lint:md` script to verify they express the same `CHANGELOG.md` exclusion.
+
+The root workflow already has the expected line, so realignment should not require a root diff. If verification shows otherwise, mirror the template-derived root change before publishing.
+
+## Non-Goals
+
+- Do not change markdownlint rules.
+- Do not change Release Please output or ownership of `CHANGELOG.md`.
+- Do not change staged-file linting behavior.
+
+## Verification Strategy
+
+- Inspect the template workflow and root workflow for `#CHANGELOG.md`.
+- Inspect `package.json` and `skills/bootstrap/templates/core/package.json.tmpl` for the matching `#CHANGELOG.md` lint script exclusion.
+- Run `pnpm lint:md` to confirm repository markdown still passes after adding the design, plan, and template changes.

--- a/skills/bootstrap/templates/core/.github/workflows/lint-md.yml
+++ b/skills/bootstrap/templates/core/.github/workflows/lint-md.yml
@@ -21,3 +21,4 @@ jobs:
           globs: |
             **/*.md
             #node_modules
+            #CHANGELOG.md


### PR DESCRIPTION
## Summary

- Adds `#CHANGELOG.md` to the bootstrap core `Lint Markdown` workflow template.
- Confirms the template workflow now matches the root workflow and both package lint scripts.
- Adds the Superpowers design and implementation plan artifacts for issue #36.

## Linked issue

Closes #36

## Acceptance criteria

### AC-36-1

Scaffolded repos using the bootstrap core template will exclude `CHANGELOG.md` from markdownlint workflow globs.

- [x] Local evidence — `diff -u skills/bootstrap/templates/core/.github/workflows/lint-md.yml .github/workflows/lint-md.yml` exit 0 | macOS / pnpm 10.33.2 | @tlmader | 2026-04-26T12:59:58Z

### AC-36-2

The bootstrap reference repo template, root workflow, and package lint scripts all agree on the `CHANGELOG.md` markdown lint exclusion.

- [x] Local evidence — `rg -n '#CHANGELOG.md|lint:md' skills/bootstrap/templates/core/.github/workflows/lint-md.yml .github/workflows/lint-md.yml package.json skills/bootstrap/templates/core/package.json.tmpl` shows all four expected matches | macOS / pnpm 10.33.2 | @tlmader | 2026-04-26T12:59:58Z

## Validation

- [x] `pnpm lint:md` — exit 0, 60 files, 0 errors.
- [x] `node scripts/check-plugin-versions.mjs` — exit 0, manifests at 1.1.2.
- [x] `./actionlint -color .github/workflows/*.yml` using actionlint 1.7.12 — exit 0.

## Docs updated

- [ ] Not needed
- [x] Updated in this PR
