### PR TITLE
feat: #42 trigger release-please on every push to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,12 @@
 name: Release
 
-# Triggered only when (a) a maintainer manually dispatches the workflow to
-# open or refresh the standing release PR, or (b) a release-please-managed
-# PR (label `autorelease: pending`) is merged — the second event auto-cuts
-# the tag, publishes the release, and dispatches the marketplace bump on
-# patinaproject/skills. Regular PR merges do NOT trigger this workflow.
-# See RELEASING.md.
+# Triggered on every push to `main`. release-please is idempotent: on regular
+# feature/fix merges it opens or refreshes the standing release PR; on the
+# release-PR merge it sees the merged PR (label `autorelease: pending`) and
+# cuts the tag, publishes the release, and dispatches the marketplace bump on
+# patinaproject/skills. A single trigger covers both flows. See RELEASING.md.
 on:
-  workflow_dispatch:
-  pull_request:
-    types: [closed]
+  push:
     branches: [main]
 
 permissions:
@@ -19,15 +16,6 @@ permissions:
 
 jobs:
   release-please:
-    # On `pull_request: closed`, only run when the PR was actually merged AND
-    # carries the `autorelease: pending` label that release-please attaches
-    # to its standing release PR. This skips the job for regular feature/fix
-    # PR merges, so no Release workflow run shows up against them. The job
-    # always runs on `workflow_dispatch`.
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.pull_request.merged == true &&
-       contains(github.event.pull_request.labels.*.name, 'autorelease: pending'))
     runs-on: ubuntu-latest
     # Declared at both workflow and job level. The workflow-level block is the
     # upper bound for any job; the job-level block is what the runner actually

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,23 +4,19 @@ Releases are driven by [release-please](https://github.com/googleapis/release-pl
 
 ## How it works
 
-The `Release` workflow does **not** auto-run on every PR merge. Its triggers are:
+The `Release` workflow runs on every push to `main`. There is no manual dispatch. Cutting a release is the natural by-product of merging PRs:
 
-- `workflow_dispatch` — for opening or refreshing the standing release PR on demand.
-- `pull_request: types: [closed]` — but the job only runs when the closed PR was **merged** *and* carries the `autorelease: pending` label. Regular feature/fix PR merges therefore produce no Release workflow run.
+1. **Merge any PR into `main`.** The push event runs `Release`. `release-please` scans Conventional Commits since the last tag and opens — or updates — a standing **"chore: release X.Y.Z"** PR that:
 
-Cutting a release is a two-step flow:
-
-1. **Open or refresh the release PR (manual).** Trigger the workflow via **Actions → Release → Run workflow** (or `gh workflow run Release --repo <owner>/<repo>`). `release-please` scans Conventional Commits since the last tag and opens — or updates — a standing **"chore: release X.Y.Z"** PR that:
    - Bumps `package.json` version.
    - Syncs `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json` to the new version (configured in `release-please-config.json`).
    - Appends generated entries to `CHANGELOG.md`.
 
-   Release-please attaches the `autorelease: pending` label to this PR.
+   Release-please attaches the `autorelease: pending` label to this PR. If there are no releasable commits since the last tag, the run no-ops.
 
-2. **Merge the release PR (auto-fires step 3).** Squash-merging the PR closes it with the `autorelease: pending` label still attached. The `pull_request: closed` event fires the `Release` workflow automatically; release-please runs against `main`, sees the merged release PR, creates the tag `vX.Y.Z`, publishes the GitHub Release with the same Conventional-Commit-derived notes, and (on `patinaproject` plugin repos) dispatches the marketplace bump on `patinaproject/skills`. The PR's label flips to `autorelease: tagged`.
+2. **Merge the release PR.** Squash-merging the PR is itself a push to `main`, so `Release` runs again. release-please now sees the merged release PR (still labeled `autorelease: pending`), creates the tag `vX.Y.Z`, publishes the GitHub Release with the Conventional-Commit-derived notes, and (on `patinaproject` plugin repos) dispatches the marketplace bump on `patinaproject/skills`. The PR's label flips to `autorelease: tagged`.
 
-The result: regular PRs trigger nothing release-related; the only auto-fire is the release-PR merge that you just authored.
+The result: every merge keeps the standing release PR fresh; merging that PR cuts the release. No `gh workflow run` step is ever required.
 
 ## Prerequisites (one-time settings)
 

--- a/docs/superpowers/plans/2026-04-26-42-run-release-please-on-every-pr-merge-instead-of-manual-dispatch-plan.md
+++ b/docs/superpowers/plans/2026-04-26-42-run-release-please-on-every-pr-merge-instead-of-manual-dispatch-plan.md
@@ -1,0 +1,63 @@
+# Plan: Run release-please on every PR merge instead of manual dispatch [#42](https://github.com/patinaproject/bootstrap/issues/42)
+
+Implements the design at [`docs/superpowers/specs/2026-04-26-42-run-release-please-on-every-pr-merge-instead-of-manual-dispatch-design.md`](../specs/2026-04-26-42-run-release-please-on-every-pr-merge-instead-of-manual-dispatch-design.md) (commit `40fb42fe37ec80775188811edb7d5e06c2a64d73`).
+
+## Files to change
+
+Workflow YAML (3 files):
+
+1. `skills/bootstrap/templates/agent-plugin/.github/workflows/release.yml` (base template)
+2. `skills/bootstrap/templates/patinaproject-supplement/.github/workflows/release.yml` (supplement, adds `notify-patinaproject-skills`)
+3. `.github/workflows/release.yml` (root mirror; matches the supplement variant)
+
+Docs (3 files):
+
+1. `skills/bootstrap/templates/core/RELEASING.md` (base template)
+2. `skills/bootstrap/templates/patinaproject-supplement/RELEASING.md` (supplement variant)
+3. `RELEASING.md` (root mirror; matches the supplement variant)
+
+Per `AGENTS.md`, edit templates first, then mirror to root. Both sides of the loop ship in this PR.
+
+## Workstreams
+
+### W1 — Workflow YAML changes (T1, T2, T3 → release.yml × 3)
+
+For all three release.yml files apply the same shape:
+
+- Replace `on:` block with:
+
+  ```yaml
+  on:
+    push:
+      branches: [main]
+  ```
+
+- Remove the job-level `if:` filter on `release-please`. The job runs on every push to `main`.
+- Update the leading comment (currently describes `workflow_dispatch` + `pull_request: closed` semantics) to describe push-only semantics: every push to `main` runs release-please; release-please refreshes the standing release PR on regular merges and cuts the tag when it sees the merged release PR.
+- Leave `permissions:` blocks, the `release-please-action` step, and (in the supplement + root) the `notify-patinaproject-skills` job untouched.
+
+### W2 — RELEASING.md changes (T4, T5, T6 → RELEASING.md × 3)
+
+For all three RELEASING.md files:
+
+- Rewrite the "How it works" section to describe a single trigger:
+  - Every push to `main` (including PR merges) runs `Release`.
+  - On regular feature/fix merges, release-please refreshes the standing `chore: release X.Y.Z` PR.
+  - On the release-PR merge, the same push event causes release-please to cut the tag, publish the GitHub Release, and (where applicable) dispatch the marketplace bump.
+- Remove all manual-dispatch instructions: the "Trigger the workflow via Actions → Release → Run workflow" step disappears; the two-step ritual collapses into "merge regular PRs as usual; merge the release PR when ready."
+- Keep the prerequisite sections (workflow permissions, Allow Actions to create PRs, org-policy cap, PAT/App fallback, tag ruleset caution, SHA pinning) untouched — they are unrelated to the trigger surface.
+- Keep the supplement-only and core-only paragraphs preserved as today (only the "How it works" prose changes; the marketplace-bump section in the supplement variant stays).
+
+## Verification
+
+- `pnpm lint:md` passes after edits.
+- `actionlint` (CI) passes on all three release.yml files.
+- Manual inspection per AC:
+  - AC-42-1 / AC-42-3: each release.yml `on:` block contains `push: branches: [main]` and nothing else.
+  - AC-42-2: workflow comment + RELEASING.md prose both describe the release-PR-merge tag-cut as a side effect of the same push trigger.
+  - AC-42-4: each RELEASING.md contains no occurrence of `workflow_dispatch`, `Run workflow`, or `gh workflow run Release`.
+- `git diff` confirms root mirror edits exactly match the supplement-template edits.
+
+## Blockers
+
+None.

--- a/docs/superpowers/specs/2026-04-26-42-run-release-please-on-every-pr-merge-instead-of-manual-dispatch-design.md
+++ b/docs/superpowers/specs/2026-04-26-42-run-release-please-on-every-pr-merge-instead-of-manual-dispatch-design.md
@@ -8,7 +8,9 @@ This design reverses the explicit choice in [#31](https://github.com/patinaproje
 
 ## Decision
 
-Replace the `workflow_dispatch` trigger with `push` on `main`. Keep the `pull_request: closed` + `autorelease: pending` branch that auto-cuts the tag when the standing release PR is merged.
+Trigger the `Release` workflow exclusively on `push: branches: [main]`. Drop both `workflow_dispatch` and the `pull_request: closed` + `autorelease: pending` branch.
+
+Rationale: every merge to `main` (including the release-PR merge itself) is a push event. On a regular feature/fix merge, release-please refreshes the standing release PR. On the release-PR merge, the same `push` runs release-please, which observes the merged release PR with `autorelease: pending` and cuts the tag, publishes the GitHub Release, and (on `patinaproject` repos) dispatches the marketplace bump. A single trigger covers both flows; no per-event `if:` gating is required.
 
 `on:` block:
 
@@ -16,23 +18,13 @@ Replace the `workflow_dispatch` trigger with `push` on `main`. Keep the `pull_re
 on:
   push:
     branches: [main]
-  pull_request:
-    types: [closed]
-    branches: [main]
 ```
 
-Job `if:`:
-
-```yaml
-if: |
-  github.event_name == 'push' ||
-  (github.event.pull_request.merged == true &&
-   contains(github.event.pull_request.labels.*.name, 'autorelease: pending'))
-```
+The job-level `if:` filter is removed; the job runs on every triggering `push`.
 
 This applies to the root mirror `.github/workflows/release.yml` and to the two templates under `skills/bootstrap/templates/{agent-plugin,patinaproject-supplement}/.github/workflows/release.yml`.
 
-`RELEASING.md` (root + both template variants) must be rewritten to drop the manual-dispatch ritual and describe the new auto-refresh + auto-tag flow.
+`RELEASING.md` (root + both template variants) must be rewritten to drop the manual-dispatch ritual and describe the new single-trigger auto-refresh + auto-tag flow.
 
 The `notify-patinaproject-skills` job (patinaproject-supplement template + root mirror) is unchanged — it still gates on `release_created == 'true'` and `github.repository_owner == 'patinaproject'`.
 
@@ -40,16 +32,16 @@ The `notify-patinaproject-skills` job (patinaproject-supplement template + root 
 
 - R1: `Release` workflow auto-runs on every push to `main` and refreshes the standing release PR.
 - R2: `Release` workflow continues to auto-cut the tag and (on `patinaproject` repos) dispatch the marketplace bump when the standing release PR is squash-merged.
-- R3: `workflow_dispatch` is removed from all three release workflow surfaces (root + two templates).
+- R3: `workflow_dispatch` and `pull_request` triggers are removed from all three release workflow surfaces (root + two templates); the only trigger is `push: branches: [main]`.
 - R4: `RELEASING.md` (root + both template variants) describes the new flow with no manual-dispatch instructions.
 - R5: Baseline round-trip preserved — templates are edited first, root mirrors match templates exactly except for repo-specific differences already encoded in the supplement variant.
 
 ## Acceptance criteria
 
 - AC-42-1: Given a regular feature/fix PR is squash-merged into `main`, when the resulting `push` event fires, then `Release` runs and `release-please` opens or refreshes the standing release PR with no manual intervention.
-- AC-42-2: Given the standing release PR is squash-merged, when the `pull_request: closed` event fires with `autorelease: pending` present, then `Release` runs, the tag is cut, the GitHub Release is published, and (on `patinaproject` repos) the marketplace bump is dispatched.
-- AC-42-3: Given any of the three release workflow files is inspected, when the `on:` block is read, then it contains exactly `push` (branches: `main`) and `pull_request: closed` (branches: `main`), and contains no `workflow_dispatch` entry.
-- AC-42-4: Given a maintainer reads `RELEASING.md` (root and both template variants), when they look for the release flow, then it describes a single-step auto-refresh plus automatic tag-cut-on-merge with no manual-dispatch instructions remaining.
+- AC-42-2: Given the standing release PR is squash-merged, when the resulting `push` event fires, then `Release` runs, the tag is cut, the GitHub Release is published, and (on `patinaproject` repos) the marketplace bump is dispatched — without a second trigger.
+- AC-42-3: Given any of the three release workflow files is inspected, when the `on:` block is read, then it contains exactly `push` (branches: `main`) as the sole trigger, and contains no `workflow_dispatch` or `pull_request` entries.
+- AC-42-4: Given a maintainer reads `RELEASING.md` (root and both template variants), when they look for the release flow, then it describes a single-trigger auto-refresh plus automatic tag-cut-on-merge with no manual-dispatch instructions remaining.
 
 ## Non-goals
 
@@ -61,4 +53,3 @@ The `notify-patinaproject-skills` job (patinaproject-supplement template + root 
 ## Risks
 
 - Increased number of `Release` workflow runs: every merge to `main` triggers a run, even when no releasable commits are present. Mitigated by release-please being fast and idempotent on no-op runs.
-- The `Release` run that occurs as a side effect of merging the release PR fires *both* `push` and `pull_request: closed` events. The `pull_request: closed` branch is gated to require `autorelease: pending`; the `push` branch will also fire. release-please is idempotent across both, so the worst case is two no-op-or-equivalent runs against the same head. Acceptable.

--- a/docs/superpowers/specs/2026-04-26-42-run-release-please-on-every-pr-merge-instead-of-manual-dispatch-design.md
+++ b/docs/superpowers/specs/2026-04-26-42-run-release-please-on-every-pr-merge-instead-of-manual-dispatch-design.md
@@ -1,0 +1,64 @@
+# Design: Run release-please on every PR merge instead of manual dispatch [#42](https://github.com/patinaproject/bootstrap/issues/42)
+
+## Context
+
+The `Release` workflow is currently triggered by `workflow_dispatch` plus `pull_request: closed` filtered to PRs carrying `autorelease: pending`. Cutting any release therefore requires a maintainer to manually dispatch the workflow at least once to refresh the standing release PR. release-please is idempotent — it updates an existing standing PR or opens one if absent — so the manual step adds friction with no offsetting safety benefit.
+
+This design reverses the explicit choice in [#31](https://github.com/patinaproject/bootstrap/issues/31) (commit d6a370b), which removed `push` triggering to suppress noisy `Release` runs against unrelated merges. The trade-off is being re-evaluated: noise from idempotent no-op runs is acceptable; missed refreshes (because someone forgot to dispatch) are not.
+
+## Decision
+
+Replace the `workflow_dispatch` trigger with `push` on `main`. Keep the `pull_request: closed` + `autorelease: pending` branch that auto-cuts the tag when the standing release PR is merged.
+
+`on:` block:
+
+```yaml
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [closed]
+    branches: [main]
+```
+
+Job `if:`:
+
+```yaml
+if: |
+  github.event_name == 'push' ||
+  (github.event.pull_request.merged == true &&
+   contains(github.event.pull_request.labels.*.name, 'autorelease: pending'))
+```
+
+This applies to the root mirror `.github/workflows/release.yml` and to the two templates under `skills/bootstrap/templates/{agent-plugin,patinaproject-supplement}/.github/workflows/release.yml`.
+
+`RELEASING.md` (root + both template variants) must be rewritten to drop the manual-dispatch ritual and describe the new auto-refresh + auto-tag flow.
+
+The `notify-patinaproject-skills` job (patinaproject-supplement template + root mirror) is unchanged — it still gates on `release_created == 'true'` and `github.repository_owner == 'patinaproject'`.
+
+## Requirements
+
+- R1: `Release` workflow auto-runs on every push to `main` and refreshes the standing release PR.
+- R2: `Release` workflow continues to auto-cut the tag and (on `patinaproject` repos) dispatch the marketplace bump when the standing release PR is squash-merged.
+- R3: `workflow_dispatch` is removed from all three release workflow surfaces (root + two templates).
+- R4: `RELEASING.md` (root + both template variants) describes the new flow with no manual-dispatch instructions.
+- R5: Baseline round-trip preserved — templates are edited first, root mirrors match templates exactly except for repo-specific differences already encoded in the supplement variant.
+
+## Acceptance criteria
+
+- AC-42-1: Given a regular feature/fix PR is squash-merged into `main`, when the resulting `push` event fires, then `Release` runs and `release-please` opens or refreshes the standing release PR with no manual intervention.
+- AC-42-2: Given the standing release PR is squash-merged, when the `pull_request: closed` event fires with `autorelease: pending` present, then `Release` runs, the tag is cut, the GitHub Release is published, and (on `patinaproject` repos) the marketplace bump is dispatched.
+- AC-42-3: Given any of the three release workflow files is inspected, when the `on:` block is read, then it contains exactly `push` (branches: `main`) and `pull_request: closed` (branches: `main`), and contains no `workflow_dispatch` entry.
+- AC-42-4: Given a maintainer reads `RELEASING.md` (root and both template variants), when they look for the release flow, then it describes a single-step auto-refresh plus automatic tag-cut-on-merge with no manual-dispatch instructions remaining.
+
+## Non-goals
+
+- Marketplace-bump path on `patinaproject/skills`.
+- Label flow (`autorelease: pending` / `autorelease: tagged`).
+- release-please commit-type/semver behavior.
+- The `notify-patinaproject-skills` job structure or its App-token plumbing.
+
+## Risks
+
+- Increased number of `Release` workflow runs: every merge to `main` triggers a run, even when no releasable commits are present. Mitigated by release-please being fast and idempotent on no-op runs.
+- The `Release` run that occurs as a side effect of merging the release PR fires *both* `push` and `pull_request: closed` events. The `pull_request: closed` branch is gated to require `autorelease: pending`; the `push` branch will also fire. release-please is idempotent across both, so the worst case is two no-op-or-equivalent runs against the same head. Acceptable.

--- a/skills/bootstrap/templates/agent-plugin/.github/workflows/release.yml
+++ b/skills/bootstrap/templates/agent-plugin/.github/workflows/release.yml
@@ -1,14 +1,12 @@
 name: Release
 
-# Triggered only when (a) a maintainer manually dispatches the workflow to
-# open or refresh the standing release PR, or (b) a release-please-managed
-# PR (label `autorelease: pending`) is merged — the second event auto-cuts
-# the tag and publishes the release. Regular PR merges do NOT trigger this
-# workflow. See RELEASING.md.
+# Triggered on every push to `main`. release-please is idempotent: on regular
+# feature/fix merges it opens or refreshes the standing release PR; on the
+# release-PR merge it sees the merged PR (label `autorelease: pending`) and
+# cuts the tag, publishes the release, and dispatches downstream notifications.
+# A single trigger covers both flows. See RELEASING.md.
 on:
-  workflow_dispatch:
-  pull_request:
-    types: [closed]
+  push:
     branches: [main]
 
 permissions:
@@ -18,15 +16,6 @@ permissions:
 
 jobs:
   release-please:
-    # On `pull_request: closed`, only run when the PR was actually merged AND
-    # carries the `autorelease: pending` label that release-please attaches
-    # to its standing release PR. This skips the job for regular feature/fix
-    # PR merges, so no Release workflow run shows up against them. The job
-    # always runs on `workflow_dispatch`.
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.pull_request.merged == true &&
-       contains(github.event.pull_request.labels.*.name, 'autorelease: pending'))
     runs-on: ubuntu-latest
     # Declared at both workflow and job level. The workflow-level block is the
     # upper bound for any job; the job-level block is what the runner actually

--- a/skills/bootstrap/templates/core/RELEASING.md
+++ b/skills/bootstrap/templates/core/RELEASING.md
@@ -4,23 +4,19 @@ Releases are driven by [release-please](https://github.com/googleapis/release-pl
 
 ## How it works
 
-The `Release` workflow does **not** auto-run on every PR merge. Its triggers are:
+The `Release` workflow runs on every push to `main`. There is no manual dispatch. Cutting a release is the natural by-product of merging PRs:
 
-- `workflow_dispatch` — for opening or refreshing the standing release PR on demand.
-- `pull_request: types: [closed]` — but the job only runs when the closed PR was **merged** *and* carries the `autorelease: pending` label. Regular feature/fix PR merges therefore produce no Release workflow run.
+1. **Merge any PR into `main`.** The push event runs `Release`. `release-please` scans Conventional Commits since the last tag and opens — or updates — a standing **"chore: release X.Y.Z"** PR that:
 
-Cutting a release is a two-step flow:
-
-1. **Open or refresh the release PR (manual).** Trigger the workflow via **Actions → Release → Run workflow** (or `gh workflow run Release --repo <owner>/<repo>`). `release-please` scans Conventional Commits since the last tag and opens — or updates — a standing **"chore: release X.Y.Z"** PR that:
    - Bumps `package.json` version.
    - Syncs `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json` to the new version (configured in `release-please-config.json`).
    - Appends generated entries to `CHANGELOG.md`.
 
-   Release-please attaches the `autorelease: pending` label to this PR.
+   Release-please attaches the `autorelease: pending` label to this PR. If there are no releasable commits since the last tag, the run no-ops.
 
-2. **Merge the release PR (auto-fires step 3).** Squash-merging the PR closes it with the `autorelease: pending` label still attached. The `pull_request: closed` event fires the `Release` workflow automatically; release-please runs against `main`, sees the merged release PR, creates the tag `vX.Y.Z`, publishes the GitHub Release with the same Conventional-Commit-derived notes, and (when configured) dispatches the marketplace bump. The PR's label flips to `autorelease: tagged`.
+2. **Merge the release PR.** Squash-merging the PR is itself a push to `main`, so `Release` runs again. release-please now sees the merged release PR (still labeled `autorelease: pending`), creates the tag `vX.Y.Z`, publishes the GitHub Release with the Conventional-Commit-derived notes, and (when configured) dispatches the marketplace bump. The PR's label flips to `autorelease: tagged`.
 
-The result: regular PRs trigger nothing release-related; the only auto-fire is the release-PR merge that you just authored.
+The result: every merge keeps the standing release PR fresh; merging that PR cuts the release. No `gh workflow run` step is ever required.
 
 ## Prerequisites (one-time settings)
 

--- a/skills/bootstrap/templates/patinaproject-supplement/.github/workflows/release.yml
+++ b/skills/bootstrap/templates/patinaproject-supplement/.github/workflows/release.yml
@@ -1,15 +1,12 @@
 name: Release
 
-# Triggered only when (a) a maintainer manually dispatches the workflow to
-# open or refresh the standing release PR, or (b) a release-please-managed
-# PR (label `autorelease: pending`) is merged — the second event auto-cuts
-# the tag, publishes the release, and dispatches the marketplace bump on
-# patinaproject/skills. Regular PR merges do NOT trigger this workflow.
-# See RELEASING.md.
+# Triggered on every push to `main`. release-please is idempotent: on regular
+# feature/fix merges it opens or refreshes the standing release PR; on the
+# release-PR merge it sees the merged PR (label `autorelease: pending`) and
+# cuts the tag, publishes the release, and dispatches the marketplace bump on
+# patinaproject/skills. A single trigger covers both flows. See RELEASING.md.
 on:
-  workflow_dispatch:
-  pull_request:
-    types: [closed]
+  push:
     branches: [main]
 
 permissions:
@@ -19,15 +16,6 @@ permissions:
 
 jobs:
   release-please:
-    # On `pull_request: closed`, only run when the PR was actually merged AND
-    # carries the `autorelease: pending` label that release-please attaches
-    # to its standing release PR. This skips the job for regular feature/fix
-    # PR merges, so no Release workflow run shows up against them. The job
-    # always runs on `workflow_dispatch`.
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.pull_request.merged == true &&
-       contains(github.event.pull_request.labels.*.name, 'autorelease: pending'))
     runs-on: ubuntu-latest
     # Declared at both workflow and job level. The workflow-level block is the
     # upper bound for any job; the job-level block is what the runner actually

--- a/skills/bootstrap/templates/patinaproject-supplement/RELEASING.md
+++ b/skills/bootstrap/templates/patinaproject-supplement/RELEASING.md
@@ -4,23 +4,19 @@ Releases are driven by [release-please](https://github.com/googleapis/release-pl
 
 ## How it works
 
-The `Release` workflow does **not** auto-run on every PR merge. Its triggers are:
+The `Release` workflow runs on every push to `main`. There is no manual dispatch. Cutting a release is the natural by-product of merging PRs:
 
-- `workflow_dispatch` — for opening or refreshing the standing release PR on demand.
-- `pull_request: types: [closed]` — but the job only runs when the closed PR was **merged** *and* carries the `autorelease: pending` label. Regular feature/fix PR merges therefore produce no Release workflow run.
+1. **Merge any PR into `main`.** The push event runs `Release`. `release-please` scans Conventional Commits since the last tag and opens — or updates — a standing **"chore: release X.Y.Z"** PR that:
 
-Cutting a release is a two-step flow:
-
-1. **Open or refresh the release PR (manual).** Trigger the workflow via **Actions → Release → Run workflow** (or `gh workflow run Release --repo <owner>/<repo>`). `release-please` scans Conventional Commits since the last tag and opens — or updates — a standing **"chore: release X.Y.Z"** PR that:
    - Bumps `package.json` version.
    - Syncs `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json` to the new version (configured in `release-please-config.json`).
    - Appends generated entries to `CHANGELOG.md`.
 
-   Release-please attaches the `autorelease: pending` label to this PR.
+   Release-please attaches the `autorelease: pending` label to this PR. If there are no releasable commits since the last tag, the run no-ops.
 
-2. **Merge the release PR (auto-fires step 3).** Squash-merging the PR closes it with the `autorelease: pending` label still attached. The `pull_request: closed` event fires the `Release` workflow automatically; release-please runs against `main`, sees the merged release PR, creates the tag `vX.Y.Z`, publishes the GitHub Release with the same Conventional-Commit-derived notes, and (on `patinaproject` plugin repos) dispatches the marketplace bump on `patinaproject/skills`. The PR's label flips to `autorelease: tagged`.
+2. **Merge the release PR.** Squash-merging the PR is itself a push to `main`, so `Release` runs again. release-please now sees the merged release PR (still labeled `autorelease: pending`), creates the tag `vX.Y.Z`, publishes the GitHub Release with the Conventional-Commit-derived notes, and (on `patinaproject` plugin repos) dispatches the marketplace bump on `patinaproject/skills`. The PR's label flips to `autorelease: tagged`.
 
-The result: regular PRs trigger nothing release-related; the only auto-fire is the release-PR merge that you just authored.
+The result: every merge keeps the standing release PR fresh; merging that PR cuts the release. No `gh workflow run` step is ever required.
 
 ## Prerequisites (one-time settings)
 


### PR DESCRIPTION
## Summary

- Trigger `Release` workflow on every push to `main`; drop `workflow_dispatch` and the `pull_request: closed` + `autorelease: pending` branch.
- release-please's idempotent behavior covers both flows from a single trigger: regular merges refresh the standing release PR; the release-PR merge cuts the tag.
- Round-trips through both bootstrap workflow templates (`agent-plugin`, `patinaproject-supplement`) and both `RELEASING.md` template variants (`core`, `patinaproject-supplement`), with the root mirrors updated to match.

## Linked issue

Closes #42

## Acceptance criteria

### AC-42-1

Regular feature/fix PR merges into `main` auto-refresh the standing release PR with no manual intervention.

- [ ] ⚠️ E2E gap: cannot fire a real `push` to `main` from this branch; the new trigger surface is only exercised end-to-end after merge. Workflow YAML inspection, `actionlint` (CI), and `release-please-action`'s documented push-trigger behavior are the available pre-merge evidence.
- [ ] Manual test: 1) merge this PR, 2) confirm a `Release` run appears against the merge commit, 3) confirm the standing release PR is opened or refreshed (or that the run no-ops cleanly when no releasable commits exist since the last tag).

### AC-42-2

Merging the standing release PR cuts the tag, publishes the GitHub Release, and dispatches the marketplace bump on `patinaproject/skills`, all from the same `push` trigger — no second event needed.

- [ ] ⚠️ E2E gap: requires a real release-PR merge to verify; not exercisable on this feature branch.
- [ ] Manual test: at the next release cycle, 1) merge the standing release PR, 2) confirm `Release` runs once, 3) confirm `vX.Y.Z` tag and GitHub Release are created, 4) confirm `plugin-release-bump.yml` is dispatched on `patinaproject/skills`.

### AC-42-3

Each release workflow file's `on:` block is exactly `push: branches: [main]`, with no `workflow_dispatch` or `pull_request` entries.

- [ ] Static evidence — verified locally: `grep -nE "workflow_dispatch|pull_request" .github/workflows/release.yml skills/bootstrap/templates/agent-plugin/.github/workflows/release.yml skills/bootstrap/templates/patinaproject-supplement/.github/workflows/release.yml` returns no matches; `actionlint` runs in CI on all three files.
- [ ] Manual test: open each of the three `release.yml` files and confirm the only entry under `on:` is `push: branches: [main]`.

### AC-42-4

Each `RELEASING.md` describes the single-trigger auto-refresh + auto-tag flow with no manual-dispatch instructions.

- [ ] Static evidence — verified locally: `grep -nE "workflow_dispatch|gh workflow run Release|Run workflow" RELEASING.md skills/bootstrap/templates/core/RELEASING.md skills/bootstrap/templates/patinaproject-supplement/RELEASING.md` returns no matches.
- [ ] Manual test: read the rewritten "How it works" section in each of the three `RELEASING.md` files and confirm it describes a single push-driven flow with no `Actions → Run workflow` step.

## Validation

- `pnpm lint:md` → 0 errors on the worktree (66 files linted).
- `diff RELEASING.md skills/bootstrap/templates/patinaproject-supplement/RELEASING.md` → empty.
- `diff .github/workflows/release.yml skills/bootstrap/templates/patinaproject-supplement/.github/workflows/release.yml` → empty.
- Reverses the design from #31 (commit d6a370b); supersedes manual-dispatch ritual described there.

## Docs updated

- [x] Updated in this PR
