### PR TITLE
ci: #49 add release workflow dispatch escape hatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,13 @@
 name: Release
 
-# Triggered on every push to `main`. release-please is idempotent: on regular
-# feature/fix merges it opens or refreshes the standing release PR; on the
-# release-PR merge it sees the merged PR (label `autorelease: pending`) and
-# cuts the tag, publishes the release, and dispatches the marketplace bump on
-# patinaproject/skills. A single trigger covers both flows. See RELEASING.md.
+# Triggered on every push to `main`, with workflow_dispatch available as a
+# recovery escape hatch. release-please is idempotent: on regular feature/fix
+# merges it opens or refreshes the standing release PR; on the release-PR merge
+# it sees the merged PR (label `autorelease: pending`) and cuts the tag,
+# publishes the release, and dispatches the marketplace bump on
+# patinaproject/skills. Manual dispatch runs the same path. See RELEASING.md.
 on:
+  workflow_dispatch:
   push:
     branches: [main]
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,7 +4,7 @@ Releases are driven by [release-please](https://github.com/googleapis/release-pl
 
 ## How it works
 
-The `Release` workflow runs on every push to `main`. There is no manual dispatch. Cutting a release is the natural by-product of merging PRs:
+The `Release` workflow runs on every push to `main`. Cutting a release is the natural by-product of merging PRs:
 
 1. **Merge any PR into `main`.** The push event runs `Release`. `release-please` scans Conventional Commits since the last tag and opens — or updates — a standing **"chore: release X.Y.Z"** PR that:
 
@@ -16,7 +16,21 @@ The `Release` workflow runs on every push to `main`. There is no manual dispatch
 
 2. **Merge the release PR.** Squash-merging the PR is itself a push to `main`, so `Release` runs again. release-please now sees the merged release PR (still labeled `autorelease: pending`), creates the tag `vX.Y.Z`, publishes the GitHub Release with the Conventional-Commit-derived notes, and (on `patinaproject` plugin repos) dispatches the marketplace bump on `patinaproject/skills`. The PR's label flips to `autorelease: tagged`.
 
-The result: every merge keeps the standing release PR fresh; merging that PR cuts the release. No `gh workflow run` step is ever required.
+The result: every merge keeps the standing release PR fresh; merging that PR cuts the release. No manual step is required during the normal flow.
+
+## Manual recovery dispatch
+
+Manual dispatch is an escape hatch, not the normal release path. Use it only when the latest automatic `Release` run was skipped, cancelled, failed for transient reasons, or needs to be retried after permissions or repository settings were fixed.
+
+Start the same workflow from the GitHub Actions UI, or run:
+
+```bash
+gh workflow run Release
+```
+
+The manual run performs the same release-please evaluation as a push-triggered run. If releasable commits exist, it opens or refreshes the standing release PR. If the release PR has already been merged and the repository state calls for a release, it can cut the tag and GitHub Release. If there is nothing to release, it no-ops.
+
+Do not use manual dispatch as the ordinary release process. Do not perform manual version bumps or local release commands.
 
 ## Prerequisites (one-time settings)
 

--- a/docs/superpowers/plans/2026-04-27-49-allow-manual-dispatch-for-the-release-workflow-escape-hatch-plan.md
+++ b/docs/superpowers/plans/2026-04-27-49-allow-manual-dispatch-for-the-release-workflow-escape-hatch-plan.md
@@ -132,8 +132,8 @@ Do not use manual dispatch as the ordinary release process. Do not perform manua
 Run:
 
 ```bash
-rg -n "There is no manual dispatch|No `gh workflow run` step is ever required" skills/bootstrap/templates/core/RELEASING.md skills/bootstrap/templates/patinaproject-supplement/RELEASING.md
-rg -n "Manual recovery dispatch|gh workflow run Release|escape hatch" skills/bootstrap/templates/core/RELEASING.md skills/bootstrap/templates/patinaproject-supplement/RELEASING.md
+rg -n 'There is no manual dispatch|No `gh workflow run` step is ever required' skills/bootstrap/templates/core/RELEASING.md skills/bootstrap/templates/patinaproject-supplement/RELEASING.md
+rg -n 'Manual recovery dispatch|gh workflow run Release|escape hatch' skills/bootstrap/templates/core/RELEASING.md skills/bootstrap/templates/patinaproject-supplement/RELEASING.md
 ```
 
 Expected: the first command returns no matches; the second command returns the
@@ -146,29 +146,21 @@ new recovery section in both template files.
 - Modify: `.github/workflows/release.yml`
 - Modify: `RELEASING.md`
 
-- [ ] **Step 1: Mirror the Patina Project workflow supplement to root**
+- [ ] **Step 1: Run the local bootstrap realignment loop for root mirrors**
 
-Run:
+Invoke the local `bootstrap` skill against this repository in realignment mode
+after the template edits are complete. Accept the proposed release workflow and
+release-doc root mirror updates for this repository. The accepted mirror updates
+must make root `.github/workflows/release.yml` match
+`skills/bootstrap/templates/patinaproject-supplement/.github/workflows/release.yml`
+and root `RELEASING.md` match
+`skills/bootstrap/templates/patinaproject-supplement/RELEASING.md`.
 
-```bash
-cp skills/bootstrap/templates/patinaproject-supplement/.github/workflows/release.yml .github/workflows/release.yml
-```
+Expected: the realignment loop reports `.github/workflows/release.yml` and
+`RELEASING.md` as root baseline files updated from the Patina Project
+supplement templates.
 
-Expected: root `.github/workflows/release.yml` now matches the supplement
-template byte-for-byte.
-
-- [ ] **Step 2: Mirror the Patina Project release docs to root**
-
-Run:
-
-```bash
-cp skills/bootstrap/templates/patinaproject-supplement/RELEASING.md RELEASING.md
-```
-
-Expected: root `RELEASING.md` now matches the supplement template
-byte-for-byte.
-
-- [ ] **Step 3: Verify root/template parity**
+- [ ] **Step 2: Verify root/template parity**
 
 Run:
 
@@ -212,14 +204,15 @@ Expected: every printed `on:` block contains both `workflow_dispatch:` and
 Run:
 
 ```bash
-rg -n "github.event|event_name|workflow_dispatch" \
+rg -n 'github\.event_name|event_name|if:.*github\.event|workflow_dispatch' \
   skills/bootstrap/templates/agent-plugin/.github/workflows/release.yml \
   skills/bootstrap/templates/patinaproject-supplement/.github/workflows/release.yml \
   .github/workflows/release.yml
 ```
 
 Expected: matches are limited to the `workflow_dispatch:` trigger and comments;
-there are no event-type conditionals such as `github.event_name`.
+there are no event-type conditionals such as `github.event_name` or
+`if: ... github.event...`.
 
 - [ ] **Step 3: Verify AC-49-3 documentation framing**
 

--- a/docs/superpowers/plans/2026-04-27-49-allow-manual-dispatch-for-the-release-workflow-escape-hatch-plan.md
+++ b/docs/superpowers/plans/2026-04-27-49-allow-manual-dispatch-for-the-release-workflow-escape-hatch-plan.md
@@ -1,0 +1,301 @@
+# Allow Manual Dispatch For The Release Workflow Escape Hatch Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `workflow_dispatch` back to the release workflow as a recovery-only escape hatch while keeping push-to-main release automation as the normal path.
+
+**Architecture:** The release workflow remains a single release-please path triggered by either `push` to `main` or manual dispatch. Template files under `skills/bootstrap/templates/**` are edited first, then root mirrors are aligned from those sources so this repository stays self-hosting.
+
+**Tech Stack:** GitHub Actions YAML, release-please-action, Markdown release docs, PNPM markdownlint.
+
+---
+
+Approved design: [`docs/superpowers/specs/2026-04-27-49-allow-manual-dispatch-for-the-release-workflow-escape-hatch-design.md`](../specs/2026-04-27-49-allow-manual-dispatch-for-the-release-workflow-escape-hatch-design.md) at commit `6351ab9fa8d58f155c471fb6327d4a5c78982a67`.
+
+## File Structure
+
+- Modify: `skills/bootstrap/templates/agent-plugin/.github/workflows/release.yml` — base emitted release workflow for plugin repos outside `patinaproject`.
+- Modify: `skills/bootstrap/templates/patinaproject-supplement/.github/workflows/release.yml` — Patina Project release workflow with marketplace notification.
+- Modify: `.github/workflows/release.yml` — root mirror of the Patina Project supplement workflow.
+- Modify: `skills/bootstrap/templates/core/RELEASING.md` — shared release docs emitted to repos.
+- Modify: `skills/bootstrap/templates/patinaproject-supplement/RELEASING.md` — Patina Project release docs with marketplace-distribution wording.
+- Modify: `RELEASING.md` — root mirror of the Patina Project release docs.
+
+## Task T49-1: Add the Manual Trigger To Release Workflow Templates
+
+**Files:**
+
+- Modify: `skills/bootstrap/templates/agent-plugin/.github/workflows/release.yml`
+- Modify: `skills/bootstrap/templates/patinaproject-supplement/.github/workflows/release.yml`
+
+- [ ] **Step 1: Inspect the current trigger blocks**
+
+Run:
+
+```bash
+sed -n '1,24p' skills/bootstrap/templates/agent-plugin/.github/workflows/release.yml
+sed -n '1,24p' skills/bootstrap/templates/patinaproject-supplement/.github/workflows/release.yml
+```
+
+Expected: both files describe push-only release automation and have:
+
+```yaml
+on:
+  push:
+    branches: [main]
+```
+
+- [ ] **Step 2: Update the leading comments and trigger blocks**
+
+Change both template files so the leading comment says the workflow is normally
+triggered by pushes to `main` and can also be manually dispatched as a recovery
+escape hatch. The trigger block in both files must become:
+
+```yaml
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+```
+
+Keep every job, permission, action SHA, and `with:` value unchanged.
+
+- [ ] **Step 3: Verify the template trigger blocks**
+
+Run:
+
+```bash
+sed -n '1,18p' skills/bootstrap/templates/agent-plugin/.github/workflows/release.yml
+sed -n '1,18p' skills/bootstrap/templates/patinaproject-supplement/.github/workflows/release.yml
+```
+
+Expected: each file includes `workflow_dispatch:` immediately under `on:` and
+still includes `push` with `branches: [main]`.
+
+## Task T49-2: Document Manual Dispatch As Recovery Only
+
+**Files:**
+
+- Modify: `skills/bootstrap/templates/core/RELEASING.md`
+- Modify: `skills/bootstrap/templates/patinaproject-supplement/RELEASING.md`
+
+- [ ] **Step 1: Replace push-only wording in both release-doc templates**
+
+In both files, replace the sentence:
+
+```markdown
+The `Release` workflow runs on every push to `main`. There is no manual dispatch. Cutting a release is the natural by-product of merging PRs:
+```
+
+with:
+
+```markdown
+The `Release` workflow runs on every push to `main`. Cutting a release is the natural by-product of merging PRs:
+```
+
+- [ ] **Step 2: Replace the no-manual-run conclusion**
+
+In both files, replace:
+
+```markdown
+The result: every merge keeps the standing release PR fresh; merging that PR cuts the release. No `gh workflow run` step is ever required.
+```
+
+with:
+
+```markdown
+The result: every merge keeps the standing release PR fresh; merging that PR cuts the release. No manual step is required during the normal flow.
+```
+
+- [ ] **Step 3: Add a recovery section after the flow explanation**
+
+Add this section in both files immediately after the paragraph from Step 2:
+
+````markdown
+## Manual recovery dispatch
+
+Manual dispatch is an escape hatch, not the normal release path. Use it only when the latest automatic `Release` run was skipped, cancelled, failed for transient reasons, or needs to be retried after permissions or repository settings were fixed.
+
+Start the same workflow from the GitHub Actions UI, or run:
+
+```bash
+gh workflow run Release
+```
+
+The manual run performs the same release-please evaluation as a push-triggered run. If releasable commits exist, it opens or refreshes the standing release PR. If the release PR has already been merged and the repository state calls for a release, it can cut the tag and GitHub Release. If there is nothing to release, it no-ops.
+
+Do not use manual dispatch as the ordinary release process. Do not perform manual version bumps or local release commands.
+````
+
+- [ ] **Step 4: Verify recovery wording**
+
+Run:
+
+```bash
+rg -n "There is no manual dispatch|No `gh workflow run` step is ever required" skills/bootstrap/templates/core/RELEASING.md skills/bootstrap/templates/patinaproject-supplement/RELEASING.md
+rg -n "Manual recovery dispatch|gh workflow run Release|escape hatch" skills/bootstrap/templates/core/RELEASING.md skills/bootstrap/templates/patinaproject-supplement/RELEASING.md
+```
+
+Expected: the first command returns no matches; the second command returns the
+new recovery section in both template files.
+
+## Task T49-3: Mirror Template Changes Into Root Files
+
+**Files:**
+
+- Modify: `.github/workflows/release.yml`
+- Modify: `RELEASING.md`
+
+- [ ] **Step 1: Mirror the Patina Project workflow supplement to root**
+
+Run:
+
+```bash
+cp skills/bootstrap/templates/patinaproject-supplement/.github/workflows/release.yml .github/workflows/release.yml
+```
+
+Expected: root `.github/workflows/release.yml` now matches the supplement
+template byte-for-byte.
+
+- [ ] **Step 2: Mirror the Patina Project release docs to root**
+
+Run:
+
+```bash
+cp skills/bootstrap/templates/patinaproject-supplement/RELEASING.md RELEASING.md
+```
+
+Expected: root `RELEASING.md` now matches the supplement template
+byte-for-byte.
+
+- [ ] **Step 3: Verify root/template parity**
+
+Run:
+
+```bash
+diff -u skills/bootstrap/templates/patinaproject-supplement/.github/workflows/release.yml .github/workflows/release.yml
+diff -u skills/bootstrap/templates/patinaproject-supplement/RELEASING.md RELEASING.md
+```
+
+Expected: both commands produce no output and exit zero.
+
+## Task T49-4: Run Acceptance Verification And Commit Implementation
+
+**Files:**
+
+- Verify: `skills/bootstrap/templates/agent-plugin/.github/workflows/release.yml`
+- Verify: `skills/bootstrap/templates/patinaproject-supplement/.github/workflows/release.yml`
+- Verify: `.github/workflows/release.yml`
+- Verify: `skills/bootstrap/templates/core/RELEASING.md`
+- Verify: `skills/bootstrap/templates/patinaproject-supplement/RELEASING.md`
+- Verify: `RELEASING.md`
+
+- [ ] **Step 1: Verify AC-49-1 trigger coverage**
+
+Run:
+
+```bash
+for file in \
+  skills/bootstrap/templates/agent-plugin/.github/workflows/release.yml \
+  skills/bootstrap/templates/patinaproject-supplement/.github/workflows/release.yml \
+  .github/workflows/release.yml; do
+  printf '%s\n' "$file"
+  sed -n '/^on:/,/^permissions:/p' "$file"
+done
+```
+
+Expected: every printed `on:` block contains both `workflow_dispatch:` and
+`push: branches: [main]`.
+
+- [ ] **Step 2: Verify AC-49-2 same-path behavior**
+
+Run:
+
+```bash
+rg -n "github.event|event_name|workflow_dispatch" \
+  skills/bootstrap/templates/agent-plugin/.github/workflows/release.yml \
+  skills/bootstrap/templates/patinaproject-supplement/.github/workflows/release.yml \
+  .github/workflows/release.yml
+```
+
+Expected: matches are limited to the `workflow_dispatch:` trigger and comments;
+there are no event-type conditionals such as `github.event_name`.
+
+- [ ] **Step 3: Verify AC-49-3 documentation framing**
+
+Run:
+
+```bash
+rg -n "Manual recovery dispatch|escape hatch|ordinary release process|normal flow" \
+  skills/bootstrap/templates/core/RELEASING.md \
+  skills/bootstrap/templates/patinaproject-supplement/RELEASING.md \
+  RELEASING.md
+```
+
+Expected: all three files describe manual dispatch as an escape hatch and keep
+normal releases push-driven.
+
+- [ ] **Step 4: Verify AC-49-4 template/root round-trip**
+
+Run:
+
+```bash
+diff -u skills/bootstrap/templates/patinaproject-supplement/.github/workflows/release.yml .github/workflows/release.yml
+diff -u skills/bootstrap/templates/patinaproject-supplement/RELEASING.md RELEASING.md
+```
+
+Expected: both commands produce no output and exit zero.
+
+- [ ] **Step 5: Run repository markdown lint**
+
+Run:
+
+```bash
+pnpm lint:md
+```
+
+Expected: exits zero with no markdownlint errors.
+
+- [ ] **Step 6: Run release workflow syntax check if available**
+
+Run:
+
+```bash
+command -v actionlint
+```
+
+Expected: if `actionlint` is installed, run:
+
+```bash
+actionlint .github/workflows/release.yml
+actionlint skills/bootstrap/templates/agent-plugin/.github/workflows/release.yml
+actionlint skills/bootstrap/templates/patinaproject-supplement/.github/workflows/release.yml
+```
+
+If `actionlint` is not installed, record `actionlint not installed` in the
+Executor verification report and rely on the trigger-block and diff checks.
+
+- [ ] **Step 7: Commit implementation**
+
+Run:
+
+```bash
+git add \
+  skills/bootstrap/templates/agent-plugin/.github/workflows/release.yml \
+  skills/bootstrap/templates/patinaproject-supplement/.github/workflows/release.yml \
+  .github/workflows/release.yml \
+  skills/bootstrap/templates/core/RELEASING.md \
+  skills/bootstrap/templates/patinaproject-supplement/RELEASING.md \
+  RELEASING.md
+git commit -m "ci: #49 add release workflow dispatch escape hatch"
+```
+
+Expected: commit succeeds, with Husky pre-commit checks passing.
+
+## Plan Self-Review
+
+- Spec coverage: T49-1 covers R1, R2, R3, AC-49-1, and AC-49-2. T49-2 covers
+  R4 and AC-49-3. T49-3 covers R5 and AC-49-4. T49-4 verifies all acceptance
+  criteria and commits the implementation.
+- Placeholder scan: no incomplete markers or unspecified implementation steps.
+- Scope check: one cohesive workflow/docs change; no decomposition needed.

--- a/docs/superpowers/specs/2026-04-27-49-allow-manual-dispatch-for-the-release-workflow-escape-hatch-design.md
+++ b/docs/superpowers/specs/2026-04-27-49-allow-manual-dispatch-for-the-release-workflow-escape-hatch-design.md
@@ -1,0 +1,115 @@
+# Design: Allow manual dispatch for the release workflow escape hatch [#49](https://github.com/patinaproject/bootstrap/issues/49)
+
+## Context
+
+Issue [#42](https://github.com/patinaproject/bootstrap/issues/42) changed the
+release flow from manual-dispatch-driven to `push`-driven. That removed the
+normal maintainer ritual: merging any PR to `main` refreshes the standing
+release PR, and merging the release PR cuts the tag and GitHub Release.
+
+That remains the right default. The missing piece is a recovery path. If a
+`Release` run is skipped, cancelled, transiently broken, or needs to be retried
+after a settings fix, maintainers currently need a no-op commit or unrelated
+merge just to make release-please evaluate the repository again.
+
+## Approaches considered
+
+1. **Recommended: add `workflow_dispatch` beside `push`.** Keep `push` to
+   `main` as the normal path, and allow maintainers to start the same workflow
+   manually when recovery requires it. This is the smallest change and relies on
+   release-please's existing idempotence.
+2. **Keep push-only and document no-op commits as recovery.** This preserves the
+   current trigger shape but makes recovery noisy and trains maintainers to
+   create commits with no product value.
+3. **Add a separate recovery workflow.** This keeps the release workflow
+   conceptually pure, but duplicates release-please configuration and increases
+   the chance that normal and recovery behavior drift.
+
+## Decision
+
+Add `workflow_dispatch` to the existing `Release` workflow `on:` block while
+leaving `push: branches: [main]` in place.
+
+Target trigger shape:
+
+```yaml
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+```
+
+The release job should not branch on event type. Manual dispatch is an escape
+hatch that runs the same release-please evaluation as the automatic path:
+
+- On ordinary unreleased commits, release-please opens or refreshes the standing
+  release PR.
+- After the standing release PR has been merged, release-please can cut the tag
+  and GitHub Release if the repository state calls for it.
+- If there is nothing to release, the run no-ops.
+
+This applies to all three release workflow surfaces:
+
+- `.github/workflows/release.yml`
+- `skills/bootstrap/templates/agent-plugin/.github/workflows/release.yml`
+- `skills/bootstrap/templates/patinaproject-supplement/.github/workflows/release.yml`
+
+Because `.github/workflows/release.yml` and `RELEASING.md` are baseline-managed,
+the implementation must edit the templates first and then mirror the repo-root
+files through the local bootstrap realignment workflow.
+
+## Documentation
+
+`RELEASING.md` should continue to describe push-triggered release automation as
+the normal path. It should no longer say that there is no manual dispatch or
+that no `gh workflow run` step is ever required.
+
+Add a short recovery section that frames manual dispatch as an escape hatch:
+
+- Use it when the latest automatic `Release` run was skipped, cancelled, failed
+  for transient reasons, or needs a retry after permissions/settings were fixed.
+- Run the same `Release` workflow manually with `gh workflow run Release` or
+  the GitHub Actions UI.
+- Do not use it as the ordinary release path, and do not perform manual version
+  bumps or local release commands.
+
+The core and patinaproject supplement release docs should remain aligned except
+for existing distribution-specific wording.
+
+## Requirements
+
+- R1: The release workflow keeps `push` to `main` as the normal automatic
+  trigger.
+- R2: The release workflow also exposes `workflow_dispatch` for maintainer
+  retry/recovery.
+- R3: Manual dispatch runs the same release-please job path as `push`; no
+  event-specific release behavior or semver input is added.
+- R4: Release documentation presents manual dispatch only as an escape hatch,
+  not as a required release step.
+- R5: Baseline round-trip is preserved: template changes are mirrored into the
+  repo-root workflow and docs through the local bootstrap realignment loop.
+
+## Acceptance criteria
+
+- AC-49-1: Given the release workflow file is inspected, when the `on:` block is read, then it includes both `push` for `main` and `workflow_dispatch`.
+- AC-49-2: Given a maintainer manually dispatches `Release`, when release-please runs, then it performs the same idempotent release evaluation used by the push-triggered path.
+- AC-49-3: Given a maintainer reads `RELEASING.md`, when they look for manual release instructions, then manual dispatch is documented only as an escape hatch for retry/recovery, not as the normal release path.
+- AC-49-4: Given this repository is realigned from the bootstrap templates, when the root workflow and docs are compared to their template sources, then the manual-dispatch escape hatch is present in both places.
+
+## Non-goals
+
+- Restoring a manual-first release ritual.
+- Adding release type inputs, semver selection, or manual version bumps.
+- Replacing release-please.
+- Changing the `notify-patinaproject-skills` marketplace-dispatch job behavior.
+- Changing release-please permissions, labels, changelog generation, or token
+  fallback guidance beyond wording needed for the new escape hatch.
+
+## Risks
+
+- Maintainers may read `workflow_dispatch` as the preferred path again. Mitigate
+  this by keeping the release docs centered on automatic `push` behavior and
+  naming manual dispatch only in recovery language.
+- Manual dispatch can be run repeatedly. This is acceptable because
+  release-please is idempotent; repeated no-op runs are noisy but not
+  state-changing.

--- a/skills/bootstrap/templates/agent-plugin/.github/workflows/release.yml
+++ b/skills/bootstrap/templates/agent-plugin/.github/workflows/release.yml
@@ -1,11 +1,13 @@
 name: Release
 
-# Triggered on every push to `main`. release-please is idempotent: on regular
-# feature/fix merges it opens or refreshes the standing release PR; on the
-# release-PR merge it sees the merged PR (label `autorelease: pending`) and
-# cuts the tag, publishes the release, and dispatches downstream notifications.
-# A single trigger covers both flows. See RELEASING.md.
+# Triggered on every push to `main`, with workflow_dispatch available as a
+# recovery escape hatch. release-please is idempotent: on regular feature/fix
+# merges it opens or refreshes the standing release PR; on the release-PR merge
+# it sees the merged PR (label `autorelease: pending`) and cuts the tag,
+# publishes the release, and dispatches downstream notifications. Manual
+# dispatch runs the same path. See RELEASING.md.
 on:
+  workflow_dispatch:
   push:
     branches: [main]
 

--- a/skills/bootstrap/templates/core/RELEASING.md
+++ b/skills/bootstrap/templates/core/RELEASING.md
@@ -4,7 +4,7 @@ Releases are driven by [release-please](https://github.com/googleapis/release-pl
 
 ## How it works
 
-The `Release` workflow runs on every push to `main`. There is no manual dispatch. Cutting a release is the natural by-product of merging PRs:
+The `Release` workflow runs on every push to `main`. Cutting a release is the natural by-product of merging PRs:
 
 1. **Merge any PR into `main`.** The push event runs `Release`. `release-please` scans Conventional Commits since the last tag and opens — or updates — a standing **"chore: release X.Y.Z"** PR that:
 
@@ -16,7 +16,21 @@ The `Release` workflow runs on every push to `main`. There is no manual dispatch
 
 2. **Merge the release PR.** Squash-merging the PR is itself a push to `main`, so `Release` runs again. release-please now sees the merged release PR (still labeled `autorelease: pending`), creates the tag `vX.Y.Z`, publishes the GitHub Release with the Conventional-Commit-derived notes, and (when configured) dispatches the marketplace bump. The PR's label flips to `autorelease: tagged`.
 
-The result: every merge keeps the standing release PR fresh; merging that PR cuts the release. No `gh workflow run` step is ever required.
+The result: every merge keeps the standing release PR fresh; merging that PR cuts the release. No manual step is required during the normal flow.
+
+## Manual recovery dispatch
+
+Manual dispatch is an escape hatch, not the normal release path. Use it only when the latest automatic `Release` run was skipped, cancelled, failed for transient reasons, or needs to be retried after permissions or repository settings were fixed.
+
+Start the same workflow from the GitHub Actions UI, or run:
+
+```bash
+gh workflow run Release
+```
+
+The manual run performs the same release-please evaluation as a push-triggered run. If releasable commits exist, it opens or refreshes the standing release PR. If the release PR has already been merged and the repository state calls for a release, it can cut the tag and GitHub Release. If there is nothing to release, it no-ops.
+
+Do not use manual dispatch as the ordinary release process. Do not perform manual version bumps or local release commands.
 
 ## Prerequisites (one-time settings)
 

--- a/skills/bootstrap/templates/patinaproject-supplement/.github/workflows/release.yml
+++ b/skills/bootstrap/templates/patinaproject-supplement/.github/workflows/release.yml
@@ -1,11 +1,13 @@
 name: Release
 
-# Triggered on every push to `main`. release-please is idempotent: on regular
-# feature/fix merges it opens or refreshes the standing release PR; on the
-# release-PR merge it sees the merged PR (label `autorelease: pending`) and
-# cuts the tag, publishes the release, and dispatches the marketplace bump on
-# patinaproject/skills. A single trigger covers both flows. See RELEASING.md.
+# Triggered on every push to `main`, with workflow_dispatch available as a
+# recovery escape hatch. release-please is idempotent: on regular feature/fix
+# merges it opens or refreshes the standing release PR; on the release-PR merge
+# it sees the merged PR (label `autorelease: pending`) and cuts the tag,
+# publishes the release, and dispatches the marketplace bump on
+# patinaproject/skills. Manual dispatch runs the same path. See RELEASING.md.
 on:
+  workflow_dispatch:
   push:
     branches: [main]
 

--- a/skills/bootstrap/templates/patinaproject-supplement/RELEASING.md
+++ b/skills/bootstrap/templates/patinaproject-supplement/RELEASING.md
@@ -4,7 +4,7 @@ Releases are driven by [release-please](https://github.com/googleapis/release-pl
 
 ## How it works
 
-The `Release` workflow runs on every push to `main`. There is no manual dispatch. Cutting a release is the natural by-product of merging PRs:
+The `Release` workflow runs on every push to `main`. Cutting a release is the natural by-product of merging PRs:
 
 1. **Merge any PR into `main`.** The push event runs `Release`. `release-please` scans Conventional Commits since the last tag and opens — or updates — a standing **"chore: release X.Y.Z"** PR that:
 
@@ -16,7 +16,21 @@ The `Release` workflow runs on every push to `main`. There is no manual dispatch
 
 2. **Merge the release PR.** Squash-merging the PR is itself a push to `main`, so `Release` runs again. release-please now sees the merged release PR (still labeled `autorelease: pending`), creates the tag `vX.Y.Z`, publishes the GitHub Release with the Conventional-Commit-derived notes, and (on `patinaproject` plugin repos) dispatches the marketplace bump on `patinaproject/skills`. The PR's label flips to `autorelease: tagged`.
 
-The result: every merge keeps the standing release PR fresh; merging that PR cuts the release. No `gh workflow run` step is ever required.
+The result: every merge keeps the standing release PR fresh; merging that PR cuts the release. No manual step is required during the normal flow.
+
+## Manual recovery dispatch
+
+Manual dispatch is an escape hatch, not the normal release path. Use it only when the latest automatic `Release` run was skipped, cancelled, failed for transient reasons, or needs to be retried after permissions or repository settings were fixed.
+
+Start the same workflow from the GitHub Actions UI, or run:
+
+```bash
+gh workflow run Release
+```
+
+The manual run performs the same release-please evaluation as a push-triggered run. If releasable commits exist, it opens or refreshes the standing release PR. If the release PR has already been merged and the repository state calls for a release, it can cut the tag and GitHub Release. If there is nothing to release, it no-ops.
+
+Do not use manual dispatch as the ordinary release process. Do not perform manual version bumps or local release commands.
 
 ## Prerequisites (one-time settings)
 


### PR DESCRIPTION
## Summary

- Add `workflow_dispatch` to the release workflow templates while keeping `push` to `main` as the normal trigger.
- Document manual release dispatch as a retry/recovery escape hatch, not the ordinary release path.
- Mirror the Patina Project supplement workflow/docs into the repo root and add the #49 design + plan artifacts.

## Linked issue

- Closes #49

## Acceptance criteria

### AC-49-1

Release workflow `on:` blocks include both `workflow_dispatch` and `push` for `main` across the root workflow and both template workflows.

- [x] Static evidence — `sed -n '/^on:/,/^permissions:/p'` on `.github/workflows/release.yml`, `skills/bootstrap/templates/agent-plugin/.github/workflows/release.yml`, and `skills/bootstrap/templates/patinaproject-supplement/.github/workflows/release.yml` | local zsh | @tlmader | 2026-04-27T15:07:47Z
- [x] Syntax evidence — `actionlint .github/workflows/release.yml skills/bootstrap/templates/agent-plugin/.github/workflows/release.yml skills/bootstrap/templates/patinaproject-supplement/.github/workflows/release.yml` | local zsh | @tlmader | 2026-04-27T15:07:47Z

### AC-49-2

Manual dispatch runs the same release-please path as push-triggered runs; no event-specific release branch or semver input was added.

- [x] Static evidence — `rg -n 'github\.event_name|event_name|if:.*github\.event|workflow_dispatch' ...` returned only workflow-dispatch trigger/comment matches | local zsh | @tlmader | 2026-04-27T15:07:47Z
- [ ] ⚠️ E2E gap: A live GitHub Actions manual dispatch was not run from this branch; release-please behavior is verified structurally.
- [ ] Manual test: 1. Open Actions → Release on this branch or after merge. 2. Run workflow manually. 3. Confirm the run reaches the same release-please step path as a push-triggered run and either refreshes the release PR, cuts an eligible release, or no-ops when there is nothing to release.

### AC-49-3

`RELEASING.md` now frames manual dispatch only as a recovery escape hatch while keeping normal releases push-driven.

- [x] Documentation evidence — `rg -n 'Manual recovery dispatch|escape hatch|ordinary release process|normal flow' skills/bootstrap/templates/core/RELEASING.md skills/bootstrap/templates/patinaproject-supplement/RELEASING.md RELEASING.md` | local zsh | @tlmader | 2026-04-27T15:07:47Z
- [x] Regression evidence — `rg -n 'There is no manual dispatch|No \`gh workflow run\` step is ever required' ...` returned no matches | local zsh | @tlmader | 2026-04-27T15:07:47Z

### AC-49-4

Root workflow/docs mirror the Patina Project supplement templates after the template-first update.

- [x] Parity evidence — `diff -u skills/bootstrap/templates/patinaproject-supplement/.github/workflows/release.yml .github/workflows/release.yml` and `diff -u skills/bootstrap/templates/patinaproject-supplement/RELEASING.md RELEASING.md` | local zsh | @tlmader | 2026-04-27T15:07:47Z
- [x] Review evidence — local Reviewer re-check closed the realignment-loop plan finding after the plan was updated to require the local bootstrap realignment loop | superteam Reviewer | @tlmader | 2026-04-27T15:07:47Z

## Validation

- `pnpm lint:md`
- `git diff --check origin/main..HEAD`
- `actionlint .github/workflows/release.yml skills/bootstrap/templates/agent-plugin/.github/workflows/release.yml skills/bootstrap/templates/patinaproject-supplement/.github/workflows/release.yml`
- `diff -u skills/bootstrap/templates/patinaproject-supplement/.github/workflows/release.yml .github/workflows/release.yml`
- `diff -u skills/bootstrap/templates/patinaproject-supplement/RELEASING.md RELEASING.md`

## Docs updated

- [x] Updated in this PR
