### PR TITLE
fix: #35 use author identity in manifests

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -3,8 +3,9 @@
   "version": "1.1.2",
   "description": "Scaffold or realign repositories to the Patina Project baseline: commits, PRs, PNPM tooling, agent docs, and plugin surfaces.",
   "author": {
-    "name": "Patina Project",
-    "url": "https://github.com/patinaproject"
+    "name": "Ted Mader",
+    "email": "ted@patinaproject.com",
+    "url": "https://github.com/tlmader"
   },
   "homepage": "https://github.com/patinaproject/bootstrap",
   "repository": "https://github.com/patinaproject/bootstrap",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -3,8 +3,9 @@
   "version": "1.1.2",
   "description": "Scaffold and realign repositories to the Patina Project baseline.",
   "author": {
-    "name": "Patina Project",
-    "url": "https://github.com/patinaproject"
+    "name": "Ted Mader",
+    "email": "ted@patinaproject.com",
+    "url": "https://github.com/tlmader"
   },
   "homepage": "https://github.com/patinaproject/bootstrap",
   "repository": "https://github.com/patinaproject/bootstrap",

--- a/docs/superpowers/plans/2026-04-26-35-use-the-author-s-identity-name-email-github-url-not-the-organization-in-emitted-manifests-plan.md
+++ b/docs/superpowers/plans/2026-04-26-35-use-the-author-s-identity-name-email-github-url-not-the-organization-in-emitted-manifests-plan.md
@@ -1,4 +1,4 @@
-# Use the author's identity in emitted manifests Implementation Plan
+# Plan: Use the author's identity (name, email, GitHub URL), not the organization, in emitted manifests [#35](https://github.com/patinaproject/bootstrap/issues/35)
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 

--- a/docs/superpowers/plans/2026-04-26-35-use-the-author-s-identity-name-email-github-url-not-the-organization-in-emitted-manifests-plan.md
+++ b/docs/superpowers/plans/2026-04-26-35-use-the-author-s-identity-name-email-github-url-not-the-organization-in-emitted-manifests-plan.md
@@ -1,0 +1,305 @@
+# Use the author's identity in emitted manifests Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Emit a single human author identity record across `package.json`, `.claude-plugin/plugin.json`, and `.codex-plugin/plugin.json`.
+
+**Architecture:** This is a templates-first baseline change. The bootstrap skill documentation and audit checklist define the prompt and realignment contract; the three manifest templates encode the emitted author record; the bootstrap repo root files mirror those templates for this repository.
+
+**Tech Stack:** Markdown skill docs, JSON templates, root JSON manifests, PNPM markdownlint and version checks.
+
+---
+
+## Source References
+
+Approved design:
+`docs/superpowers/specs/2026-04-26-35-use-the-author-s-identity-name-email-github-url-not-the-organization-in-emitted-manifests-design.md`
+
+Design handoff commit: `cf26aa1`
+
+Active acceptance criteria:
+
+- `AC-35-1`: authenticated `gh` produces consistent author blocks.
+- `AC-35-2`: unauthenticated `gh` falls back to a required handle prompt.
+- `AC-35-3`: repository URLs stay owner/repo URLs.
+- `AC-35-4`: realignment flags org-based author URLs.
+
+## File Structure
+
+- `skills/bootstrap/SKILL.md`: prompt table, author identity behavior, and realignment contract.
+- `skills/bootstrap/audit-checklist.md`: concrete audit checks for package and plugin author blocks.
+- `skills/bootstrap/templates/core/package.json.tmpl`: core package author record.
+- `skills/bootstrap/templates/agent-plugin/.claude-plugin/plugin.json.tmpl`: Claude plugin author record.
+- `skills/bootstrap/templates/agent-plugin/.codex-plugin/plugin.json.tmpl`: Codex plugin author record.
+- `package.json`: mirrored root package author record for this repo.
+- `.claude-plugin/plugin.json`: mirrored root Claude plugin author record for this repo.
+- `.codex-plugin/plugin.json`: mirrored root Codex plugin author record for this repo.
+
+## Task 1: Template and Skill Contract Updates
+
+**Files:**
+
+- Modify: `skills/bootstrap/SKILL.md`
+- Modify: `skills/bootstrap/audit-checklist.md`
+- Modify: `skills/bootstrap/templates/core/package.json.tmpl`
+- Modify: `skills/bootstrap/templates/agent-plugin/.claude-plugin/plugin.json.tmpl`
+- Modify: `skills/bootstrap/templates/agent-plugin/.codex-plugin/plugin.json.tmpl`
+
+- [ ] **Step 1: Capture current failing evidence**
+
+Run:
+
+```bash
+rg -n '"url": "https://github.com/\{\{owner\}\}"|"email": "\{\{author-email\}\}"|"url": "https://github.com/\{\{author-handle\}\}"' \
+  skills/bootstrap/templates/core/package.json.tmpl \
+  skills/bootstrap/templates/agent-plugin/.claude-plugin/plugin.json.tmpl \
+  skills/bootstrap/templates/agent-plugin/.codex-plugin/plugin.json.tmpl
+```
+
+Expected before implementation: plugin manifest templates show owner-based
+author URLs, `package.json.tmpl` has no author URL, and plugin manifests have no
+author email.
+
+- [ ] **Step 2: Update prompt and behavior docs**
+
+In `skills/bootstrap/SKILL.md`:
+
+- Change the prompt intro to mention that `<author-handle>` is resolved by
+  `gh api user --jq .login` and otherwise prompted with no default.
+- Add a prompt row:
+  `| <author-handle> | from gh api user --jq .login | prompted if unavailable; written into author.url |`
+- Update `<author-name>` and `<author-email>` notes so they say the values are
+  written into all author blocks, not only `package.json`.
+- Add a convention bullet explaining that author identity is name/email/GitHub
+  profile URL and repository URLs remain owner/repo URLs.
+- Add a realignment sentence requiring org-based author URLs to be reported as
+  divergences.
+
+- [ ] **Step 3: Update audit checklist**
+
+In `skills/bootstrap/audit-checklist.md`:
+
+- Update the `package.json` check so it requires `author.name`, `author.email`,
+  and `author.url`.
+- Update `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json` checks so
+  they require author name, email, and URL.
+- Add one concise note that author URL must point to the resolved
+  `https://github.com/<author-handle>`, not the repository owner URL.
+
+- [ ] **Step 4: Update manifest templates**
+
+Change `skills/bootstrap/templates/core/package.json.tmpl` author block to:
+
+```json
+  "author": {
+    "name": "{{author-name}}",
+    "email": "{{author-email}}",
+    "url": "https://github.com/{{author-handle}}"
+  },
+```
+
+Change both plugin manifest author blocks to:
+
+```json
+  "author": {
+    "name": "{{author-name}}",
+    "email": "{{author-email}}",
+    "url": "https://github.com/{{author-handle}}"
+  },
+```
+
+- [ ] **Step 5: Verify template evidence**
+
+Run:
+
+```bash
+rg -n '\{\{author-handle\}\}|\{\{author-email\}\}|https://github.com/\{\{owner\}\}/\{\{repo\}\}|https://github.com/\{\{owner\}\}"' \
+  skills/bootstrap/SKILL.md \
+  skills/bootstrap/audit-checklist.md \
+  skills/bootstrap/templates/core/package.json.tmpl \
+  skills/bootstrap/templates/agent-plugin/.claude-plugin/plugin.json.tmpl \
+  skills/bootstrap/templates/agent-plugin/.codex-plugin/plugin.json.tmpl
+```
+
+Expected: `{{author-handle}}` appears in author URL docs and the three author
+blocks; `{{author-email}}` appears in all three author blocks; owner/repo URLs
+remain in plugin repository fields; no plugin author URL still uses bare
+`{{owner}}`.
+
+- [ ] **Step 6: Commit Task 1**
+
+Run:
+
+```bash
+git add skills/bootstrap/SKILL.md skills/bootstrap/audit-checklist.md \
+  skills/bootstrap/templates/core/package.json.tmpl \
+  skills/bootstrap/templates/agent-plugin/.claude-plugin/plugin.json.tmpl \
+  skills/bootstrap/templates/agent-plugin/.codex-plugin/plugin.json.tmpl
+git commit -m "fix: #35 emit author identity in templates"
+```
+
+## Task 2: Root Mirror Updates
+
+**Files:**
+
+- Modify: `package.json`
+- Modify: `.claude-plugin/plugin.json`
+- Modify: `.codex-plugin/plugin.json`
+
+- [ ] **Step 1: Resolve author handle for this repo**
+
+Run:
+
+```bash
+gh api user --jq .login
+```
+
+Expected for this branch: `tlmader`.
+
+- [ ] **Step 2: Mirror package author**
+
+Update root `package.json` author block to include:
+
+```json
+  "author": {
+    "name": "Ted Mader",
+    "email": "ted@patinaproject.com",
+    "url": "https://github.com/tlmader"
+  },
+```
+
+- [ ] **Step 3: Mirror plugin manifest authors**
+
+Update both `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json` author
+blocks to include:
+
+```json
+  "author": {
+    "name": "Ted Mader",
+    "email": "ted@patinaproject.com",
+    "url": "https://github.com/tlmader"
+  },
+```
+
+Keep `homepage`, `repository`, `websiteURL`, `privacyPolicyURL`, and
+`termsOfServiceURL` pointed at `https://github.com/patinaproject/bootstrap`.
+
+- [ ] **Step 4: Verify root mirror evidence**
+
+Run:
+
+```bash
+node -e '
+const fs = require("node:fs");
+for (const file of ["package.json", ".claude-plugin/plugin.json", ".codex-plugin/plugin.json"]) {
+  const json = JSON.parse(fs.readFileSync(file, "utf8"));
+  console.log(file, JSON.stringify(json.author));
+}
+'
+```
+
+Expected: all three files print the same author object with `url` equal to
+`https://github.com/tlmader`.
+
+Run:
+
+```bash
+rg -n 'https://github.com/patinaproject/bootstrap|https://github.com/tlmader' \
+  .claude-plugin/plugin.json .codex-plugin/plugin.json package.json
+```
+
+Expected: author URLs use `tlmader`; repository fields still use
+`patinaproject/bootstrap`.
+
+- [ ] **Step 5: Commit Task 2**
+
+Run:
+
+```bash
+git add package.json .claude-plugin/plugin.json .codex-plugin/plugin.json
+git commit -m "fix: #35 mirror author identity manifests"
+```
+
+## Task 3: Verification and Review
+
+**Files:**
+
+- Verify: all files changed by Tasks 1 and 2.
+
+- [ ] **Step 1: Run markdown lint**
+
+Run:
+
+```bash
+pnpm lint:md
+```
+
+Expected: exit 0.
+
+- [ ] **Step 2: Run version lockstep check**
+
+Run:
+
+```bash
+pnpm check:versions
+```
+
+Expected: exit 0 and all manifests at the package version.
+
+- [ ] **Step 3: Run targeted author checks**
+
+Run:
+
+```bash
+node -e '
+const fs = require("node:fs");
+const expected = { name: "Ted Mader", email: "ted@patinaproject.com", url: "https://github.com/tlmader" };
+for (const file of ["package.json", ".claude-plugin/plugin.json", ".codex-plugin/plugin.json"]) {
+  const actual = JSON.parse(fs.readFileSync(file, "utf8")).author;
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    console.error(file, actual);
+    process.exit(1);
+  }
+}
+'
+```
+
+Expected: exit 0.
+
+- [ ] **Step 4: Verify AC-35-3 repository URLs**
+
+Run:
+
+```bash
+node -e '
+const fs = require("node:fs");
+for (const file of [".claude-plugin/plugin.json", ".codex-plugin/plugin.json"]) {
+  const json = JSON.parse(fs.readFileSync(file, "utf8"));
+  if (json.homepage !== "https://github.com/patinaproject/bootstrap") process.exit(1);
+  if (json.repository !== "https://github.com/patinaproject/bootstrap") process.exit(1);
+}
+const codex = JSON.parse(fs.readFileSync(".codex-plugin/plugin.json", "utf8"));
+for (const key of ["websiteURL", "privacyPolicyURL", "termsOfServiceURL"]) {
+  if (codex.interface[key] !== "https://github.com/patinaproject/bootstrap") process.exit(1);
+}
+'
+```
+
+Expected: exit 0.
+
+- [ ] **Step 5: Review skill pressure scenario**
+
+Read the final `skills/bootstrap/SKILL.md` and `skills/bootstrap/audit-checklist.md`
+as a future realignment agent. Confirm the docs make this scenario unambiguous:
+a plugin repo owned by `patinaproject` but authored by `tlmader` must rewrite
+`author.url` from `https://github.com/patinaproject` to
+`https://github.com/tlmader` while preserving `homepage` and `repository`.
+
+- [ ] **Step 6: Commit verification fixes only if needed**
+
+If verification finds a bug, fix it and commit with:
+
+```bash
+git add <fixed-files>
+git commit -m "fix: #35 tighten author identity verification"
+```

--- a/docs/superpowers/specs/2026-04-26-35-use-the-author-s-identity-name-email-github-url-not-the-organization-in-emitted-manifests-design.md
+++ b/docs/superpowers/specs/2026-04-26-35-use-the-author-s-identity-name-email-github-url-not-the-organization-in-emitted-manifests-design.md
@@ -1,0 +1,155 @@
+# Design: Use the author's identity (name, email, GitHub URL), not the organization, in emitted manifests [#35](https://github.com/patinaproject/bootstrap/issues/35)
+
+## Context
+
+The bootstrap skill currently treats the repository owner and the package or
+plugin author as overlapping identities. The core `package.json.tmpl` writes
+`author.name` and `author.email` from `git config`, but it does not write an
+author URL. The agent-plugin `.claude-plugin/plugin.json.tmpl` and
+`.codex-plugin/plugin.json.tmpl` write `author.name` from `git config`, omit
+`author.email`, and set `author.url` to `https://github.com/{{owner}}`.
+
+That produces mixed identity in organization-owned repositories: a human name
+paired with an organization URL. The issue asks for a single author identity
+record across all three manifests while preserving repository-level URLs for
+`homepage`, `repository`, and Codex interface links.
+
+## Intent
+
+Make scaffolded and realigned plugin repositories emit consistent human author
+metadata in `package.json`, `.claude-plugin/plugin.json`, and
+`.codex-plugin/plugin.json`: name, email, and GitHub profile URL all describe
+the author, while repository fields continue to describe the owning repository.
+
+## Decisions
+
+### D1. Add an explicit `<author-handle>` input
+
+Extend the bootstrap prompt table with `<author-handle>`. The value represents
+the GitHub username used in `https://github.com/<author-handle>`.
+
+Default resolution order:
+
+1. Try `gh api user --jq .login`.
+2. If that cannot produce a non-empty login, prompt the operator with
+   `Author GitHub handle (for author URL)?`.
+
+No owner fallback is allowed. If the automatic lookup fails, silently reusing
+`<owner>` would recreate the bug for organization-owned repositories.
+
+### D2. Treat author metadata as one manifest record
+
+All three emitted manifests should use the same author record:
+
+- `name`: `{{author-name}}`
+- `email`: `{{author-email}}`
+- `url`: `https://github.com/{{author-handle}}`
+
+The template changes are:
+
+- Add `url` to `skills/bootstrap/templates/core/package.json.tmpl`.
+- Add `email` to both plugin manifest templates.
+- Change both plugin manifest `author.url` values from `{{owner}}` to
+  `{{author-handle}}`.
+
+The issue states that `git config user.name` and `git config user.email` are
+already the correct source for name and email, so this design does not add a
+new source for those two fields.
+
+### D3. Keep repository URLs owner-based
+
+Do not change repository-level URL fields. In plugin manifests, `homepage`,
+`repository`, `interface.websiteURL`, `interface.privacyPolicyURL`, and
+`interface.termsOfServiceURL` continue to use `https://github.com/{{owner}}/{{repo}}`.
+
+This keeps attribution separate from project hosting and satisfies the issue's
+out-of-scope boundary.
+
+### D4. Document realignment behavior
+
+Update `skills/bootstrap/SKILL.md` and `skills/bootstrap/audit-checklist.md` so
+realignment mode treats stale author metadata as a concrete divergence:
+
+- `package.json` author must include `name`, `email`, and `url`.
+- Plugin manifest author blocks must include `name`, `email`, and `url`.
+- The author URL must use the resolved `<author-handle>`, not `<owner>`.
+
+When a target repo already has org-based author URLs, realignment should flag
+that divergence and offer the normal interactive rewrite.
+
+### D5. Reconcile this repository through the template loop
+
+`AGENTS.md` requires baseline-config changes to be edited in templates first and
+then mirrored into root files via local realignment. The root `package.json`,
+`.claude-plugin/plugin.json`, and `.codex-plugin/plugin.json` are all covered
+files, so this PR must include both template edits and mirrored root edits.
+
+The expected root author URL for this repository is `https://github.com/tlmader`
+when `gh api user --jq .login` resolves to `tlmader`.
+
+## Out of scope
+
+- Changing `homepage`, `repository`, or Codex interface URLs away from
+  `https://github.com/<owner>/<repo>`.
+- Introducing author identity sources beyond `git config` for name/email and
+  `gh api user` or prompt for the GitHub handle.
+- Adding non-interactive realignment flags.
+- Handling CI bot author identity flows.
+
+## Acceptance criteria
+
+### AC-35-1
+
+Authenticated `gh` produces a consistent author block in all three manifests.
+
+- Given `bootstrap` is run with `gh` authenticated as `tlmader`,
+- And `git config user.name = "Ted Mader"`,
+- And `git config user.email = ted@patinaproject.com`,
+- When the manifests are written,
+- Then `package.json`, `.claude-plugin/plugin.json`, and
+  `.codex-plugin/plugin.json` all contain `author.name = "Ted Mader"`,
+  `author.email = "ted@patinaproject.com"`, and
+  `author.url = "https://github.com/tlmader"`.
+
+### AC-35-2
+
+Unauthenticated `gh` falls back to a required author-handle prompt.
+
+- Given `bootstrap` is run with `gh` unavailable or unauthenticated,
+- When the author URL cannot be resolved automatically,
+- Then the skill prompts `Author GitHub handle (for author URL)?`,
+- And it uses the provided handle as `https://github.com/<handle>`,
+- And it does not fall through to `https://github.com/<owner>`.
+
+### AC-35-3
+
+Repository URLs remain owner/repo URLs.
+
+- Given a bootstrapped plugin repo,
+- When `homepage` and `repository` URLs in the plugin manifests are inspected,
+- Then they still point to `https://github.com/<owner>/<repo>`,
+- And only the `author.url` field points to the personal author profile.
+
+### AC-35-4
+
+Realignment mode flags org-based author URLs.
+
+- Given a target repo whose package or plugin author URL currently points at
+  `https://github.com/<owner>`,
+- When the bootstrap skill runs in realignment mode,
+- Then the audit reports the author block divergence,
+- And the normal interactive realignment flow offers to rewrite it to
+  `https://github.com/<author-handle>`.
+
+## Validation strategy
+
+Executor should validate the final change with targeted content checks and
+markdown lint:
+
+- Inspect the three template files for `{{author-handle}}`, author email, and
+  preserved owner/repo URLs.
+- Inspect the mirrored root manifests for `https://github.com/tlmader` in
+  `author.url`.
+- Run `pnpm lint:md`.
+- Run `pnpm check:versions` to ensure mirrored plugin manifest versions still
+  match `package.json`.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "description": "Scaffold new projects ready for structured commits, issues, and pull requests",
   "author": {
     "name": "Ted Mader",
-    "email": "ted@patinaproject.com"
+    "email": "ted@patinaproject.com",
+    "url": "https://github.com/tlmader"
   },
   "license": "MIT",
   "packageManager": "pnpm@10.33.2",

--- a/skills/bootstrap/SKILL.md
+++ b/skills/bootstrap/SKILL.md
@@ -49,7 +49,7 @@ Behavior:
 
 ## Prompts
 
-The skill collects the following inputs. Author name, author email, and the security contact are derived from `git config user.name` and `git config user.email`; halt with a blocker if those are unset.
+The skill collects the following inputs. Author name, author email, and the security contact are derived from `git config user.name` and `git config user.email`; halt with a blocker if those are unset. Author handle is resolved with `gh api user --jq .login`; when unavailable, prompt `Author GitHub handle (for author URL)?` with no default.
 
 | Prompt | Default | Notes |
 |---|---|---|
@@ -62,8 +62,9 @@ The skill collects the following inputs. Author name, author email, and the secu
 | `<primary-skill-name>` | — | optional; scaffolds `skills/<name>/SKILL.md` starter |
 | `<codeowner>` | `@<owner>` | written into `.github/CODEOWNERS` |
 | `<security-contact>` | from `git config user.email` | public repos only; written into `SECURITY.md` |
-| `<author-name>` | from `git config user.name` | written into `package.json` |
-| `<author-email>` | from `git config user.email` | written into `package.json` |
+| `<author-name>` | from `git config user.name` | written into every `author` block |
+| `<author-email>` | from `git config user.email` | written into every `author` block |
+| `<author-handle>` | from `gh api user --jq .login` | prompted if unavailable; written into `author.url` |
 | Continue.dev | no | opt-in secondary editor surface during agent-plugin mode |
 
 ## Core baseline
@@ -158,6 +159,7 @@ The skill does not recommend running any commands postinstall. Plugin enablement
 - **Workflow linting**: `.github/workflows/lint-actions.yml` runs `actionlint` on PRs that touch `.github/workflows/**` or `.github/actionlint.yaml`. Catches malformed refs, invalid expressions, permission mistakes, and (alongside our SHA-pin convention) supply-chain drift.
 - **GitHub Actions pinning**: every `uses:` in emitted workflows references a full 40-char commit SHA with a `# <action>@<version>` comment above it, rather than a mutable tag. Documented in `AGENTS.md`.
 - **Labels**: `AGENTS.md` directs contributors to use `gh label list` and the repository's label descriptions as the source of truth when labeling issues and PRs.
+- **Author identity**: `package.json`, `.claude-plugin/plugin.json`, and `.codex-plugin/plugin.json` use the same human author record: name and email from `git config`, plus `https://github.com/<author-handle>` from `gh api user --jq .login` or the required author-handle prompt. Repository-level URLs (`homepage`, `repository`, and Codex interface URLs) continue to use `<owner>/<repo>`.
 - **Releases (agent-plugin mode)**: [`release-please`](https://github.com/googleapis/release-please) reads conventional commits since the last tag, opens a standing release PR that bumps `package.json` + both plugin manifests + `CHANGELOG.md`, and publishes a GitHub Release on merge. Semver level is derived from commit types; there is no manual patch/minor/major choice.
 - **Distribution via `patinaproject/skills` (agent-plugin mode, auto-detected)**: when the repo owner is `patinaproject`, the emitted release workflow also dispatches `plugin-release-bump.yml` on `patinaproject/skills` immediately after a release, so the marketplace surfaces the new tag without manual steps. Forks outside the org skip the step automatically. The dispatch is authenticated by an org-owned GitHub App (`patina-project-automation`) installed on `patinaproject/skills` only; org secrets `PATINAPROJECT_AUTOMATION_APP_ID` and `PATINAPROJECT_AUTOMATION_PRIVATE_KEY` are exposed to every plugin repo. Setup is one-time per org and documented in the emitted `RELEASING.md`.
 - **Version canonicalization**: `package.json` is the single source of truth for the plugin version. `scripts/sync-plugin-versions.mjs` rewrites `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json` to match; `scripts/check-plugin-versions.mjs` enforces the lockstep via husky `pre-commit`.
@@ -245,7 +247,7 @@ Repository settings drift detected. Open:
 Proceed to apply via `gh api` (if available), or confirm after applying via UI?
 ```
 
-In realignment mode, report which check path was used (`gh`, `curl`, or `skipped`) and the full list of diverging fields. Never modify settings without explicit user confirmation.
+In realignment mode, report which check path was used (`gh`, `curl`, or `skipped`) and the full list of diverging fields. Never modify settings without explicit user confirmation. When package or plugin author URLs point to the repository owner instead of the resolved author handle, report the author block as divergent and offer the normal interactive rewrite.
 
 ### Reserved labels
 

--- a/skills/bootstrap/audit-checklist.md
+++ b/skills/bootstrap/audit-checklist.md
@@ -23,7 +23,7 @@ For every gap, produce a concrete recommendation and show a diff preview. Never 
 | `commitlint.config.js` | yes | present; extends `@commitlint/config-conventional`; has `ticket-required` rule |
 | `.husky/commit-msg` | yes | present; runs `pnpm exec commitlint --edit "$1"` |
 | `.husky/pre-commit` | yes | present; runs `pnpm exec lint-staged` |
-| `package.json` | yes | present; has `version`; `packageManager: pnpm@10.x`; `engines.node >= 24`; scripts include `lint:md`, `check:versions`, `sync:versions`; `lint-staged` block for `*.md` |
+| `package.json` | yes | present; has `version`; `author.name`; `author.email`; `author.url`; `packageManager: pnpm@10.x`; `engines.node >= 24`; scripts include `lint:md`, `check:versions`, `sync:versions`; `lint-staged` block for `*.md` |
 | `pnpm-lock.yaml` | yes | present |
 | `scripts/check-plugin-versions.mjs` | yes | present; fails with non-zero exit on version drift |
 | `scripts/sync-plugin-versions.mjs` | yes | present; rewrites plugin manifests from `package.json` |
@@ -80,8 +80,8 @@ When detected, the following surfaces should all be present. Missing platforms a
 
 | File | Required (agent plugin) | Check |
 |---|---|---|
-| `.claude-plugin/plugin.json` | yes | valid JSON; has `name`, `version`, `description`, `skills`; `version` matches `package.json` |
-| `.codex-plugin/plugin.json` | yes | valid JSON; has `name`, `version`, `description`, `skills`, `interface`; `version` matches `package.json` |
+| `.claude-plugin/plugin.json` | yes | valid JSON; has `name`, `version`, `description`, `author.name`, `author.email`, `author.url`, `skills`; `version` matches `package.json` |
+| `.codex-plugin/plugin.json` | yes | valid JSON; has `name`, `version`, `description`, `author.name`, `author.email`, `author.url`, `skills`, `interface`; `version` matches `package.json` |
 | `.github/copilot-instructions.md` | yes | present; references `AGENTS.md` |
 | `.github/workflows/release.yml` | yes | present; runs `release-please` on push to default branch |
 | `release-please-config.json` | yes | valid JSON; lists both plugin manifests under `extra-files` for version sync |
@@ -89,6 +89,8 @@ When detected, the following surfaces should all be present. Missing platforms a
 | `.cursor/rules/<repo>.mdc` | yes | present with frontmatter |
 | `.windsurfrules` | yes | present |
 | `skills/` | yes | directory exists with at least a `.gitkeep` or a skill subdirectory |
+
+Author URLs in `package.json`, `.claude-plugin/plugin.json`, and `.codex-plugin/plugin.json` must point to the resolved `https://github.com/<author-handle>`, not the repository owner URL. Repository-level URLs such as `homepage`, `repository`, and Codex interface URLs stay on `https://github.com/<owner>/<repo>`.
 
 ## Area 6 — Superpowers opt-in
 

--- a/skills/bootstrap/templates/agent-plugin/.claude-plugin/plugin.json.tmpl
+++ b/skills/bootstrap/templates/agent-plugin/.claude-plugin/plugin.json.tmpl
@@ -4,7 +4,8 @@
   "description": "{{repo-description}}",
   "author": {
     "name": "{{author-name}}",
-    "url": "https://github.com/{{owner}}"
+    "email": "{{author-email}}",
+    "url": "https://github.com/{{author-handle}}"
   },
   "homepage": "https://github.com/{{owner}}/{{repo}}",
   "repository": "https://github.com/{{owner}}/{{repo}}",

--- a/skills/bootstrap/templates/agent-plugin/.codex-plugin/plugin.json.tmpl
+++ b/skills/bootstrap/templates/agent-plugin/.codex-plugin/plugin.json.tmpl
@@ -4,7 +4,8 @@
   "description": "{{repo-description}}",
   "author": {
     "name": "{{author-name}}",
-    "url": "https://github.com/{{owner}}"
+    "email": "{{author-email}}",
+    "url": "https://github.com/{{author-handle}}"
   },
   "homepage": "https://github.com/{{owner}}/{{repo}}",
   "repository": "https://github.com/{{owner}}/{{repo}}",

--- a/skills/bootstrap/templates/core/package.json.tmpl
+++ b/skills/bootstrap/templates/core/package.json.tmpl
@@ -5,7 +5,8 @@
   "description": "{{repo-description}}",
   "author": {
     "name": "{{author-name}}",
-    "email": "{{author-email}}"
+    "email": "{{author-email}}",
+    "url": "https://github.com/{{author-handle}}"
   },
   "license": "MIT",
   "packageManager": "pnpm@10.33.2",


### PR DESCRIPTION
## Summary

- Adds an explicit author-handle contract to the bootstrap skill and realignment checklist.
- Emits consistent author name, email, and GitHub URL in package and plugin manifest templates.
- Mirrors the author identity fix into this repository while preserving repository owner URLs.

## Linked issue

- Closes #35

## Acceptance criteria

<!-- One heading per relevant AC. AC IDs follow the convention in docs/ac-traceability.md. -->

### AC-35-1

Authenticated gh produces consistent author blocks across package and plugin manifests.

- [x] Template/root evidence — codex | local worktree | @tlmader | 2026-04-26T18:20:00Z

### AC-35-2

Unauthenticated gh fallback is documented as a required author-handle prompt with no owner fallback.

- [x] Documentation evidence — codex | local worktree | @tlmader | 2026-04-26T18:20:00Z

### AC-35-3

Repository-level plugin URLs remain on owner/repo while only author.url uses the author profile.

- [x] Targeted JSON check — codex | local worktree | @tlmader | 2026-04-26T18:20:00Z

### AC-35-4

Realignment guidance flags org-based author URLs as divergences and offers the normal rewrite.

- [x] Skill pressure-test walkthrough — codex | local worktree | @tlmader | 2026-04-26T18:20:00Z

## Validation

- `pnpm lint:md`
- `pnpm check:versions`
- Targeted Node check that all three root author blocks equal `{ name: "Ted Mader", email: "ted@patinaproject.com", url: "https://github.com/tlmader" }`
- Targeted Node check that plugin `homepage`, `repository`, and Codex interface URLs remain `https://github.com/patinaproject/bootstrap`
- Local Reviewer pass; one plan-title finding fixed in `522818a`

## Docs updated

- [x] Updated in this PR
