### PR TITLE
feat: #48 clarify release-triggering commit types

### DIFF
--- a/.cursor/rules/bootstrap.mdc
+++ b/.cursor/rules/bootstrap.mdc
@@ -11,6 +11,7 @@ Key rules:
 
 - Commits use Conventional Commits with no scope and a required GitHub issue tag: `type: #123 short description`. Subject ≤ 72 chars.
 - PR titles match the commit format.
+- Behavior-changing skill, workflow, prompt, plugin metadata, marketplace, and generated-agent-instruction changes must use release-triggering commit types even when the diff is Markdown-only.
 - Markdown must pass `markdownlint-cli2` with `.markdownlint.jsonc` rules.
 - Skills live under `skills/`, one directory per skill, `SKILL.md` as the main contract.
 - Agent plugin surfaces at the repo root: `.claude-plugin/`, `.codex-plugin/`, `.cursor/`, `.windsurfrules`, `.github/copilot-instructions.md`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,5 +6,6 @@ Highlights:
 
 - Commits use Conventional Commits with no scope and a required GitHub issue tag: `type: #123 short description`.
 - PR titles match the commit format so squash merges reuse them verbatim.
+- Behavior-changing skill, workflow, prompt, plugin metadata, marketplace, and generated-agent-instruction changes must use release-triggering commit types even when the diff is Markdown-only.
 - Markdown is linted with `markdownlint-cli2` via a husky `pre-commit` hook.
 - Skills live under `skills/`, one directory per skill, with `SKILL.md` as the main contract.

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -6,5 +6,6 @@ Key rules:
 
 - Commits use Conventional Commits with no scope and a required GitHub issue tag: `type: #123 short description`. Subject ≤ 72 chars.
 - PR titles match the commit format.
+- Behavior-changing skill, workflow, prompt, plugin metadata, marketplace, and generated-agent-instruction changes must use release-triggering commit types even when the diff is Markdown-only.
 - Markdown must pass `markdownlint-cli2` with `.markdownlint.jsonc` rules.
 - Skills live under `skills/`, one directory per skill, `SKILL.md` as the main contract.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,6 +149,21 @@ Examples:
 
 Scopes like `feat(repo): ...` are rejected. Keep the subject within 72 characters.
 
+### Commit type selection
+
+Choose the commit type by product impact, not by file extension.
+
+| Change | Type |
+|--------|------|
+| Adds or changes shipped behavior, including behavior expressed in Markdown skill files, workflow gates, prompt contracts, plugin metadata, marketplace behavior, generated agent instructions, or other user-visible configuration | `feat:` |
+| Corrects broken shipped behavior in those same product surfaces | `fix:` |
+| Explains the product without changing shipped behavior or release semantics | `docs:` |
+| Performs maintenance that does not alter user-facing behavior | `chore:` |
+
+Edits to `skills/**/SKILL.md` and adjacent skill workflow contracts are product/runtime changes by default, not documentation edits. Use `docs:` for those files only when the change is clearly explanatory-only and does not alter installed skill behavior.
+
+Changes that should produce a release must not use non-bumping types such as `docs:` or `chore:`. Use the release-triggering type that matches the product impact.
+
 Pull requests should include a short summary, linked issue, validation notes, and any updated docs when structure or workflow changes.
 
 For squash-and-merge workflows, PR titles must exactly match the commitlint and commitizen commit format:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,19 @@ Examples:
 - `feat: #42 add audit mode`
 - `docs: #17 clarify install steps`
 
+Choose the commit type by product impact, not by file extension.
+
+| Change | Type |
+|--------|------|
+| Adds or changes shipped behavior, including behavior expressed in Markdown skill files, workflow gates, prompt contracts, plugin metadata, marketplace behavior, generated agent instructions, or other user-visible configuration | `feat:` |
+| Corrects broken shipped behavior in those same product surfaces | `fix:` |
+| Explains the product without changing shipped behavior or release semantics | `docs:` |
+| Performs maintenance that does not alter user-facing behavior | `chore:` |
+
+Edits to `skills/**/SKILL.md` and adjacent skill workflow contracts are product/runtime changes by default, not documentation edits. Use `docs:` for those files only when the change is clearly explanatory-only and does not alter installed skill behavior.
+
+Changes that should produce a release must not use non-bumping types such as `docs:` or `chore:`. Use the release-triggering type that matches the product impact.
+
 The `commit-msg` hook enforces this. PR titles follow the same format so the squash commit can be reused verbatim.
 
 ## Markdown

--- a/README.md
+++ b/README.md
@@ -245,7 +245,16 @@ pnpm check:versions    # enforce package.json ↔ plugin manifests lockstep
 pnpm commitlint        # one-off commit-message validation
 ```
 
-Commits and PR titles follow the enforced convention: `type: #<issue> short description`.
+Commits and PR titles follow the enforced convention: `type: #<issue> short description`. See [`CONTRIBUTING.md`](./CONTRIBUTING.md) for the full rule; choose the commit type by product impact, not by file extension.
+
+| Change | Type |
+|--------|------|
+| Adds or changes shipped behavior, including behavior expressed in Markdown skill files, workflow gates, prompt contracts, plugin metadata, marketplace behavior, generated agent instructions, or other user-visible configuration | `feat:` |
+| Corrects broken shipped behavior in those same product surfaces | `fix:` |
+| Explains the product without changing shipped behavior or release semantics | `docs:` |
+| Performs maintenance that does not alter user-facing behavior | `chore:` |
+
+Edits to `skills/**/SKILL.md` and adjacent skill workflow contracts are product/runtime changes by default, not documentation edits. Changes that should produce a release must not use non-bumping types such as `docs:` or `chore:`.
 
 ## Contributing
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -111,7 +111,7 @@ Determined from releasable Conventional Commit types — no human choice:
 
 - `fix:` → patch
 - `feat:` → minor
-- `feat!:` or `BREAKING CHANGE:` footer → major
+- `<type>!:` or `BREAKING CHANGE:` footer → major
 - `docs:`, `chore:`, and other non-releasable types → no version bump under this baseline
 
 If a change should produce a release, do not use a non-bumping type. For example, a Markdown-only edit to `skills/**/SKILL.md` that changes installed skill behavior should use `feat:` or `fix:`, not `docs:`.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -107,11 +107,14 @@ When enabled, GitHub refuses to run workflows that `uses:` an action by tag or b
 
 ## Semver decision
 
-Determined from commit types — no human choice:
+Determined from releasable Conventional Commit types — no human choice:
 
 - `fix:` → patch
 - `feat:` → minor
 - `feat!:` or `BREAKING CHANGE:` footer → major
+- `docs:`, `chore:`, and other non-releasable types → no version bump under this baseline
+
+If a change should produce a release, do not use a non-bumping type. For example, a Markdown-only edit to `skills/**/SKILL.md` that changes installed skill behavior should use `feat:` or `fix:`, not `docs:`.
 
 ## Keeping versions aligned between releases
 
@@ -146,5 +149,6 @@ If either secret is missing on a `patinaproject` plugin repo, the `Mint patina-p
 ## Writing commits for a clean changelog
 
 - Use Conventional Commits: `feat: #<issue> …`, `fix: #<issue> …`, etc.
+- Choose release-triggering types for product changes. Release Please can no-op when product changes are misclassified as `docs:` or `chore:`, which can skip downstream marketplace bump automation.
 - Breaking changes: prefix the type with `!` (e.g. `feat!: #123 rename foo to bar`) **and** include a `BREAKING CHANGE: …` footer in the PR body.
 - Squash-merge flow: PR titles must themselves be conventional-commit-shaped so the squash commit lands with the correct type/scope. Enforced by the `Lint PR` workflow.

--- a/docs/superpowers/plans/2026-04-27-48-clarify-commit-types-for-release-triggering-product-changes-plan.md
+++ b/docs/superpowers/plans/2026-04-27-48-clarify-commit-types-for-release-triggering-product-changes-plan.md
@@ -1,0 +1,185 @@
+# Clarify Commit Types for Release-Triggering Product Changes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Update Bootstrap-generated guidance so product-surface changes use release-triggering commit types and explanatory-only documentation keeps `docs:`.
+
+**Architecture:** Edit the authoritative templates under `skills/bootstrap/templates/**` first, then mirror the generated baseline files in the repository root through the local bootstrap realignment loop. Keep the change policy-only: no commitlint or Release Please configuration changes.
+
+**Tech Stack:** Markdown templates, Bootstrap skill realignment, PNPM, markdownlint-cli2, git.
+
+---
+
+## Task 1: Add Commit Type Selection Guidance
+
+**Files:**
+
+- Modify: `skills/bootstrap/templates/core/AGENTS.md.tmpl`
+- Modify: `skills/bootstrap/templates/core/CONTRIBUTING.md.tmpl`
+- Modify: `skills/bootstrap/templates/agent-plugin/.github/copilot-instructions.md`
+- Modify: `skills/bootstrap/templates/agent-plugin/README.md.tmpl`
+
+- [ ] **Step 1: Update agent-facing commit guidance**
+
+Add a "Commit type selection" subsection under the commit guidance in
+`skills/bootstrap/templates/core/AGENTS.md.tmpl`. It must say:
+
+```markdown
+### Commit type selection
+
+Choose the commit type by product impact, not by file extension.
+
+| Change | Type |
+|--------|------|
+| Adds or changes shipped behavior, including behavior expressed in Markdown skill files, workflow gates, prompt contracts, plugin metadata, marketplace behavior, generated agent instructions, or other user-visible configuration | `feat:` |
+| Corrects broken shipped behavior in those same product surfaces | `fix:` |
+| Explains the product without changing shipped behavior or release semantics | `docs:` |
+| Performs maintenance that does not alter user-facing behavior | `chore:` |
+
+Edits to `skills/**/SKILL.md` and adjacent skill workflow contracts are product/runtime changes by default, not documentation edits. Use `docs:` for those files only when the change is clearly explanatory-only and does not alter installed skill behavior.
+
+Changes that should produce a release must not use non-bumping types such as `docs:` or `chore:`. Use the release-triggering type that matches the product impact.
+```
+
+- [ ] **Step 2: Update human contributor guidance**
+
+Add the same rule, with the same decision table, under `## Commit messages` in
+`skills/bootstrap/templates/core/CONTRIBUTING.md.tmpl`.
+
+- [ ] **Step 3: Update generated plugin README development guidance**
+
+Replace the single sentence `Commits and PR titles follow...` in
+`skills/bootstrap/templates/agent-plugin/README.md.tmpl` with a short paragraph
+that points to `CONTRIBUTING.md`, includes the decision table, and states that
+skill file edits are product/runtime changes by default.
+
+- [ ] **Step 4: Update generated Copilot highlights**
+
+Add one bullet to `skills/bootstrap/templates/agent-plugin/.github/copilot-instructions.md`
+stating that behavior-changing skill, workflow, prompt, plugin metadata, and
+marketplace changes must use release-triggering commit types even when the diff
+is Markdown-only.
+
+- [ ] **Step 5: Verify the template text**
+
+Run:
+
+```bash
+rg -n "Commit type selection|product/runtime changes by default|must not use non-bumping|release-triggering" skills/bootstrap/templates
+```
+
+Expected: matches in `AGENTS.md.tmpl`, `CONTRIBUTING.md.tmpl`,
+`README.md.tmpl`, and `.github/copilot-instructions.md`.
+
+## Task 2: Document Release Please Bump Mapping
+
+**Files:**
+
+- Modify: `skills/bootstrap/templates/core/RELEASING.md`
+- Modify: `skills/bootstrap/templates/patinaproject-supplement/RELEASING.md`
+
+- [ ] **Step 1: Expand semver decision guidance**
+
+Update `## Semver decision` in both release templates so it documents:
+
+```markdown
+Determined from releasable Conventional Commit types — no human choice:
+
+- `fix:` -> patch
+- `feat:` -> minor
+- `feat!:` or `BREAKING CHANGE:` footer -> major
+- `docs:`, `chore:`, and other non-releasable types -> no version bump under this baseline
+
+If a change should produce a release, do not use a non-bumping type. For example, a Markdown-only edit to `skills/**/SKILL.md` that changes installed skill behavior should use `feat:` or `fix:`, not `docs:`.
+```
+
+- [ ] **Step 2: Expand clean changelog guidance**
+
+Update `## Writing commits for a clean changelog` in both release templates to
+explain that Release Please can no-op when product changes are misclassified as
+`docs:` or `chore:`, which can skip downstream marketplace bump automation.
+
+- [ ] **Step 3: Verify release mapping text**
+
+Run:
+
+```bash
+rg -n "no version bump|If a change should produce a release|misclassified as `docs:`|marketplace bump" skills/bootstrap/templates/core/RELEASING.md skills/bootstrap/templates/patinaproject-supplement/RELEASING.md
+```
+
+Expected: both files include the no-bump rule, release-worthy warning, and
+misclassification consequence.
+
+## Task 3: Mirror Template Changes to Root Baseline
+
+**Files:**
+
+- Modify: `AGENTS.md`
+- Modify: `CONTRIBUTING.md`
+- Modify: `RELEASING.md`
+- Modify: `README.md`
+- Modify: `.github/copilot-instructions.md`
+
+- [ ] **Step 1: Run local bootstrap realignment**
+
+Run the repository's local bootstrap skill against this repo in realignment mode
+and accept the proposed root diff so root generated files match the templates.
+
+- [ ] **Step 2: Verify mirrored surfaces**
+
+Run:
+
+```bash
+rg -n "Commit type selection|product/runtime changes by default|no version bump|must not use non-bumping|misclassified as `docs:`" AGENTS.md CONTRIBUTING.md RELEASING.md README.md .github/copilot-instructions.md
+```
+
+Expected: the root files contain the same commit-type and release-mapping
+guidance emitted by the templates.
+
+## Task 4: Validate and Commit Implementation
+
+**Files:**
+
+- All modified templates, mirrored root files, design doc, and plan doc.
+
+- [ ] **Step 1: Run markdown lint**
+
+Run:
+
+```bash
+pnpm lint:md
+```
+
+Expected: `Summary: 0 error(s)`.
+
+- [ ] **Step 2: Review final diff**
+
+Run:
+
+```bash
+git diff -- skills/bootstrap/templates AGENTS.md CONTRIBUTING.md RELEASING.md README.md .github/copilot-instructions.md docs/superpowers
+```
+
+Expected: only issue #48 guidance, design, and plan changes are present.
+
+- [ ] **Step 3: Commit**
+
+Run:
+
+```bash
+git add skills/bootstrap/templates AGENTS.md CONTRIBUTING.md RELEASING.md README.md .github/copilot-instructions.md docs/superpowers
+git commit -m "feat: #48 clarify release-triggering commit types"
+```
+
+Expected: commit succeeds, including Husky markdown lint and plugin version
+checks.
+
+## Self-Review
+
+- Spec coverage: Task 1 covers AC-48-1, AC-48-2, and AC-48-3. Task 2 covers
+  AC-48-4 plus the approved deltas about Release Please bump mapping and
+  avoiding non-bumping types for release-worthy changes. Task 3 covers the
+  template-first/root-mirror repository rule.
+- Placeholder scan: no TBD/TODO placeholders remain.
+- Scope check: the plan is policy text only and avoids commitlint or Release
+  Please configuration changes.

--- a/docs/superpowers/plans/2026-04-27-48-clarify-commit-types-for-release-triggering-product-changes-plan.md
+++ b/docs/superpowers/plans/2026-04-27-48-clarify-commit-types-for-release-triggering-product-changes-plan.md
@@ -87,7 +87,7 @@ Determined from releasable Conventional Commit types — no human choice:
 
 - `fix:` -> patch
 - `feat:` -> minor
-- `feat!:` or `BREAKING CHANGE:` footer -> major
+- `<type>!:` or `BREAKING CHANGE:` footer -> major
 - `docs:`, `chore:`, and other non-releasable types -> no version bump under this baseline
 
 If a change should produce a release, do not use a non-bumping type. For example, a Markdown-only edit to `skills/**/SKILL.md` that changes installed skill behavior should use `feat:` or `fix:`, not `docs:`.

--- a/docs/superpowers/plans/2026-04-27-48-clarify-commit-types-for-release-triggering-product-changes-plan.md
+++ b/docs/superpowers/plans/2026-04-27-48-clarify-commit-types-for-release-triggering-product-changes-plan.md
@@ -104,7 +104,7 @@ explain that Release Please can no-op when product changes are misclassified as
 Run:
 
 ```bash
-rg -n "no version bump|If a change should produce a release|misclassified as `docs:`|marketplace bump" skills/bootstrap/templates/core/RELEASING.md skills/bootstrap/templates/patinaproject-supplement/RELEASING.md
+rg -n 'no version bump|If a change should produce a release|misclassified as `docs:`|marketplace bump' skills/bootstrap/templates/core/RELEASING.md skills/bootstrap/templates/patinaproject-supplement/RELEASING.md
 ```
 
 Expected: both files include the no-bump rule, release-worthy warning, and
@@ -130,7 +130,7 @@ and accept the proposed root diff so root generated files match the templates.
 Run:
 
 ```bash
-rg -n "Commit type selection|product/runtime changes by default|no version bump|must not use non-bumping|misclassified as `docs:`" AGENTS.md CONTRIBUTING.md RELEASING.md README.md .github/copilot-instructions.md
+rg -n 'Commit type selection|product/runtime changes by default|no version bump|must not use non-bumping|misclassified as `docs:`' AGENTS.md CONTRIBUTING.md RELEASING.md README.md .github/copilot-instructions.md
 ```
 
 Expected: the root files contain the same commit-type and release-mapping

--- a/docs/superpowers/specs/2026-04-27-48-clarify-commit-types-for-release-triggering-product-changes-design.md
+++ b/docs/superpowers/specs/2026-04-27-48-clarify-commit-types-for-release-triggering-product-changes-design.md
@@ -1,0 +1,132 @@
+# Design: Clarify commit types for release-triggering product changes [#48](https://github.com/patinaproject/bootstrap/issues/48)
+
+## Context
+
+Bootstrap emits a repository baseline that uses Conventional Commits,
+Release Please, PR-title linting, and agent-facing contribution guidance.
+In plugin and skill repositories, Markdown can be the shipped product surface:
+`skills/**/*.md`, prompt contracts, workflow gates, marketplace metadata, and
+generated AI-agent instructions can all alter installed behavior even though
+they are text files.
+Skill files are especially important: edits to `skills/**/SKILL.md` and
+adjacent skill workflow contracts are product/runtime edits, not documentation
+edits, unless the change is clearly explanatory-only and does not alter the
+installed skill's behavior.
+
+Issue #48 asks Bootstrap to make that distinction explicit so contributors and
+agents do not classify behavior-changing product-surface changes as `docs:`.
+Misclassification matters because Release Please ignores non-releasable commit
+types when opening release PRs, which can prevent downstream marketplace bumps
+for behavior changes.
+
+## Requirements
+
+- AC-48-1: Given a Bootstrap-generated repo where Markdown files define shipped
+  skill or plugin behavior, when contributor guidance explains Conventional
+  Commit types, then it states that behavior-changing Markdown can require
+  `feat:` or `fix:` rather than `docs:`.
+- AC-48-2: Given a contributor is choosing between `docs:` and `feat:`, when
+  the change alters installed skill behavior, workflow gates, prompt contracts,
+  marketplace metadata, or other user-visible product behavior, then the
+  guidance directs them to use a release-triggering type.
+- AC-48-3: Given a contributor is making explanatory-only documentation
+  changes, when the guidance describes `docs:`, then it preserves `docs:` for
+  non-product-surface documentation that should not trigger a release.
+- AC-48-4: Given Bootstrap templates or generated instructions mention Release
+  Please, when they describe release-triggering behavior, then they explain
+  that misclassifying product changes as `docs:` can prevent release PRs and
+  downstream marketplace bumps.
+
+## Considered approaches
+
+### Recommended: Add a shared decision table to contributor guidance and release docs
+
+Update the template-owned baseline surfaces that already teach commit rules:
+`AGENTS.md.tmpl`, `CONTRIBUTING.md.tmpl`, `RELEASING.md`,
+`agent-plugin/README.md.tmpl`, and `.github/copilot-instructions.md`. Mirror
+the same guidance into this repository root by running the local bootstrap
+realignment loop after template edits.
+
+This keeps the rule near the decision points: agents see it in `AGENTS.md` and
+Copilot instructions, humans see it in `CONTRIBUTING.md`, and release owners see
+the Release Please consequence in `RELEASING.md`. It avoids changing enforcement
+logic while still shaping the squash commit title that Release Please consumes.
+
+### Alternative: Put the guidance only in `RELEASING.md`
+
+This would explain Release Please behavior clearly, but it would be too far from
+the normal commit and PR-title workflow. Agents and contributors could still
+read `AGENTS.md` or `CONTRIBUTING.md`, choose `docs:`, and never reach the
+release docs before opening a PR.
+
+### Alternative: Change commitlint or Release Please configuration
+
+The issue explicitly avoids requiring scopes or making every Markdown change
+releasable. Enforcement cannot reliably know whether a Markdown diff changes a
+runtime contract, so policy text is the right first fix.
+
+## Design
+
+The baseline should introduce a short "Commit type selection" rule in the
+generated contributor and agent guidance. The rule should say that commit type
+is based on product impact, not file extension. Markdown-only changes use
+`feat:` when they add or change shipped behavior, `fix:` when they correct
+broken shipped behavior, and `docs:` only when they explain behavior without
+changing the shipped product contract.
+
+The guidance should name the product surfaces called out by the issue:
+installed skill behavior, `skills/**/SKILL.md` contracts, adjacent skill
+workflow files, workflow gates, prompt contracts, plugin metadata, marketplace
+behavior, generated agent instructions, and other user-visible configuration.
+It should explicitly warn that skill file edits are not automatically `docs:`
+changes just because the files are Markdown. It should also preserve `chore:`
+for maintenance that does not alter user-facing behavior.
+
+`RELEASING.md` should connect this classification to Release Please. It should
+state that Release Please opens release PRs from releasable Conventional Commit
+types, and that misclassifying product changes as `docs:` can cause a no-op
+release run and skip downstream marketplace bump automation. It should document
+the default bump mapping used by the baseline: `fix:` creates a patch release,
+`feat:` creates a minor release, and `feat!:` or a `BREAKING CHANGE:` footer
+creates a major release. It should also say that other types, including
+`docs:` and `chore:`, do not bump versions under the baseline unless Release
+Please configuration changes later. The guidance should be prescriptive:
+changes that should produce a release must not use non-bumping types such as
+`docs:` or `chore:`. Contributors should choose the release-triggering type
+that matches the product impact instead.
+
+Because this repository treats `skills/bootstrap/templates/**` as the source of
+truth for its own baseline, implementation must edit templates first and then
+mirror the root generated files through bootstrap realignment. The PR body must
+call out that loop.
+
+## Scope
+
+In scope:
+
+- Template updates for generated commit, PR-title, and release guidance.
+- Root mirrored updates produced by the local bootstrap realignment loop.
+- Markdown lint and targeted text verification.
+
+Out of scope:
+
+- Commitlint rule changes.
+- Requiring scopes.
+- Release Please configuration changes that release on all `docs:` commits.
+- Any claim that every Markdown change is releasable.
+
+## Verification
+
+- Run `pnpm lint:md`.
+- Use `rg` to confirm generated guidance mentions behavior-changing Markdown,
+  release-triggering types, `docs:` preservation, and Release Please
+  misclassification consequences.
+- Use `rg` to confirm the generated release guidance documents which commit
+  types produce patch, minor, and major releases, and which common types do not
+  bump versions under the baseline.
+- Review root and template surfaces with `sed` to confirm the template-first
+  changes mirrored correctly.
+
+## Concerns
+
+No approval-relevant concerns remain.

--- a/docs/superpowers/specs/2026-04-27-48-clarify-commit-types-for-release-triggering-product-changes-design.md
+++ b/docs/superpowers/specs/2026-04-27-48-clarify-commit-types-for-release-triggering-product-changes-design.md
@@ -87,7 +87,7 @@ state that Release Please opens release PRs from releasable Conventional Commit
 types, and that misclassifying product changes as `docs:` can cause a no-op
 release run and skip downstream marketplace bump automation. It should document
 the default bump mapping used by the baseline: `fix:` creates a patch release,
-`feat:` creates a minor release, and `feat!:` or a `BREAKING CHANGE:` footer
+`feat:` creates a minor release, and `<type>!:` or a `BREAKING CHANGE:` footer
 creates a major release. It should also say that other types, including
 `docs:` and `chore:`, do not bump versions under the baseline unless Release
 Please configuration changes later. The guidance should be prescriptive:

--- a/skills/bootstrap/templates/agent-plugin/.cursor/rules/{{repo}}.mdc
+++ b/skills/bootstrap/templates/agent-plugin/.cursor/rules/{{repo}}.mdc
@@ -11,6 +11,7 @@ Key rules:
 
 - Commits use Conventional Commits with no scope and a required GitHub issue tag: `type: #123 short description`. Subject ≤ 72 chars.
 - PR titles match the commit format.
+- Behavior-changing skill, workflow, prompt, plugin metadata, marketplace, and generated-agent-instruction changes must use release-triggering commit types even when the diff is Markdown-only.
 - Markdown must pass `markdownlint-cli2` with `.markdownlint.jsonc` rules.
 - Skills live under `skills/`, one directory per skill, `SKILL.md` as the main contract.
 - Agent plugin surfaces at the repo root: `.claude-plugin/`, `.codex-plugin/`, `.cursor/`, `.windsurfrules`, `.github/copilot-instructions.md`.

--- a/skills/bootstrap/templates/agent-plugin/.github/copilot-instructions.md
+++ b/skills/bootstrap/templates/agent-plugin/.github/copilot-instructions.md
@@ -6,5 +6,6 @@ Highlights:
 
 - Commits use Conventional Commits with no scope and a required GitHub issue tag: `type: #123 short description`.
 - PR titles match the commit format so squash merges reuse them verbatim.
+- Behavior-changing skill, workflow, prompt, plugin metadata, marketplace, and generated-agent-instruction changes must use release-triggering commit types even when the diff is Markdown-only.
 - Markdown is linted with `markdownlint-cli2` via a husky `pre-commit` hook.
 - Skills live under `skills/`, one directory per skill, with `SKILL.md` as the main contract.

--- a/skills/bootstrap/templates/agent-plugin/.windsurfrules
+++ b/skills/bootstrap/templates/agent-plugin/.windsurfrules
@@ -6,5 +6,6 @@ Key rules:
 
 - Commits use Conventional Commits with no scope and a required GitHub issue tag: `type: #123 short description`. Subject ≤ 72 chars.
 - PR titles match the commit format.
+- Behavior-changing skill, workflow, prompt, plugin metadata, marketplace, and generated-agent-instruction changes must use release-triggering commit types even when the diff is Markdown-only.
 - Markdown must pass `markdownlint-cli2` with `.markdownlint.jsonc` rules.
 - Skills live under `skills/`, one directory per skill, `SKILL.md` as the main contract.

--- a/skills/bootstrap/templates/agent-plugin/README.md.tmpl
+++ b/skills/bootstrap/templates/agent-plugin/README.md.tmpl
@@ -167,7 +167,18 @@ pnpm check:versions    # enforce package.json ↔ plugin manifests lockstep
 pnpm commitlint        # one-off commit-message validation
 ```
 
-Commits and PR titles follow `type: #<issue> short description`.
+Commits and PR titles follow `type: #<issue> short description`. See
+[`CONTRIBUTING.md`](./CONTRIBUTING.md) for the full rule; choose the commit type
+by product impact, not by file extension.
+
+| Change | Type |
+|--------|------|
+| Adds or changes shipped behavior, including behavior expressed in Markdown skill files, workflow gates, prompt contracts, plugin metadata, marketplace behavior, generated agent instructions, or other user-visible configuration | `feat:` |
+| Corrects broken shipped behavior in those same product surfaces | `fix:` |
+| Explains the product without changing shipped behavior or release semantics | `docs:` |
+| Performs maintenance that does not alter user-facing behavior | `chore:` |
+
+Edits to `skills/**/SKILL.md` and adjacent skill workflow contracts are product/runtime changes by default, not documentation edits. Changes that should produce a release must not use non-bumping types such as `docs:` or `chore:`.
 
 Releases are driven by [release-please](https://github.com/googleapis/release-please) — merge the standing release PR to cut a new `vX.Y.Z`. See [`RELEASING.md`](./RELEASING.md).
 

--- a/skills/bootstrap/templates/core/AGENTS.md.tmpl
+++ b/skills/bootstrap/templates/core/AGENTS.md.tmpl
@@ -101,6 +101,21 @@ Commits are enforced with Husky + commitlint. Use conventional commits with no s
 
 Scopes like `feat(repo): ...` are rejected. Keep the subject within 72 characters.
 
+### Commit type selection
+
+Choose the commit type by product impact, not by file extension.
+
+| Change | Type |
+|--------|------|
+| Adds or changes shipped behavior, including behavior expressed in Markdown skill files, workflow gates, prompt contracts, plugin metadata, marketplace behavior, generated agent instructions, or other user-visible configuration | `feat:` |
+| Corrects broken shipped behavior in those same product surfaces | `fix:` |
+| Explains the product without changing shipped behavior or release semantics | `docs:` |
+| Performs maintenance that does not alter user-facing behavior | `chore:` |
+
+Edits to `skills/**/SKILL.md` and adjacent skill workflow contracts are product/runtime changes by default, not documentation edits. Use `docs:` for those files only when the change is clearly explanatory-only and does not alter installed skill behavior.
+
+Changes that should produce a release must not use non-bumping types such as `docs:` or `chore:`. Use the release-triggering type that matches the product impact.
+
 Pull requests should include a short summary, linked issue, validation notes, and any updated docs when structure or workflow changes.
 
 For squash-and-merge workflows, PR titles must exactly match the commit format. Use the final intended squash commit title as the PR title.

--- a/skills/bootstrap/templates/core/CONTRIBUTING.md.tmpl
+++ b/skills/bootstrap/templates/core/CONTRIBUTING.md.tmpl
@@ -23,6 +23,19 @@ Examples:
 - `feat: #42 add a feature`
 - `docs: #17 clarify install steps`
 
+Choose the commit type by product impact, not by file extension.
+
+| Change | Type |
+|--------|------|
+| Adds or changes shipped behavior, including behavior expressed in Markdown skill files, workflow gates, prompt contracts, plugin metadata, marketplace behavior, generated agent instructions, or other user-visible configuration | `feat:` |
+| Corrects broken shipped behavior in those same product surfaces | `fix:` |
+| Explains the product without changing shipped behavior or release semantics | `docs:` |
+| Performs maintenance that does not alter user-facing behavior | `chore:` |
+
+Edits to `skills/**/SKILL.md` and adjacent skill workflow contracts are product/runtime changes by default, not documentation edits. Use `docs:` for those files only when the change is clearly explanatory-only and does not alter installed skill behavior.
+
+Changes that should produce a release must not use non-bumping types such as `docs:` or `chore:`. Use the release-triggering type that matches the product impact.
+
 The `commit-msg` hook enforces this. PR titles follow the same format so the squash commit can be reused verbatim.
 
 ## Markdown

--- a/skills/bootstrap/templates/core/README.md.tmpl
+++ b/skills/bootstrap/templates/core/README.md.tmpl
@@ -4,7 +4,7 @@
 
 ## Conventions
 
-- Commits: `type: #<issue> short description` (enforced by husky + commitlint).
+- Commits: `type: #<issue> short description` (enforced by husky + commitlint); choose release-triggering types for product changes, even when the diff is Markdown-only.
 - PR titles: same format.
 - Markdown lints with `markdownlint-cli2` via the husky `pre-commit` hook.
 - Plugin enablement for Claude Code is declarative in `.claude/settings.json`.

--- a/skills/bootstrap/templates/core/RELEASING.md
+++ b/skills/bootstrap/templates/core/RELEASING.md
@@ -111,7 +111,7 @@ Determined from releasable Conventional Commit types — no human choice:
 
 - `fix:` → patch
 - `feat:` → minor
-- `feat!:` or `BREAKING CHANGE:` footer → major
+- `<type>!:` or `BREAKING CHANGE:` footer → major
 - `docs:`, `chore:`, and other non-releasable types → no version bump under this baseline
 
 If a change should produce a release, do not use a non-bumping type. For example, a Markdown-only edit to `skills/**/SKILL.md` that changes installed skill behavior should use `feat:` or `fix:`, not `docs:`.

--- a/skills/bootstrap/templates/core/RELEASING.md
+++ b/skills/bootstrap/templates/core/RELEASING.md
@@ -107,11 +107,14 @@ When enabled, GitHub refuses to run workflows that `uses:` an action by tag or b
 
 ## Semver decision
 
-Determined from commit types — no human choice:
+Determined from releasable Conventional Commit types — no human choice:
 
 - `fix:` → patch
 - `feat:` → minor
 - `feat!:` or `BREAKING CHANGE:` footer → major
+- `docs:`, `chore:`, and other non-releasable types → no version bump under this baseline
+
+If a change should produce a release, do not use a non-bumping type. For example, a Markdown-only edit to `skills/**/SKILL.md` that changes installed skill behavior should use `feat:` or `fix:`, not `docs:`.
 
 ## Keeping versions aligned between releases
 
@@ -146,5 +149,6 @@ If either secret is missing on a `patinaproject` plugin repo, the `Mint patina-p
 ## Writing commits for a clean changelog
 
 - Use Conventional Commits: `feat: #<issue> …`, `fix: #<issue> …`, etc.
+- Choose release-triggering types for product changes. Release Please can no-op when product changes are misclassified as `docs:` or `chore:`, which can skip downstream marketplace bump automation.
 - Breaking changes: prefix the type with `!` (e.g. `feat!: #123 rename foo to bar`) **and** include a `BREAKING CHANGE: …` footer in the PR body.
 - Squash-merge flow: PR titles must themselves be conventional-commit-shaped so the squash commit lands with the correct type/scope. Enforced by the `Lint PR` workflow.

--- a/skills/bootstrap/templates/patinaproject-supplement/RELEASING.md
+++ b/skills/bootstrap/templates/patinaproject-supplement/RELEASING.md
@@ -111,7 +111,7 @@ Determined from releasable Conventional Commit types — no human choice:
 
 - `fix:` → patch
 - `feat:` → minor
-- `feat!:` or `BREAKING CHANGE:` footer → major
+- `<type>!:` or `BREAKING CHANGE:` footer → major
 - `docs:`, `chore:`, and other non-releasable types → no version bump under this baseline
 
 If a change should produce a release, do not use a non-bumping type. For example, a Markdown-only edit to `skills/**/SKILL.md` that changes installed skill behavior should use `feat:` or `fix:`, not `docs:`.

--- a/skills/bootstrap/templates/patinaproject-supplement/RELEASING.md
+++ b/skills/bootstrap/templates/patinaproject-supplement/RELEASING.md
@@ -107,11 +107,14 @@ When enabled, GitHub refuses to run workflows that `uses:` an action by tag or b
 
 ## Semver decision
 
-Determined from commit types — no human choice:
+Determined from releasable Conventional Commit types — no human choice:
 
 - `fix:` → patch
 - `feat:` → minor
 - `feat!:` or `BREAKING CHANGE:` footer → major
+- `docs:`, `chore:`, and other non-releasable types → no version bump under this baseline
+
+If a change should produce a release, do not use a non-bumping type. For example, a Markdown-only edit to `skills/**/SKILL.md` that changes installed skill behavior should use `feat:` or `fix:`, not `docs:`.
 
 ## Keeping versions aligned between releases
 
@@ -146,5 +149,6 @@ If either secret is missing on a `patinaproject` plugin repo, the `Mint patina-p
 ## Writing commits for a clean changelog
 
 - Use Conventional Commits: `feat: #<issue> …`, `fix: #<issue> …`, etc.
+- Choose release-triggering types for product changes. Release Please can no-op when product changes are misclassified as `docs:` or `chore:`, which can skip downstream marketplace bump automation.
 - Breaking changes: prefix the type with `!` (e.g. `feat!: #123 rename foo to bar`) **and** include a `BREAKING CHANGE: …` footer in the PR body.
 - Squash-merge flow: PR titles must themselves be conventional-commit-shaped so the squash commit lands with the correct type/scope. Enforced by the `Lint PR` workflow.


### PR DESCRIPTION
# Pull Request

PR title rule for squash merges: use the exact commitlint/commitizen format for the PR title so the squash commit can be reused unchanged.

`type: #123 short description`

Examples:

- `docs: #12 add bootstrap skill guide`
- `chore: #34 bootstrap commit hooks`

This title rule applies to pull requests only. GitHub issue titles should stay plain-language and should not use conventional-commit prefixes.

## Summary

- Adds template-first guidance that commit type is based on product impact, not file extension.
- Clarifies that skill contract edits are product/runtime changes by default, not `docs:` changes.
- Documents Release Please bump mapping and warns release-worthy changes not to use non-bumping types.

## Linked issue

- Closes #48

## Acceptance criteria

### AC-48-1

Contributor guidance states that behavior-changing Markdown can require `feat:` or `fix:` rather than `docs:`.

- [x] Repo evidence — rg guidance assertions | local | @codex | 2026-04-27T15:07:31Z
- [ ] Manual test: 1. Open `AGENTS.md` or `CONTRIBUTING.md`. 2. Confirm the Commit type selection guidance classifies behavior-changing Markdown by product impact rather than file extension.

### AC-48-2

Generated guidance directs installed skill behavior, workflow gate, prompt contract, plugin metadata, marketplace, and generated-agent-instruction changes to release-triggering types.

- [x] Repo evidence — rg release-triggering assertions | local | @codex | 2026-04-27T15:07:31Z
- [ ] Manual test: 1. Open `.github/copilot-instructions.md`, `.cursor/rules/bootstrap.mdc`, or `.windsurfrules`. 2. Confirm behavior-changing agent/plugin surfaces must use release-triggering commit types even for Markdown-only diffs.

### AC-48-3

The decision table preserves `docs:` for explanatory-only documentation that does not change shipped behavior or release semantics.

- [x] Repo evidence — rg docs-preservation assertions | local | @codex | 2026-04-27T15:07:31Z
- [ ] Manual test: 1. Open `CONTRIBUTING.md`. 2. Confirm `docs:` remains reserved for explanatory-only changes and is not banned for all Markdown.

### AC-48-4

Release guidance documents bumping commit types, non-bumping types, and the Release Please/marketplace consequence of misclassification.

- [x] Repo evidence — rg Release Please mapping assertions | local | @codex | 2026-04-27T15:07:31Z
- [ ] Manual test: 1. Open `RELEASING.md`. 2. Confirm `fix:` maps to patch, `feat:` maps to minor, `<type>!:` or `BREAKING CHANGE:` maps to major, and `docs:`/`chore:` do not bump versions under the baseline.

## Validation

- [x] `pnpm lint:md`
- [x] `rg -n 'Commit type selection|product/runtime changes by default|must not use non-bumping|release-triggering|diff is Markdown-only' skills/bootstrap/templates AGENTS.md CONTRIBUTING.md README.md .github/copilot-instructions.md .cursor/rules/bootstrap.mdc .windsurfrules`
- [x] `rg -n '<type>!:|no version bump|If a change should produce a release|misclassified as \`docs:\`|marketplace bump' skills/bootstrap/templates/core/RELEASING.md skills/bootstrap/templates/patinaproject-supplement/RELEASING.md RELEASING.md`
- [x] `printf 'feat: bad\n' | pnpm exec commitlint` exits non-zero with `ticket-required`
- [x] `printf 'feat: #1 ok\n' | pnpm exec commitlint`
- [x] `git diff --check origin/main...HEAD`

## Docs updated

- [x] Updated in this PR
