### PR TITLE
fix: #38 align autorelease label color with release-please default

### DIFF
--- a/docs/superpowers/plans/2026-04-26-38-autorelease-label-color-should-be-ededed-to-not-conflict-with-release-please-defaults-plan.md
+++ b/docs/superpowers/plans/2026-04-26-38-autorelease-label-color-should-be-ededed-to-not-conflict-with-release-please-defaults-plan.md
@@ -1,0 +1,82 @@
+# Plan: autorelease label color should be #ededed to not conflict with release-please defaults [#38](https://github.com/patinaproject/bootstrap/issues/38)
+
+Approved design: [2026-04-26-38-…-design.md](../specs/2026-04-26-38-autorelease-label-color-should-be-ededed-to-not-conflict-with-release-please-defaults-design.md).
+
+## Workstream A — skill source edits
+
+Single workstream; both edits change the same color literal in adjacent
+sentences and ship together.
+
+### Task A1 — Update `skills/bootstrap/SKILL.md`
+
+In [skills/bootstrap/SKILL.md:252](../../../skills/bootstrap/SKILL.md), under
+`### Reserved labels`, change:
+
+```text
+…verify that `autorelease: pending` exists with color `c5def5` and a non-empty description…
+```
+
+to:
+
+```text
+…verify that `autorelease: pending` exists with color `ededed` (the
+release-please default) and a non-empty description…
+```
+
+The "(the release-please default)" parenthetical makes the rationale legible
+in the audit prose so future readers don't have to chase the issue. Satisfies
+**AC-38-1**.
+
+### Task A2 — Update `skills/bootstrap/audit-checklist.md`
+
+In [skills/bootstrap/audit-checklist.md:53](../../../skills/bootstrap/audit-checklist.md),
+under `### Reserved GitHub labels`, change the `autorelease: pending` row's
+"color `c5def5`" to "color `ededed`".
+
+Satisfies **AC-38-2**.
+
+### Task A3 — Repaint the live label
+
+After the two doc edits land in the PR (or as a one-shot before merge — order
+doesn't matter for the PR diff), run on `patinaproject/bootstrap`:
+
+```bash
+gh label edit "autorelease: pending" --color ededed
+```
+
+Note: `--color` ignores `#`. The edit is idempotent and safe to re-run.
+Satisfies **AC-38-3**.
+
+This is a live-repo administrative action, not a code change. It will be
+performed once the PR merges (so the docs and live state align in the same
+operator action), and verified with the AC-38-3 command. Note this in the PR
+body's `Validation` section.
+
+## Verification
+
+Run from the worktree root:
+
+```bash
+grep -rn "c5def5" skills/        # expect: no matches
+grep -n "ededed" skills/bootstrap/SKILL.md skills/bootstrap/audit-checklist.md
+pnpm lint:md
+```
+
+After Task A3 (post-merge):
+
+```bash
+gh label list --json name,color --jq '.[] | select(.name | startswith("autorelease"))'
+# expect: both labels report color ededed
+```
+
+## Blockers
+
+None.
+
+## Out of scope
+
+- Editing historical `docs/superpowers/{specs,plans}/**` files that reference
+  `c5def5`. Snapshots only.
+- Adding `autorelease: tagged` to the audit-checklist row (its color is
+  already `ededed` and it isn't currently audited).
+- Any release-please configuration change.

--- a/docs/superpowers/specs/2026-04-26-38-autorelease-label-color-should-be-ededed-to-not-conflict-with-release-please-defaults-design.md
+++ b/docs/superpowers/specs/2026-04-26-38-autorelease-label-color-should-be-ededed-to-not-conflict-with-release-please-defaults-design.md
@@ -1,0 +1,69 @@
+# Design: autorelease label color should be #ededed to not conflict with release-please defaults [#38](https://github.com/patinaproject/bootstrap/issues/38)
+
+## Problem
+
+The bootstrap skill currently documents `autorelease: pending` as expected to
+have color `c5def5`, in two places:
+
+- [skills/bootstrap/SKILL.md:252](../../../skills/bootstrap/SKILL.md): "verify
+  that `autorelease: pending` exists with color `c5def5`…"
+- [skills/bootstrap/audit-checklist.md:53](../../../skills/bootstrap/audit-checklist.md):
+  "present; color `c5def5`; description non-empty…"
+
+release-please creates both autorelease labels with color `ededed` by default.
+The live `patinaproject/bootstrap` repo is split today: `autorelease: pending`
+is `c5def5` (because we explicitly set it that way) and `autorelease: tagged`
+is `ededed` (release-please's default). Every newly bootstrapped repo will
+either drift from release-please's default or be repainted by our audit, with
+no observable benefit.
+
+## Goals
+
+- Align the documented expected color for `autorelease: pending` with
+  release-please's default (`ededed`).
+- Repaint the live label in `patinaproject/bootstrap` so the repo matches the
+  new baseline.
+- Keep the audit a no-op for any repo whose autorelease labels already match
+  release-please defaults.
+
+## Non-goals
+
+- Changing release-please's own configuration or defaults.
+- Editing historical Superpowers plan/spec files under `docs/superpowers/`
+  that reference `c5def5` — point-in-time artifacts.
+- Changing the `description` field of either autorelease label.
+- Adding `autorelease: tagged` to the audit checklist (it's only listed in
+  the documentation paragraph today, not the checklist row).
+
+## Proposed change
+
+1. Edit [skills/bootstrap/SKILL.md:252](../../../skills/bootstrap/SKILL.md)
+   to specify color `ededed` for `autorelease: pending`.
+2. Edit [skills/bootstrap/audit-checklist.md:53](../../../skills/bootstrap/audit-checklist.md)
+   to specify color `ededed` for `autorelease: pending`.
+3. Repaint the live `autorelease: pending` label in `patinaproject/bootstrap`
+   via `gh label edit "autorelease: pending" --color ededed`.
+
+These two source files live under `skills/bootstrap/` (the skill itself), not
+under `skills/bootstrap/templates/**`, so the
+template-round-trip workflow described in
+[AGENTS.md](../../../AGENTS.md) does not apply here.
+
+## Acceptance criteria
+
+- **AC-38-1**: Given a fresh read of [skills/bootstrap/SKILL.md](../../../skills/bootstrap/SKILL.md),
+  when the reader looks at the "Reserved labels" paragraph, then the
+  documented expected color for `autorelease: pending` is `ededed`.
+- **AC-38-2**: Given a fresh read of [skills/bootstrap/audit-checklist.md](../../../skills/bootstrap/audit-checklist.md),
+  when the reader looks at the `autorelease: pending` row in
+  "Reserved GitHub labels", then the expected color is `ededed`.
+- **AC-38-3**: Given the live `patinaproject/bootstrap` repo, when running
+  `gh label list --json name,color --jq '.[] | select(.name | startswith("autorelease"))'`,
+  then both `autorelease: pending` and `autorelease: tagged` report color
+  `ededed`.
+
+## Out of scope
+
+- Any change to release-please configuration.
+- Any change to historical plan/spec files referencing `c5def5`.
+- Any change to label descriptions.

--- a/skills/bootstrap/SKILL.md
+++ b/skills/bootstrap/SKILL.md
@@ -249,7 +249,7 @@ In realignment mode, report which check path was used (`gh`, `curl`, or `skipped
 
 ### Reserved labels
 
-The `autorelease: pending` and `autorelease: tagged` labels are owned by Release Please. In realignment mode, verify that `autorelease: pending` exists with color `c5def5` and a non-empty description explaining the reservation; if either is missing or divergent, recommend a `gh label edit` fix. Never instruct agents to apply or remove these labels manually.
+The `autorelease: pending` and `autorelease: tagged` labels are owned by Release Please. In realignment mode, verify that `autorelease: pending` exists with color `ededed` (the release-please default) and a non-empty description explaining the reservation; if either is missing or divergent, recommend a `gh label edit` fix. Never instruct agents to apply or remove these labels manually.
 
 ## Verification self-test
 

--- a/skills/bootstrap/audit-checklist.md
+++ b/skills/bootstrap/audit-checklist.md
@@ -50,7 +50,7 @@ For every gap, produce a concrete recommendation and show a diff preview. Never 
 
 | Label | Required | Check |
 |---|---|---|
-| `autorelease: pending` | yes | present; color `c5def5`; description non-empty and documents that the label is reserved for Release Please automation; confirm via `gh label list --repo <owner>/<repo> --json name,color,description --jq '.[] \| select(.name=="autorelease: pending")'` |
+| `autorelease: pending` | yes | present; color `ededed`; description non-empty and documents that the label is reserved for Release Please automation; confirm via `gh label list --repo <owner>/<repo> --json name,color,description --jq '.[] \| select(.name=="autorelease: pending")'` |
 
 ## Area 3 — Agent + repo docs
 


### PR DESCRIPTION
## Summary

- Align the bootstrap skill's expected color for `autorelease: pending` with release-please's default (`ededed`), removing a baseline conflict that flagged every newly bootstrapped repo.
- Update both the `Reserved labels` paragraph in `skills/bootstrap/SKILL.md` and the `Reserved GitHub labels` row in `skills/bootstrap/audit-checklist.md`.

## Linked issue

- Closes #38

## Acceptance criteria

### AC-38-1

`skills/bootstrap/SKILL.md` documents the expected color for `autorelease: pending` as `ededed`.

- [ ] ⚠️ E2E gap: docs-only edit; no automated test verifies the audit prose. A reviewer must spot-read the `Reserved labels` paragraph.
- [ ] Manual test: 1) Open `skills/bootstrap/SKILL.md` and locate the `### Reserved labels` section. 2) Confirm the line reads `…color \`ededed\` (the release-please default)…`. Observed: paragraph matches.

### AC-38-2

`skills/bootstrap/audit-checklist.md` documents the expected color for `autorelease: pending` as `ededed`.

- [ ] ⚠️ E2E gap: docs-only table edit; no automated test verifies the audit row.
- [ ] Manual test: 1) Open `skills/bootstrap/audit-checklist.md` and locate the `### Reserved GitHub labels` table. 2) Confirm the `autorelease: pending` row's `Check` column reads `present; color \`ededed\`; …`. Observed: row matches.

### AC-38-3

Live `patinaproject/bootstrap` repo reports both autorelease labels as color `ededed`.

- [ ] ⚠️ E2E gap: live-repo administrative action (`gh label edit`) is performed once after merge; no CI step verifies live label state.
- [ ] Manual test: 1) After merge, run `gh label edit "autorelease: pending" --color ededed`. 2) Run `gh label list --json name,color --jq '.[] | select(.name | startswith("autorelease"))'` and confirm both labels report `"color":"ededed"`.

## Validation

- `grep -rn "c5def5" skills/` returns no matches.
- `pnpm lint:md` passes (0 errors across 62 files).
- The two edited files are skill source, not under `skills/bootstrap/templates/**`, so no template round-trip is required.

## Docs updated

- [ ] Not needed
- [x] Updated in this PR
