### PR TITLE
chore: #39 add LABELS.md template to bootstrap baseline

### DIFF
--- a/.github/LABELS.md
+++ b/.github/LABELS.md
@@ -2,23 +2,25 @@
 
 This file is the source of truth for when to apply each issue and pull-request label in this repository. It exists so reporters and agents can pick labels without guessing, and so label drift stays visible in review. For the authoritative runtime inventory, run `gh label list --json name,description`.
 
-## Current labels
+## Labels
 
-- `bug`: Apply when the report describes a defect, regression, or unexpected behavior in shipped code or docs.
-- `documentation`: Apply when the change is primarily to Markdown, in-repo docs, or comments that describe behavior.
-- `duplicate`: Apply when another open or closed issue already tracks the same problem; link the canonical issue in the body.
-- `enhancement`: Apply when the report proposes a new capability or improves an existing one without fixing a defect.
-- `good first issue`: Apply when the work is small, well-scoped, and safe for a first-time contributor to pick up.
-- `help wanted`: Apply when maintainers are actively soliciting outside contributions on the issue.
-- `invalid`: Apply when the report is not actionable as filed (wrong repo, not reproducible, out of scope) and cannot be salvaged by editing.
-- `question`: Apply when the issue is a support request or clarification rather than a change request.
-- `wontfix`: Apply when the behavior described is intentional or the maintainers have decided not to act on it; leave a short rationale before closing.
+| Name | Description |
+| --- | --- |
+| `bug` | Apply when the report describes a defect, regression, or unexpected behavior in shipped code or docs. |
+| `documentation` | Apply when the change is primarily to Markdown, in-repo docs, or comments that describe behavior. |
+| `duplicate` | Apply when another open or closed issue already tracks the same problem; link the canonical issue in the body. |
+| `enhancement` | Apply when the report proposes a new capability or improves an existing one without fixing a defect. |
+| `good first issue` | Apply when the work is small, well-scoped, and safe for a first-time contributor to pick up. |
+| `help wanted` | Apply when maintainers are actively soliciting outside contributions on the issue. |
+| `invalid` | Apply when the report is not actionable as filed (wrong repo, not reproducible, out of scope) and cannot be salvaged by editing. |
+| `question` | Apply when the issue is a support request or clarification rather than a change request. |
+| `wontfix` | Apply when the behavior described is intentional or the maintainers have decided not to act on it; leave a short rationale before closing. |
 
 ### Release-please (tool-managed)
 
-release-please creates/applies these automatically on the release PR; do not apply manually; labels are created on demand so may not appear in `gh label list` until the first release cycle runs.
+`release-please` creates and applies these labels automatically on the standing release PR; do not apply or remove them by hand. They may not appear in `gh label list` until the first release cycle runs.
 
-- `autorelease: pending`: Applied to the release PR while a release is in progress. Its GitHub description is currently empty, which is a known gap tracked for follow-up.
+- `autorelease: pending`: Applied to the release PR while a release is in progress.
 - `autorelease: tagged`: Applied to the release PR once the release has been tagged.
 
 ## Adding or changing labels

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ Covered files (any change here must round-trip through a template edit):
 - `.github/ISSUE_TEMPLATE/*`
 - `.github/pull_request_template.md`
 - `.github/copilot-instructions.md`
+- `.github/LABELS.md`
 - `RELEASING.md`
 - `README.md`
 - `AGENTS.md`

--- a/docs/superpowers/plans/2026-04-26-39-add-labels-md-template-to-bootstrap-core-baseline-plan.md
+++ b/docs/superpowers/plans/2026-04-26-39-add-labels-md-template-to-bootstrap-core-baseline-plan.md
@@ -1,0 +1,416 @@
+# Plan: Add LABELS.md template to bootstrap core baseline so /github-flows:new-issue works on freshly bootstrapped repos [#39](https://github.com/patinaproject/bootstrap/issues/39)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a parser-compatible `.github/LABELS.md` from the `bootstrap` skill (core + agent-plugin variants) and reconcile this repo's own root file via realignment, in one PR.
+
+**Architecture:** Two whole-file templates at the conventional locations. The core template covers non-plugin repos. The agent-plugin variant is a whole-file override (same shape + a `### Release-please (tool-managed)` subsection inserted between the `## Labels` table and `## Adding or changing labels`). The bootstrap emitter already resolves agent-plugin overrides as whole-file replacements — see `skills/bootstrap/templates/patinaproject-supplement/RELEASING.md` and the agent-plugin `.github/workflows/release.yml` for the existing precedent. The audit checklist gains one row for parser-shape compliance. The repo-root `AGENTS.md` "Source of truth for repo baseline" list gains `.github/LABELS.md`. Finally, the local skill is run in realignment mode against this repo so the root `.github/LABELS.md` is regenerated from the new template.
+
+**Tech Stack:** Markdown templates, husky + markdownlint-cli2, `gh` CLI for label inventory verification, the local `bootstrap` skill for self-realignment.
+
+**Composition mechanism note:** Design doc D2 specifies mid-file composition for the agent-plugin overlay. The existing bootstrap emitter does not implement mid-file composition or sentinel-marker inserts — every "supplement" in `skills/bootstrap/templates/` (the only precedent being `patinaproject-supplement/`) is a whole-file replacement at the same relative path. This plan therefore implements the agent-plugin overlay as **option (c) whole-file override** at `skills/bootstrap/templates/agent-plugin/.github/LABELS.md.tmpl`. The duplication is one nine-row table; acceptable per the parent's guidance. The agent-plugin file embeds the Release-please subsection between the table and the trailing section, satisfying AC-39-3's structural requirements.
+
+---
+
+## File map
+
+- Create: `skills/bootstrap/templates/core/.github/LABELS.md.tmpl` — parser-compatible LABELS.md for non-plugin repos. (T-39-1)
+- Create: `skills/bootstrap/templates/agent-plugin/.github/LABELS.md.tmpl` — whole-file override for agent-plugin repos; identical to the core file plus a `### Release-please (tool-managed)` subsection. (T-39-2)
+- Modify: `skills/bootstrap/audit-checklist.md` — add a parser-shape row under "Area 2 — GitHub metadata". (T-39-3)
+- Modify: `AGENTS.md` (repo root) — add `.github/LABELS.md` to the "Covered files" bullet list under "Source of truth for repo baseline". (T-39-4)
+- Modify: `.github/LABELS.md` (repo root) — regenerate from the new agent-plugin template via the local bootstrap skill in realignment mode. (T-39-5)
+- Verify: `.github/LABELS.md` (repo root) parser shape per the audit-checklist row added in T-39-3. (T-39-6)
+
+Per-task ATDD detail follows. Tasks are ordered so each one is independently verifiable; commit at the end of each task.
+
+---
+
+## Task T-39-1: Create the core LABELS.md template
+
+**AC advanced:** AC-39-1.
+
+**Files:**
+
+- Create: `skills/bootstrap/templates/core/.github/LABELS.md.tmpl`
+
+**Why this file:** A freshly bootstrapped non-plugin repo must end up with a parser-compatible `.github/LABELS.md`. Per design D1, the core template owns the canonical nine-label baseline. See design doc §Decisions D1 for shape rationale; do not re-litigate column count or row set here.
+
+- [ ] **Step 1: Write the template file**
+
+Create `skills/bootstrap/templates/core/.github/LABELS.md.tmpl` with exactly this content:
+
+```markdown
+# Labels
+
+This file is the source of truth for when to apply each issue and pull-request label in this repository. It exists so reporters and agents can pick labels without guessing, and so label drift stays visible in review. For the authoritative runtime inventory, run `gh label list --json name,description`.
+
+## Labels
+
+| Name | Description |
+| --- | --- |
+| `bug` | Apply when the report describes a defect, regression, or unexpected behavior in shipped code or docs. |
+| `documentation` | Apply when the change is primarily to Markdown, in-repo docs, or comments that describe behavior. |
+| `duplicate` | Apply when another open or closed issue already tracks the same problem; link the canonical issue in the body. |
+| `enhancement` | Apply when the report proposes a new capability or improves an existing one without fixing a defect. |
+| `good first issue` | Apply when the work is small, well-scoped, and safe for a first-time contributor to pick up. |
+| `help wanted` | Apply when maintainers are actively soliciting outside contributions on the issue. |
+| `invalid` | Apply when the report is not actionable as filed (wrong repo, not reproducible, out of scope) and cannot be salvaged by editing. |
+| `question` | Apply when the issue is a support request or clarification rather than a change request. |
+| `wontfix` | Apply when the behavior described is intentional or the maintainers have decided not to act on it; leave a short rationale before closing. |
+
+## Adding or changing labels
+
+Use `gh label list --json name,description` as the canonical inventory and follow the label-hygiene rule in [`AGENTS.md`](../AGENTS.md) (every label must have a non-empty description). Do not introduce new labels in an issue or PR without first updating the repository label set and this file.
+```
+
+- [ ] **Step 2: Verify parser-shape preconditions on the new file**
+
+Run:
+
+```bash
+grep -n "^## Labels$" skills/bootstrap/templates/core/.github/LABELS.md.tmpl
+grep -n "^| Name | Description |$" skills/bootstrap/templates/core/.github/LABELS.md.tmpl
+awk '/^## Labels$/{flag=1; next} /^## /{flag=0} flag && /^\| `?[a-z]/ {gsub(/[`| ]/,""); print $0}' skills/bootstrap/templates/core/.github/LABELS.md.tmpl
+```
+
+Expected:
+
+- `## Labels` appears exactly once.
+- `| Name | Description |` appears exactly once.
+- The third command prints the first column values in order: `bug`, `documentation`, `duplicate`, `enhancement`, `goodfirstissue`, `helpwanted`, `invalid`, `question`, `wontfix` — alphabetically sorted, with `bug` and `enhancement` both present.
+
+- [ ] **Step 3: Lint the file with markdownlint**
+
+Run:
+
+```bash
+pnpm exec markdownlint-cli2 skills/bootstrap/templates/core/.github/LABELS.md.tmpl
+```
+
+Expected: exit code 0 (no findings).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add skills/bootstrap/templates/core/.github/LABELS.md.tmpl
+git commit -m "feat: #39 add core LABELS.md template for bootstrap"
+```
+
+---
+
+## Task T-39-2: Create the agent-plugin LABELS.md whole-file override
+
+**AC advanced:** AC-39-3.
+
+**Files:**
+
+- Create: `skills/bootstrap/templates/agent-plugin/.github/LABELS.md.tmpl`
+
+**Why this file:** The agent-plugin tree gets its own LABELS.md so the Release-please subsection ships only for repos that actually run release-please. The bootstrap emitter resolves this as a whole-file replacement of the core file (precedent: `skills/bootstrap/templates/patinaproject-supplement/RELEASING.md` replaces the core RELEASING.md whole-file). The structural shape — single `## Labels` heading, single `| Name |` table, alphabetical first column, `### Release-please (tool-managed)` subsection placed after the table and before `## Adding or changing labels` — satisfies AC-39-3 without breaking the parser.
+
+- [ ] **Step 1: Write the template file**
+
+Create `skills/bootstrap/templates/agent-plugin/.github/LABELS.md.tmpl` with exactly this content:
+
+```markdown
+# Labels
+
+This file is the source of truth for when to apply each issue and pull-request label in this repository. It exists so reporters and agents can pick labels without guessing, and so label drift stays visible in review. For the authoritative runtime inventory, run `gh label list --json name,description`.
+
+## Labels
+
+| Name | Description |
+| --- | --- |
+| `bug` | Apply when the report describes a defect, regression, or unexpected behavior in shipped code or docs. |
+| `documentation` | Apply when the change is primarily to Markdown, in-repo docs, or comments that describe behavior. |
+| `duplicate` | Apply when another open or closed issue already tracks the same problem; link the canonical issue in the body. |
+| `enhancement` | Apply when the report proposes a new capability or improves an existing one without fixing a defect. |
+| `good first issue` | Apply when the work is small, well-scoped, and safe for a first-time contributor to pick up. |
+| `help wanted` | Apply when maintainers are actively soliciting outside contributions on the issue. |
+| `invalid` | Apply when the report is not actionable as filed (wrong repo, not reproducible, out of scope) and cannot be salvaged by editing. |
+| `question` | Apply when the issue is a support request or clarification rather than a change request. |
+| `wontfix` | Apply when the behavior described is intentional or the maintainers have decided not to act on it; leave a short rationale before closing. |
+
+### Release-please (tool-managed)
+
+`release-please` creates and applies these labels automatically on the standing release PR; do not apply or remove them by hand. They may not appear in `gh label list` until the first release cycle runs.
+
+- `autorelease: pending`: Applied to the release PR while a release is in progress.
+- `autorelease: tagged`: Applied to the release PR once the release has been tagged.
+
+## Adding or changing labels
+
+Use `gh label list --json name,description` as the canonical inventory and follow the label-hygiene rule in [`AGENTS.md`](../AGENTS.md) (every label must have a non-empty description). Do not introduce new labels in an issue or PR without first updating the repository label set and this file.
+```
+
+- [ ] **Step 2: Verify parser-shape preconditions and Release-please placement**
+
+Run:
+
+```bash
+grep -cn "^## Labels$" skills/bootstrap/templates/agent-plugin/.github/LABELS.md.tmpl
+grep -cn "^| Name | Description |$" skills/bootstrap/templates/agent-plugin/.github/LABELS.md.tmpl
+grep -n "^## Labels$\|^### Release-please (tool-managed)$\|^## Adding or changing labels$" skills/bootstrap/templates/agent-plugin/.github/LABELS.md.tmpl
+```
+
+Expected:
+
+- First two commands each print `1` (single `## Labels` heading and single `| Name |` header row — parser invariant preserved).
+- Third command prints three lines whose line numbers are strictly increasing in this order: `## Labels`, `### Release-please (tool-managed)`, `## Adding or changing labels`.
+
+- [ ] **Step 3: Lint the file with markdownlint**
+
+Run:
+
+```bash
+pnpm exec markdownlint-cli2 skills/bootstrap/templates/agent-plugin/.github/LABELS.md.tmpl
+```
+
+Expected: exit code 0 (no findings).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add skills/bootstrap/templates/agent-plugin/.github/LABELS.md.tmpl
+git commit -m "feat: #39 add agent-plugin LABELS.md template with release-please section"
+```
+
+---
+
+## Task T-39-3: Add parser-shape audit row
+
+**AC advanced:** AC-39-5.
+
+**Files:**
+
+- Modify: `skills/bootstrap/audit-checklist.md`
+
+**Why this file:** The audit checklist is the canonical source for what realignment mode walks. AC-39-5 requires `.github/LABELS.md` presence and parser-shape compliance to be a checked item under "Area 2 — GitHub metadata". Per design D3, the check is shape compliance, not row-content equivalence.
+
+- [ ] **Step 1: Insert the new row into Area 2**
+
+In `skills/bootstrap/audit-checklist.md`, locate the "Area 2 — GitHub metadata" table. Insert a new row immediately after the `.github/CODEOWNERS` row (so all `.github/*.md` and `.github/*.yaml`-style metadata files stay grouped before the `workflows/` rows).
+
+The exact line to insert (using the table's existing column layout):
+
+```markdown
+| `.github/LABELS.md` | yes | present; contains a `## Labels` heading; the heading is followed by a markdown table whose header row starts with `\| Name \|`; the first data column lists `bug` and `enhancement` and is alphabetically sorted |
+```
+
+- [ ] **Step 2: Verify the row was added correctly**
+
+Run:
+
+```bash
+grep -n "LABELS.md" skills/bootstrap/audit-checklist.md
+```
+
+Expected: one new line under Area 2 containing `.github/LABELS.md` and the parser-shape check text from Step 1. The existing "Reserved GitHub labels" sub-table is untouched.
+
+- [ ] **Step 3: Lint the file with markdownlint**
+
+Run:
+
+```bash
+pnpm exec markdownlint-cli2 skills/bootstrap/audit-checklist.md
+```
+
+Expected: exit code 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add skills/bootstrap/audit-checklist.md
+git commit -m "docs: #39 audit LABELS.md presence and parser shape"
+```
+
+---
+
+## Task T-39-4: Add `.github/LABELS.md` to AGENTS.md "Source of truth" list
+
+**AC advanced:** AC-39-4 (prerequisite for the realignment loop in T-39-5).
+
+**Files:**
+
+- Modify: `AGENTS.md` (repo root)
+
+**Why this file:** Per design D5, `.github/LABELS.md` must be in the "Covered files" bullet list under `## Source of truth for repo baseline` so future hand-edits to the root file are blocked by the workflow contract. Note: `skills/bootstrap/templates/core/AGENTS.md.tmpl` does **not** currently contain this section — the "Source of truth" block is bootstrap-repo-specific and lives only at the repo root. (Verified via `grep -n "Source of truth" skills/bootstrap/templates/core/AGENTS.md.tmpl` returning no matches.) So the only edit needed for D5 is at the root `AGENTS.md`.
+
+- [ ] **Step 1: Read the current "Covered files" block**
+
+Run:
+
+```bash
+sed -n '21,44p' AGENTS.md
+```
+
+Expected: a bullet list starting with the `.github/workflows/*` entry and including bullets for `.github/ISSUE_TEMPLATE/*`, `.github/pull_request_template.md`, and `.github/copilot-instructions.md`, then a `RELEASING.md` line and so on.
+
+- [ ] **Step 2: Insert the new bullet adjacent to the other `.github/*` entries**
+
+Edit `AGENTS.md` to insert the following bullet line immediately after `- \`.github/copilot-instructions.md\`` (keeps all `.github/*` entries grouped):
+
+```markdown
+- `.github/LABELS.md`
+```
+
+- [ ] **Step 3: Verify the bullet is present and grouped**
+
+Run:
+
+```bash
+grep -n "^- \`.github/" AGENTS.md
+```
+
+Expected: four lines, in order — `.github/workflows/*`, `.github/ISSUE_TEMPLATE/*`, `.github/pull_request_template.md`, `.github/copilot-instructions.md`, `.github/LABELS.md`. (Five total `.github/*` bullets.)
+
+- [ ] **Step 4: Lint the file with markdownlint**
+
+Run:
+
+```bash
+pnpm exec markdownlint-cli2 AGENTS.md
+```
+
+Expected: exit code 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add AGENTS.md
+git commit -m "docs: #39 add LABELS.md to source-of-truth covered files"
+```
+
+---
+
+## Task T-39-5: Realign this repo's `.github/LABELS.md` from the new template
+
+**AC advanced:** AC-39-4 (and provides the artifact AC-39-1 / AC-39-2 / AC-39-3 will be verified against in T-39-6).
+
+**Files:**
+
+- Modify: `.github/LABELS.md` (repo root) — replace the current bullet-list shape with the table shape emitted by `skills/bootstrap/templates/agent-plugin/.github/LABELS.md.tmpl`. This repo is itself an agent plugin (it ships `.claude-plugin/`, `.codex-plugin/`, `release-please-config.json`), so the agent-plugin variant is the correct source.
+
+**Why this file:** The "Source of truth for repo baseline" rule requires the template change and the mirrored root change to ship in the same PR. The current root file is a bullet list and would itself trip the `/github-flows:new-issue` parser; D4 makes converting it to the table shape part of this issue.
+
+- [ ] **Step 1: Invoke the local bootstrap skill in realignment mode**
+
+In a Claude Code session against this worktree, run:
+
+```text
+/bootstrap
+```
+
+Then answer prompts as follows:
+
+- The skill auto-detects realignment mode (this repo has existing baseline files). No mode flag to set.
+- When the realignment walks Area 2 and reaches `.github/LABELS.md`, it will report the file as **divergent** (current shape: bullet list under `## Current labels`; template shape: table under `## Labels` plus `### Release-please (tool-managed)` subsection).
+- When prompted with `Action? (accept / skip / defer)` for the `.github/LABELS.md` recommendation, answer `accept`.
+- For all other files in this realignment pass, answer `skip` (this PR is scoped to issue #39; out-of-scope baseline drift is not in scope here).
+
+If the skill asks for `<owner>` / `<repo>` / agent-plugin detection, accept the autodetected values (`patinaproject` / `bootstrap` / yes — verifiable with `git remote get-url origin` and the presence of `.claude-plugin/`).
+
+If `/bootstrap` is unavailable or the skill cannot be invoked from this Claude Code session, fall back to manually copying the agent-plugin template into place:
+
+```bash
+cp skills/bootstrap/templates/agent-plugin/.github/LABELS.md.tmpl .github/LABELS.md
+```
+
+The template currently contains no `{{...}}` placeholders that need substitution at emit time, so a literal copy is byte-for-byte equivalent to what the skill would emit for this repo. (Verify with `grep -c '{{' skills/bootstrap/templates/agent-plugin/.github/LABELS.md.tmpl` — expected output: `0`.)
+
+- [ ] **Step 2: Verify the regenerated root file matches the template**
+
+Run:
+
+```bash
+diff skills/bootstrap/templates/agent-plugin/.github/LABELS.md.tmpl .github/LABELS.md
+```
+
+Expected: empty diff (exit code 0). If the realignment skill performed any placeholder substitution, the diff will surface those lines and Step 1 should be re-run to capture what the skill actually emitted.
+
+- [ ] **Step 3: Lint the regenerated file**
+
+Run:
+
+```bash
+pnpm exec markdownlint-cli2 .github/LABELS.md
+```
+
+Expected: exit code 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/LABELS.md
+git commit -m "docs: #39 regenerate root LABELS.md from template"
+```
+
+---
+
+## Task T-39-6: Verify the parser-shape audit assertion against the regenerated root file
+
+**AC advanced:** AC-39-1, AC-39-2 (validation), AC-39-3, AC-39-5 (canonical assertion exercised end-to-end).
+
+**Files:**
+
+- Verify only: `.github/LABELS.md` (repo root). No code changes in this task.
+
+**Why this task:** Per design §Validation strategy, the audit checklist's parser-shape assertion is the canonical test for AC-39-1, AC-39-3, and AC-39-4. Running it explicitly against the regenerated root file is the proof-of-correctness step before opening the PR.
+
+- [ ] **Step 1: Walk the new audit row against the root file**
+
+Run each check in turn against `.github/LABELS.md`:
+
+```bash
+test -f .github/LABELS.md && echo "present: yes"
+grep -c "^## Labels$" .github/LABELS.md
+grep -n "^| Name |" .github/LABELS.md
+awk '/^## Labels$/{flag=1; next} /^## /{flag=0} flag && /^\| `?[a-z]/ {gsub(/[`| ]/,""); print $0}' .github/LABELS.md
+```
+
+Expected:
+
+- First line: `present: yes`.
+- Second command: `1` (exactly one `## Labels` heading).
+- Third command: one match whose row text begins with `| Name |`.
+- Fourth command: prints the first-column names in order — `bug`, `documentation`, `duplicate`, `enhancement`, `goodfirstissue`, `helpwanted`, `invalid`, `question`, `wontfix`. The list is alphabetical and includes both `bug` and `enhancement`.
+
+If any check fails, STOP. Re-run T-39-5 to regenerate, then redo this step. Do not paper over a failure by hand-editing the root file.
+
+- [ ] **Step 2: Verify the Release-please subsection placement**
+
+Run:
+
+```bash
+grep -n "^## Labels$\|^### Release-please (tool-managed)$\|^## Adding or changing labels$" .github/LABELS.md
+```
+
+Expected: three lines whose line numbers strictly increase in the order `## Labels`, `### Release-please (tool-managed)`, `## Adding or changing labels`. This is the AC-39-3 placement assertion against the live root file.
+
+- [ ] **Step 3: Confirm no second `## Labels` heading or second `| Name |` table sneaked in**
+
+Run:
+
+```bash
+grep -c "^## Labels$" .github/LABELS.md
+grep -c "^| Name |" .github/LABELS.md
+```
+
+Expected: both print `1`. (The Release-please subsection must not introduce a duplicate `## Labels` heading or a second table — this is the parser invariant from AC-39-3.)
+
+- [ ] **Step 4: Manual AC-39-2 spot-check (optional but recommended)**
+
+In a Claude Code session against this worktree, invoke `/github-flows:new-issue` and confirm Step 1's parser succeeds against the regenerated `.github/LABELS.md` (no malformed-table or file-not-found halt; the workflow proceeds to its label-selection step). If `/github-flows:new-issue` is not available in the executor's environment, document this as a deferred manual verification in the PR body's `Validation` section rather than blocking the PR.
+
+- [ ] **Step 5: No commit needed**
+
+This task verifies prior work; no files change. Do not create an empty commit.
+
+---
+
+## Self-review
+
+- **Spec coverage:** AC-39-1 → T-39-1 + T-39-6 verifies. AC-39-2 → T-39-6 step 4. AC-39-3 → T-39-2 + T-39-6 steps 2–3. AC-39-4 → T-39-5 (template + root mirrored in one PR). AC-39-5 → T-39-3.
+- **Out of scope per design (D-OOS):** parser changes, per-repo customization, label backfill on diverged repos, CI re-validation against `gh label list`. None of these tasks attempt them.
+- **Composition mechanism:** option (c) whole-file override at `skills/bootstrap/templates/agent-plugin/.github/LABELS.md.tmpl`. Documented in the Architecture note above with file evidence.
+- **Mirror obligation:** T-39-4 + T-39-5 ensure the `AGENTS.md` "Source of truth" list and the root `.github/LABELS.md` ship together with the template adds. The template-only commits (T-39-1, T-39-2, T-39-3) and the mirrored-root commits (T-39-4, T-39-5) all live on the same PR branch.

--- a/docs/superpowers/specs/2026-04-26-39-add-labels-md-template-to-bootstrap-core-baseline-design.md
+++ b/docs/superpowers/specs/2026-04-26-39-add-labels-md-template-to-bootstrap-core-baseline-design.md
@@ -1,0 +1,130 @@
+# Design: Add LABELS.md template to bootstrap core baseline so /github-flows:new-issue works on freshly bootstrapped repos [#39](https://github.com/patinaproject/bootstrap/issues/39)
+
+## Context
+
+`/github-flows:new-issue` Step 1 hard-requires `.github/LABELS.md` and parses it strictly: a `## Labels` heading followed by a `| Name |` markdown table whose rows are alphabetically sorted by the first column, with at least `bug` and `enhancement` present. If the file is missing or shaped differently, the workflow halts before it can pick a label.
+
+The `bootstrap` skill does not currently emit this file. `skills/bootstrap/templates/core/.github/` ships `CODEOWNERS.tmpl`, `ISSUE_TEMPLATE/`, `actionlint.yaml`, `pull_request_template.md`, and `workflows/`, but no `LABELS.md.tmpl`. As a side-effect, the bootstrap repo's own `.github/LABELS.md` was hand-authored as a bullet list and would itself trip the parser.
+
+This design adds the template, reconciles the bootstrap repo's root file, updates the audit checklist, and adds the file to the AGENTS.md "Source of truth for repo baseline" list.
+
+## Intent
+
+Make `/github-flows:new-issue` work out of the box on any freshly bootstrapped repo by shipping a parser-compatible `.github/LABELS.md` from the `bootstrap` skill, while preserving the human-readable description column the bootstrap repo already documents.
+
+## Decisions
+
+### D1. Template location and shape
+
+Create `skills/bootstrap/templates/core/.github/LABELS.md.tmpl` with:
+
+- An H1 (`# Labels`) and a short prose intro identifying the file as the source of truth for label application, with a pointer to `gh label list --json name,description` as the authoritative runtime inventory.
+- A `## Labels` heading (exact text — the parser keys on this).
+- A two-column markdown table with header `| Name | Description |` and the divider row `| --- | --- |`.
+- One row per label, alphabetically sorted by `Name` (lowercase ASCII sort).
+- Canonical row set, minimum: `bug`, `documentation`, `duplicate`, `enhancement`, `good first issue`, `help wanted`, `invalid`, `question`, `wontfix`.
+- A trailing `## Adding or changing labels` section pointing back at `AGENTS.md` label-hygiene rules.
+
+**Column choice — two columns, not three.** The `/github-flows:new-issue` parser only reads column 1 (`Name`). A `Description` column is enough for humans to pick the right label and matches what `gh label list --json name,description` already returns, so the file stays trivially diff-able against the live inventory. A third "When to apply" column would duplicate the description in practice (the existing bullet-list shape of the bootstrap repo proves this — its bullets are single-sentence "apply when" descriptions) and adds a column the parser ignores. Keeping it at two columns is the YAGNI choice.
+
+### D2. Agent-plugin mode handling
+
+The Release-please labels (`autorelease: pending`, `autorelease: tagged`) only make sense when the repo cuts releases via release-please, which today maps 1:1 to agent-plugin mode (the `agent-plugin/` template tree is what installs `release.yml`, `release-please-config.json`, and the manifest).
+
+Mirror the existing per-mode supplement pattern by creating a parallel template under the agent-plugin tree:
+
+- `skills/bootstrap/templates/agent-plugin/.github/LABELS.md.supplement.tmpl`
+
+The supplement contains a `### Release-please (tool-managed)` subsection — heading plus a short note that the labels are tool-applied and must not be hand-edited, plus two `- \`autorelease: pending\`: …` and `- \`autorelease: tagged\`: …` bullets.
+
+Bootstrap's emitter, when running in agent-plugin mode, appends the supplement's body **after** the core template's `## Labels` table and **before** the `## Adding or changing labels` section. This keeps the parser's table-shape assertion intact (the supplement does not introduce a second `## Labels` heading or a second `| Name |` table) while documenting the reserved labels for humans.
+
+This mirrors how `skills/bootstrap/templates/patinaproject-supplement/RELEASING.md` and `release.yml` extend their core counterparts: a thin overlay file under a mode-specific subtree, composed at emit time. No new templating mechanism is introduced.
+
+### D3. Audit checklist update
+
+Add a row under "Area 2 — GitHub metadata" of `skills/bootstrap/audit-checklist.md`:
+
+| File | Required | Check |
+|---|---|---|
+| `.github/LABELS.md` | yes | present; contains a `## Labels` heading; the heading is followed by a markdown table whose header row starts with `\| Name \|`; the first data column lists `bug` and `enhancement` and is alphabetically sorted |
+
+The check is parser-shape compliance, not row-content equivalence with the template. A repo that has diverged its label set after bootstrap is not in violation, as long as the parser still passes.
+
+The existing "Reserved GitHub labels" sub-table (which already covers `autorelease: pending` via `gh label list`) is untouched. Audit verifies the file shape; it does not re-verify the runtime label inventory from the file.
+
+### D4. Bootstrap repo self-reconciliation
+
+Per `AGENTS.md` "Source of truth for repo baseline": the template change and the mirrored root change must ship together in the same PR. The Executor will:
+
+1. Add the template (D1) and the supplement (D2).
+2. Run the local `bootstrap` skill against this repo in realignment mode and accept the proposed diff for `.github/LABELS.md` — converting it from the current bullet-list shape to the table shape.
+3. Verify the parser shape on the regenerated root file (the audit check from D3 is the canonical assertion).
+
+The regenerated root file must include the agent-plugin Release-please subsection because the bootstrap repo is itself an agent plugin (it ships `.claude-plugin/`, `.codex-plugin/`, `.cursor/`, `.windsurfrules`, `release-please-config.json`).
+
+### D5. AGENTS.md "Source of truth" list update
+
+Add `.github/LABELS.md` to the "Covered files" bullet list under `## Source of truth for repo baseline` in both:
+
+- `AGENTS.md` (repo root, mirrored from the template).
+- `skills/bootstrap/templates/core/AGENTS.md.tmpl` (the source).
+
+Place it adjacent to the other `.github/*` entries to keep the list grouped.
+
+## Out of scope
+
+- Changing `/github-flows:new-issue` parser semantics (e.g. fallback to `gh label list`). The issue explicitly defers this.
+- Per-repo customization tooling for label sets. Downstream repos can hand-edit after bootstrap; that path is already covered by the existing `AGENTS.md` label-hygiene guidance.
+- Backfilling label descriptions on repos that have already diverged from the canonical inventory.
+- Adding a CI check that re-validates the file against `gh label list` at PR time. The audit checklist covers it interactively; a CI check is a separate decision.
+
+## Acceptance criteria
+
+### AC-39-1
+
+A freshly bootstrapped repo has a parser-compatible `.github/LABELS.md` at its root.
+
+- Given a target repo bootstrapped from this skill in initial mode,
+- When the bootstrap skill emits files,
+- Then `.github/LABELS.md` exists at the repo root with a `## Labels` heading and a `| Name | Description |` markdown table whose first column is alphabetically sorted and includes at least `bug` and `enhancement`.
+
+### AC-39-2
+
+`/github-flows:new-issue` Step 1 succeeds on a freshly bootstrapped repo.
+
+- Given a target repo bootstrapped from this skill (post-bootstrap, no further hand-edits to `.github/LABELS.md`),
+- When an agent runs `/github-flows:new-issue`,
+- Then Step 1's parser succeeds (no malformed-table or file-not-found halt) and the workflow proceeds to Step 2.
+
+### AC-39-3
+
+Agent-plugin mode adds a Release-please subsection without breaking the parser.
+
+- Given a target repo bootstrapped in agent-plugin mode,
+- When the bootstrap skill emits `.github/LABELS.md`,
+- Then the file contains a `### Release-please (tool-managed)` subsection covering `autorelease: pending` and `autorelease: tagged`, placed after the `## Labels` table and before `## Adding or changing labels`,
+- And the file still satisfies AC-39-1 (single `## Labels` heading, single `| Name |` table, alphabetical first column).
+
+### AC-39-4
+
+The bootstrap repo's own `.github/LABELS.md` is regenerated from the template in the same PR.
+
+- Given the bootstrap repo,
+- When the local `bootstrap` skill is run in realignment mode and the proposed diff is accepted,
+- Then `.github/LABELS.md` at the bootstrap repo root matches the table shape emitted by the template (no bullet-list shape remains) and includes the agent-plugin Release-please subsection,
+- And both the template change and the mirrored root change are committed together in the same PR (per `AGENTS.md` "Source of truth for repo baseline").
+
+### AC-39-5
+
+The audit checklist enforces presence and parser-shape compliance.
+
+- Given the bootstrap audit checklist,
+- When an auditor walks `skills/bootstrap/audit-checklist.md` against any bootstrapped repo,
+- Then `.github/LABELS.md` presence and parser-shape compliance is one of the checked items under "Area 2 — GitHub metadata".
+
+## Validation strategy
+
+The Planner / Executor will rely on the audit checklist's parser-shape assertion (AC-39-5) as the canonical test for AC-39-1, AC-39-3, and AC-39-4. AC-39-2 is validated by manually invoking `/github-flows:new-issue` Step 1 against the bootstrap repo's regenerated root file (the bootstrap repo is itself a freshly-realigned target).
+
+Markdownlint must pass on the new template files and the regenerated root file under the repo's `.markdownlint.jsonc` rules — the husky `pre-commit` hook covers this on staged files.

--- a/skills/bootstrap/audit-checklist.md
+++ b/skills/bootstrap/audit-checklist.md
@@ -38,7 +38,7 @@ For every gap, produce a concrete recommendation and show a diff preview. Never 
 | `.github/ISSUE_TEMPLATE/bug_report.md` | yes | present with frontmatter |
 | `.github/ISSUE_TEMPLATE/feature_request.md` | yes | present with frontmatter |
 | `.github/CODEOWNERS` | yes | present; at least one non-comment rule |
-| `.github/LABELS.md` | yes | present; contains a `## Labels` heading; the heading is followed by a markdown table whose header row starts with `\| Name \|`; the first data column lists `bug` and `enhancement` and is alphabetically sorted |
+| `.github/LABELS.md` | yes | present; contains a `## Labels` heading; the heading is followed by a markdown table whose header row starts with `\| Name \|`; the first data column lists `bug` and `enhancement` and is alphabetically sorted (case-insensitive). When the target repo is an agent plugin, the file additionally contains a `### Release-please (tool-managed)` subsection mentioning both `autorelease: pending` and `autorelease: tagged`. |
 | `.github/workflows/lint-pr.yml` | yes | present; validates PR title format, breaking-change marker consistency, closing keyword |
 | `.github/workflows/lint-md.yml` | yes | present; runs `DavidAnson/markdownlint-cli2-action` on PRs |
 | `.github/workflows/lint-actions.yml` | yes | present; runs `actionlint` on PRs touching `.github/workflows/**` |

--- a/skills/bootstrap/audit-checklist.md
+++ b/skills/bootstrap/audit-checklist.md
@@ -38,6 +38,7 @@ For every gap, produce a concrete recommendation and show a diff preview. Never 
 | `.github/ISSUE_TEMPLATE/bug_report.md` | yes | present with frontmatter |
 | `.github/ISSUE_TEMPLATE/feature_request.md` | yes | present with frontmatter |
 | `.github/CODEOWNERS` | yes | present; at least one non-comment rule |
+| `.github/LABELS.md` | yes | present; contains a `## Labels` heading; the heading is followed by a markdown table whose header row starts with `\| Name \|`; the first data column lists `bug` and `enhancement` and is alphabetically sorted |
 | `.github/workflows/lint-pr.yml` | yes | present; validates PR title format, breaking-change marker consistency, closing keyword |
 | `.github/workflows/lint-md.yml` | yes | present; runs `DavidAnson/markdownlint-cli2-action` on PRs |
 | `.github/workflows/lint-actions.yml` | yes | present; runs `actionlint` on PRs touching `.github/workflows/**` |

--- a/skills/bootstrap/templates/agent-plugin/.github/LABELS.md.tmpl
+++ b/skills/bootstrap/templates/agent-plugin/.github/LABELS.md.tmpl
@@ -1,0 +1,28 @@
+# Labels
+
+This file is the source of truth for when to apply each issue and pull-request label in this repository. It exists so reporters and agents can pick labels without guessing, and so label drift stays visible in review. For the authoritative runtime inventory, run `gh label list --json name,description`.
+
+## Labels
+
+| Name | Description |
+| --- | --- |
+| `bug` | Apply when the report describes a defect, regression, or unexpected behavior in shipped code or docs. |
+| `documentation` | Apply when the change is primarily to Markdown, in-repo docs, or comments that describe behavior. |
+| `duplicate` | Apply when another open or closed issue already tracks the same problem; link the canonical issue in the body. |
+| `enhancement` | Apply when the report proposes a new capability or improves an existing one without fixing a defect. |
+| `good first issue` | Apply when the work is small, well-scoped, and safe for a first-time contributor to pick up. |
+| `help wanted` | Apply when maintainers are actively soliciting outside contributions on the issue. |
+| `invalid` | Apply when the report is not actionable as filed (wrong repo, not reproducible, out of scope) and cannot be salvaged by editing. |
+| `question` | Apply when the issue is a support request or clarification rather than a change request. |
+| `wontfix` | Apply when the behavior described is intentional or the maintainers have decided not to act on it; leave a short rationale before closing. |
+
+### Release-please (tool-managed)
+
+`release-please` creates and applies these labels automatically on the standing release PR; do not apply or remove them by hand. They may not appear in `gh label list` until the first release cycle runs.
+
+- `autorelease: pending`: Applied to the release PR while a release is in progress.
+- `autorelease: tagged`: Applied to the release PR once the release has been tagged.
+
+## Adding or changing labels
+
+Use `gh label list --json name,description` as the canonical inventory and follow the label-hygiene rule in [`AGENTS.md`](../AGENTS.md) (every label must have a non-empty description). Do not introduce new labels in an issue or PR without first updating the repository label set and this file.

--- a/skills/bootstrap/templates/core/.github/LABELS.md.tmpl
+++ b/skills/bootstrap/templates/core/.github/LABELS.md.tmpl
@@ -1,0 +1,21 @@
+# Labels
+
+This file is the source of truth for when to apply each issue and pull-request label in this repository. It exists so reporters and agents can pick labels without guessing, and so label drift stays visible in review. For the authoritative runtime inventory, run `gh label list --json name,description`.
+
+## Labels
+
+| Name | Description |
+| --- | --- |
+| `bug` | Apply when the report describes a defect, regression, or unexpected behavior in shipped code or docs. |
+| `documentation` | Apply when the change is primarily to Markdown, in-repo docs, or comments that describe behavior. |
+| `duplicate` | Apply when another open or closed issue already tracks the same problem; link the canonical issue in the body. |
+| `enhancement` | Apply when the report proposes a new capability or improves an existing one without fixing a defect. |
+| `good first issue` | Apply when the work is small, well-scoped, and safe for a first-time contributor to pick up. |
+| `help wanted` | Apply when maintainers are actively soliciting outside contributions on the issue. |
+| `invalid` | Apply when the report is not actionable as filed (wrong repo, not reproducible, out of scope) and cannot be salvaged by editing. |
+| `question` | Apply when the issue is a support request or clarification rather than a change request. |
+| `wontfix` | Apply when the behavior described is intentional or the maintainers have decided not to act on it; leave a short rationale before closing. |
+
+## Adding or changing labels
+
+Use `gh label list --json name,description` as the canonical inventory and follow the label-hygiene rule in [`AGENTS.md`](../AGENTS.md) (every label must have a non-empty description). Do not introduce new labels in an issue or PR without first updating the repository label set and this file.


### PR DESCRIPTION
## Summary

- Add `.github/LABELS.md.tmpl` to bootstrap's `core` and `agent-plugin` template tiers in the parser-compatible shape (`## Labels` heading + `| Name | Description |` table, alphabetically sorted), with a `### Release-please (tool-managed)` subsection in agent-plugin mode covering `autorelease: pending` and `autorelease: tagged`.
- Regenerate this repo's own `.github/LABELS.md` from the new template (bullet-list -> table) so the bootstrap repo stays its own canonical realignment target, and add `.github/LABELS.md` to the source-of-truth list in `AGENTS.md`.
- Add an audit-checklist row under "Area 2 - GitHub metadata" asserting `.github/LABELS.md` presence and parser-shape compliance.

## Linked issue

Closes #39

## Acceptance criteria

### AC-39-1

Freshly bootstrapped repo gets a parser-compatible `.github/LABELS.md` from the core template.

- [x] Template `skills/bootstrap/templates/core/.github/LABELS.md.tmpl` ships a `## Labels` heading and `| Name | Description |` table; first column alphabetically sorted and includes `bug` and `enhancement`.
- [x] Manual test: `grep -c "^## Labels" .github/LABELS.md` -> `1`; `grep -c "^| Name" .github/LABELS.md` -> `1`.

### AC-39-2

`/github-flows:new-issue` Step 1 succeeds on a freshly bootstrapped repo.

- [ ] E2E gap: no automated harness invokes `/github-flows:new-issue` Step 1 against the regenerated root file in CI.
- [ ] Manual test: 1) on a fresh checkout of this branch, run `/github-flows:new-issue`; 2) confirm Step 1 parses `.github/LABELS.md` without a malformed-table or file-not-found halt and proceeds to Step 2.

### AC-39-3

Agent-plugin mode adds the Release-please subsection without breaking the parser.

- [x] `skills/bootstrap/templates/agent-plugin/.github/LABELS.md.tmpl` contains a `### Release-please (tool-managed)` subsection covering `autorelease: pending` and `autorelease: tagged`, placed after the `## Labels` table and before `## Adding or changing labels`, while keeping a single `## Labels` heading and `| Name |` table with alphabetical first column.

### AC-39-4

The bootstrap repo's own `.github/LABELS.md` is regenerated from the template in this PR.

- [x] Template change (`skills/bootstrap/templates/agent-plugin/.github/LABELS.md.tmpl`) and mirrored root change (`.github/LABELS.md`) are committed together on this branch.
- [x] `diff <(sed 's/{{[^}]*}}//g' skills/bootstrap/templates/agent-plugin/.github/LABELS.md.tmpl) .github/LABELS.md` -> exit `0` (template realignment round-trips cleanly with placeholders stripped).

### AC-39-5

The audit checklist enforces presence and parser-shape compliance.

- [x] `skills/bootstrap/audit-checklist.md` "Area 2 - GitHub metadata" includes a row asserting `.github/LABELS.md` presence with `## Labels` heading and `| Name |` table row, and pressure-tests the agent-plugin Release-please subsection.

## Validation

- `pnpm lint:md` -> 0 errors across 64 files (covers new templates and regenerated root file under `.markdownlint.jsonc`).
- `diff <(sed 's/{{[^}]*}}//g' skills/bootstrap/templates/agent-plugin/.github/LABELS.md.tmpl) .github/LABELS.md` -> exit `0`.
- `grep -c "^## Labels" .github/LABELS.md` -> `1`; `grep -c "^| Name" .github/LABELS.md` -> `1` (parser-shape pressure test for the audit row).
- Manual `/github-flows:new-issue` Step 1 smoke against the regenerated root file is deferred to a reviewer pass (flagged as the AC-39-2 E2E gap above).

## Docs updated

- [x] Updated in this PR
  - `docs/superpowers/specs/2026-04-26-39-add-labels-md-template-to-bootstrap-core-baseline-design.md` (design doc).
  - `docs/superpowers/plans/2026-04-26-39-add-labels-md-template-to-bootstrap-core-baseline-plan.md` (implementation plan).
  - `AGENTS.md` "Source of truth for repo baseline" list now covers `.github/LABELS.md`.
  - `skills/bootstrap/audit-checklist.md` "Area 2 - GitHub metadata" gains the LABELS.md row.
