### PR TITLE
feat: #54 sharpen commit-type guidance for product surfaces

### DIFF
--- a/.cursor/rules/bootstrap.mdc
+++ b/.cursor/rules/bootstrap.mdc
@@ -11,7 +11,24 @@ Key rules:
 
 - Commits use Conventional Commits with no scope and a required GitHub issue tag: `type: #123 short description`. Subject ≤ 72 chars.
 - PR titles match the commit format.
-- Behavior-changing skill, workflow, prompt, plugin metadata, marketplace, and generated-agent-instruction changes must use release-triggering commit types even when the diff is Markdown-only.
 - Markdown must pass `markdownlint-cli2` with `.markdownlint.jsonc` rules.
 - Skills live under `skills/`, one directory per skill, `SKILL.md` as the main contract.
 - Agent plugin surfaces at the repo root: `.claude-plugin/`, `.codex-plugin/`, `.cursor/`, `.windsurfrules`, `.github/copilot-instructions.md`.
+
+### Commit type — path-first rule
+
+If any file in the diff is under one of these globs, the commit type is `feat:` or `fix:` — never `docs:` or `chore:`:
+
+- `skills/**`
+- `skills/bootstrap/templates/**`
+- `.claude-plugin/**`, `.codex-plugin/**`
+- `.cursor/**`, `.windsurfrules`, `.github/copilot-instructions.md`
+- `.github/workflows/**`, `.github/ISSUE_TEMPLATE/**`, `.github/pull_request_template.md`, `.github/LABELS.md`
+- `AGENTS.md`, `AGENTS.md.tmpl`, `CONTRIBUTING.md`, `CONTRIBUTING.md.tmpl`, `RELEASING.md`, `RELEASING.md.tmpl`
+
+Example — wording standardization across plugin manifests, skill bodies, and templates:
+
+- WRONG: `docs: #46 standardize Patina Project name`
+- RIGHT: `feat: #46 standardize Patina Project name across product surfaces`
+
+Full rationalization table and red flags: see [`AGENTS.md` "Commit type selection"](/AGENTS.md#commit-type-selection).

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,6 +6,23 @@ Highlights:
 
 - Commits use Conventional Commits with no scope and a required GitHub issue tag: `type: #123 short description`.
 - PR titles match the commit format so squash merges reuse them verbatim.
-- Behavior-changing skill, workflow, prompt, plugin metadata, marketplace, and generated-agent-instruction changes must use release-triggering commit types even when the diff is Markdown-only.
 - Markdown is linted with `markdownlint-cli2` via a husky `pre-commit` hook.
 - Skills live under `skills/`, one directory per skill, with `SKILL.md` as the main contract.
+
+## Commit type — path-first rule
+
+If any file in the diff is under one of these globs, the commit type is `feat:` or `fix:` — never `docs:` or `chore:`:
+
+- `skills/**`
+- `skills/bootstrap/templates/**`
+- `.claude-plugin/**`, `.codex-plugin/**`
+- `.cursor/**`, `.windsurfrules`, `.github/copilot-instructions.md`
+- `.github/workflows/**`, `.github/ISSUE_TEMPLATE/**`, `.github/pull_request_template.md`, `.github/LABELS.md`
+- `AGENTS.md`, `AGENTS.md.tmpl`, `CONTRIBUTING.md`, `CONTRIBUTING.md.tmpl`, `RELEASING.md`, `RELEASING.md.tmpl`
+
+Example — wording standardization across plugin manifests, skill bodies, and templates:
+
+- WRONG: `docs: #46 standardize Patina Project name`
+- RIGHT: `feat: #46 standardize Patina Project name across product surfaces`
+
+Full rationalization table and red flags: see [`AGENTS.md` "Commit type selection"](../AGENTS.md#commit-type-selection).

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -6,6 +6,23 @@ Key rules:
 
 - Commits use Conventional Commits with no scope and a required GitHub issue tag: `type: #123 short description`. Subject ≤ 72 chars.
 - PR titles match the commit format.
-- Behavior-changing skill, workflow, prompt, plugin metadata, marketplace, and generated-agent-instruction changes must use release-triggering commit types even when the diff is Markdown-only.
 - Markdown must pass `markdownlint-cli2` with `.markdownlint.jsonc` rules.
 - Skills live under `skills/`, one directory per skill, `SKILL.md` as the main contract.
+
+## Commit type — path-first rule
+
+If any file in the diff is under one of these globs, the commit type is `feat:` or `fix:` — never `docs:` or `chore:`:
+
+- `skills/**`
+- `skills/bootstrap/templates/**`
+- `.claude-plugin/**`, `.codex-plugin/**`
+- `.cursor/**`, `.windsurfrules`, `.github/copilot-instructions.md`
+- `.github/workflows/**`, `.github/ISSUE_TEMPLATE/**`, `.github/pull_request_template.md`, `.github/LABELS.md`
+- `AGENTS.md`, `AGENTS.md.tmpl`, `CONTRIBUTING.md`, `CONTRIBUTING.md.tmpl`, `RELEASING.md`, `RELEASING.md.tmpl`
+
+Example — wording standardization across plugin manifests, skill bodies, and templates:
+
+- WRONG: `docs: #46 standardize Patina Project name`
+- RIGHT: `feat: #46 standardize Patina Project name across product surfaces`
+
+Full rationalization table and red flags: see [`AGENTS.md` "Commit type selection"](AGENTS.md#commit-type-selection).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,18 +151,64 @@ Scopes like `feat(repo): ...` are rejected. Keep the subject within 72 character
 
 ### Commit type selection
 
-Choose the commit type by product impact, not by file extension.
+Pick the commit type by **path**, not by file extension or self-judged "intent". If any file in the diff matches one of the product-surface globs below, the commit type is `feat:` or `fix:` — never `docs:` or `chore:`.
+
+**Product-surface globs:**
+
+- `skills/**`
+- `skills/bootstrap/templates/**`
+- `.claude-plugin/**`, `.codex-plugin/**`
+- `.cursor/**`, `.windsurfrules`, `.github/copilot-instructions.md`
+- `.github/workflows/**`, `.github/ISSUE_TEMPLATE/**`, `.github/pull_request_template.md`, `.github/LABELS.md`
+- `AGENTS.md`, `AGENTS.md.tmpl`, `CONTRIBUTING.md`, `CONTRIBUTING.md.tmpl`, `RELEASING.md`, `RELEASING.md.tmpl`
+
+**Path-first rule:** If any file in the diff is under one of these globs, the commit type is `feat:` or `fix:` — never `docs:` or `chore:`. `docs:` and `chore:` apply if and only if the diff touches **zero** product-surface globs. There is no "explanatory-only" exception, no PR-body call-out, no reviewer override.
+
+The type table below is for reference once the path test has resolved to `feat:` / `fix:` (additive vs. corrective) or — when no product-surface glob is touched — to `docs:` / `chore:`.
 
 | Change | Type |
 |--------|------|
 | Adds or changes shipped behavior, including behavior expressed in Markdown skill files, workflow gates, prompt contracts, plugin metadata, marketplace behavior, generated agent instructions, or other user-visible configuration | `feat:` |
 | Corrects broken shipped behavior in those same product surfaces | `fix:` |
-| Explains the product without changing shipped behavior or release semantics | `docs:` |
-| Performs maintenance that does not alter user-facing behavior | `chore:` |
-
-Edits to `skills/**/SKILL.md` and adjacent skill workflow contracts are product/runtime changes by default, not documentation edits. Use `docs:` for those files only when the change is clearly explanatory-only and does not alter installed skill behavior.
+| Explains the product without changing shipped behavior or release semantics, and touches zero product-surface globs | `docs:` |
+| Performs maintenance that does not alter user-facing behavior, and touches zero product-surface globs | `chore:` |
 
 Changes that should produce a release must not use non-bumping types such as `docs:` or `chore:`. Use the release-triggering type that matches the product impact.
+
+#### Rationalizations the path-first rule overrides
+
+| Rationalization | Reality |
+|-----------------|---------|
+| "It's just Markdown." | Markdown on `skills/**`, plugin manifests, or agent-instruction surfaces is the shipped product. Type by path, not by file extension. |
+| "I'm only aligning wording with the source of truth." | If the source of truth is itself a product surface (skill, template, agent instruction), wording IS behavior. Use `feat:`. |
+| "It's just a template change." | Templates under `skills/bootstrap/templates/**` ship to every bootstrapped repo on the next realignment. They are product. Use `feat:` / `fix:`. |
+| "I'm only adding a non-goal or an example to a skill." | Examples and non-goals on a `SKILL.md` change how the skill is interpreted by agents. Product. `feat:`. |
+| "I'm fixing a typo in a skill body." | Path-only rule: any edit inside `skills/**`, `.claude-plugin/**`, `.codex-plugin/**`, `.cursor/**`, `.windsurfrules`, or `.github/copilot-instructions.md` is `fix:` when correcting wrong shipped content and `feat:` when adding or changing shipped content. Do not assess "whether it affects how the skill is read" — the path test already settled it. `chore:` is only available when the diff touches zero product-surface globs. |
+| "It's a plugin manifest version bump." | Release-please owns version bumps under `chore: release X.Y.Z`. Hand-editing a manifest version outside that flow is a `fix:` (lockstep correction) or a release-PR commit, never `docs:`. Other manifest edits (description, homepage, keywords) are `feat:` because they change marketplace-visible product. |
+| "I'm rewording an agent instruction." | Agent instructions ARE the contract. `feat:`. |
+| "It's a markdown-lint cleanup with no semantic change." | Allowed as `chore:` only if zero product-surface globs are touched. If any product-surface glob is touched, `feat:` (or `fix:` if the lint fix corrected wrong shipped content). |
+| "The change is too small to bump a version." | Version magnitude is release-please's job. Type by intent. Small `feat:` is fine. |
+
+#### Red flags
+
+> **STOP and reconsider if any of these are true:**
+>
+> - You are about to commit `docs:` or `chore:` but `git diff --name-only` shows a file under `skills/**`, `.claude-plugin/**`, `.codex-plugin/**`, `.cursor/**`, `.windsurfrules`, `.github/copilot-instructions.md`, `.github/workflows/**`, `.github/ISSUE_TEMPLATE/**`, `.github/pull_request_template.md`, `.github/LABELS.md`, `AGENTS.md`, `AGENTS.md.tmpl`, `CONTRIBUTING.md`, `CONTRIBUTING.md.tmpl`, `RELEASING.md`, or `RELEASING.md.tmpl`.
+> - Your commit message says "align", "standardize", "clarify", "rename", "rewrite", or "rework" AND the diff touches a product-surface glob.
+> - You are using `docs:` or `chore:` for any change to `AGENTS.md`, `AGENTS.md.tmpl`, `CONTRIBUTING.md`, `CONTRIBUTING.md.tmpl`, `RELEASING.md`, or `RELEASING.md.tmpl`. These files are agent-facing and contributor-facing contracts — every edit is `feat:` or `fix:`.
+
+#### Worked example (WRONG → RIGHT)
+
+A historical commit on this repository touched a plugin manifest, a skill body, and three templates in one go to standardize wording. It was typed `docs:`, which suppressed a release.
+
+- WRONG: `docs: #46 standardize Patina Project name`
+- RIGHT: `feat: #46 standardize Patina Project name across product surfaces`
+
+The verb "standardize" combined with a diff under `skills/**` and `.codex-plugin/**` is a path-first `feat:` — no judgement call required.
+
+#### Round-trip discipline
+
+On this repo the canonical "Commit type selection" section is shipped through `skills/bootstrap/templates/core/AGENTS.md.tmpl` and round-tripped to root `AGENTS.md` via the `bootstrap` skill in realignment mode. Mistyped commits silently suppress releases — see [`RELEASING.md`](RELEASING.md) for the release-please semver mapping. The AC-54-7 parity grep (a one-liner that checks every per-tool surface for the verbatim glob list) is the verification artifact.
 
 Pull requests should include a short summary, linked issue, validation notes, and any updated docs when structure or workflow changes.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,18 +23,29 @@ Examples:
 - `feat: #42 add audit mode`
 - `docs: #17 clarify install steps`
 
-Choose the commit type by product impact, not by file extension.
+Pick the commit type by **path**, not by file extension. If any file in the diff matches one of the product-surface globs below, the commit type is `feat:` or `fix:` — never `docs:` or `chore:`.
+
+**Product-surface globs:**
+
+- `skills/**`
+- `skills/bootstrap/templates/**`
+- `.claude-plugin/**`, `.codex-plugin/**`
+- `.cursor/**`, `.windsurfrules`, `.github/copilot-instructions.md`
+- `.github/workflows/**`, `.github/ISSUE_TEMPLATE/**`, `.github/pull_request_template.md`, `.github/LABELS.md`
+- `AGENTS.md`, `AGENTS.md.tmpl`, `CONTRIBUTING.md`, `CONTRIBUTING.md.tmpl`, `RELEASING.md`, `RELEASING.md.tmpl`
+
+**Path-first rule:** If any file in the diff is under one of these globs, the commit type is `feat:` or `fix:` — never `docs:` or `chore:`. `docs:` and `chore:` apply if and only if the diff touches **zero** product-surface globs.
 
 | Change | Type |
 |--------|------|
 | Adds or changes shipped behavior, including behavior expressed in Markdown skill files, workflow gates, prompt contracts, plugin metadata, marketplace behavior, generated agent instructions, or other user-visible configuration | `feat:` |
 | Corrects broken shipped behavior in those same product surfaces | `fix:` |
-| Explains the product without changing shipped behavior or release semantics | `docs:` |
-| Performs maintenance that does not alter user-facing behavior | `chore:` |
-
-Edits to `skills/**/SKILL.md` and adjacent skill workflow contracts are product/runtime changes by default, not documentation edits. Use `docs:` for those files only when the change is clearly explanatory-only and does not alter installed skill behavior.
+| Explains the product without changing shipped behavior or release semantics, and touches zero product-surface globs | `docs:` |
+| Performs maintenance that does not alter user-facing behavior, and touches zero product-surface globs | `chore:` |
 
 Changes that should produce a release must not use non-bumping types such as `docs:` or `chore:`. Use the release-triggering type that matches the product impact.
+
+See [`AGENTS.md` "Commit type selection"](./AGENTS.md#commit-type-selection) for the full rationalization table, red flags, and a WRONG → RIGHT worked example.
 
 The `commit-msg` hook enforces this. PR titles follow the same format so the squash commit can be reused verbatim.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -130,6 +130,8 @@ Determined from releasable Conventional Commit types — no human choice:
 
 If a change should produce a release, do not use a non-bumping type. For example, a Markdown-only edit to `skills/**/SKILL.md` that changes installed skill behavior should use `feat:` or `fix:`, not `docs:`.
 
+Mistyped commits silently suppress releases. See [`AGENTS.md` "Commit type selection"](AGENTS.md#commit-type-selection) for the path-first rule and the full rationalization table.
+
 ## Keeping versions aligned between releases
 
 `package.json` is the canonical source. `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json` are kept in lockstep.

--- a/docs/superpowers/plans/2026-04-28-54-sharpen-commit-type-guidance-for-product-surface-changes-plan.md
+++ b/docs/superpowers/plans/2026-04-28-54-sharpen-commit-type-guidance-for-product-surface-changes-plan.md
@@ -99,7 +99,7 @@ Example — wording standardization across plugin manifests, skill bodies, and t
 Full rationalization table and red flags: see [`AGENTS.md` "Commit type selection"](/AGENTS.md#commit-type-selection).
 ````
 
-The `{{repo}}.mdc` template uses `[\`AGENTS.md\` "Commit type selection"](/AGENTS.md#commit-type-selection)` as the link form. The `.windsurfrules` and `.github/copilot-instructions.md` templates use the same anchor with their existing relative paths (`AGENTS.md` and `../AGENTS.md` respectively). The verbatim glob bullet list is identical across all three surfaces — the AC-54-7 grep parity check enforces this.
+The `{{repo}}.mdc` template uses `[\`AGENTS.md\` "Commit type selection"](/AGENTS.md#commit-type-selection)` as the link form. The `.windsurfrules` and `.github/copilot-instructions.md`templates use the same anchor with their existing relative paths (`AGENTS.md` and `../AGENTS.md` respectively). The verbatim glob bullet list is identical across all three surfaces — the AC-54-7 grep parity check enforces this.
 
 ## Round-trip parity grep (AC-54-7)
 
@@ -181,6 +181,7 @@ Workstreams W1 → W5 run sequentially because the round-trip discipline require
 ### Task T1.1: RED — write the parity-check grep and confirm it currently fails
 
 **Files:**
+
 - Read: `skills/bootstrap/templates/core/AGENTS.md.tmpl` (current state, lacks lead glob list).
 
 - [ ] **Step 1: Run the AC-54-7 grep one-liner against current `main`-equivalent state**
@@ -217,6 +218,7 @@ Save the grep output to a scratch file or paste into the eventual PR body's `Val
 ### Task T1.2: GREEN — rewrite canonical section in `AGENTS.md.tmpl`
 
 **Files:**
+
 - Modify: `skills/bootstrap/templates/core/AGENTS.md.tmpl` (replace lines 104-117 inclusive — the existing "Commit type selection" subsection).
 
 - [ ] **Step 1: Replace the section body**
@@ -242,6 +244,7 @@ Expected: empty output. Any hit means the loophole is still present and the file
 ### Task T1.3: GREEN — mirror lead block in `CONTRIBUTING.md.tmpl`
 
 **Files:**
+
 - Modify: `skills/bootstrap/templates/core/CONTRIBUTING.md.tmpl` (existing "Choose the commit type by product impact" block at line 26).
 
 - [ ] **Step 1: Replace the section**
@@ -259,6 +262,7 @@ Expected: empty.
 ### Task T1.4: GREEN — mirror canonical section in `skills/bootstrap/SKILL.md`
 
 **Files:**
+
 - Modify: `skills/bootstrap/SKILL.md` (lines 104-117).
 
 - [ ] **Step 1: Replace the section**
@@ -276,6 +280,7 @@ Expected: empty.
 ### Task T1.5: GREEN — per-tool surface templates (AC-54-3, four-element block)
 
 **Files:**
+
 - Modify: `skills/bootstrap/templates/agent-plugin/.cursor/rules/{{repo}}.mdc`
 - Modify: `skills/bootstrap/templates/agent-plugin/.windsurfrules`
 - Modify: `skills/bootstrap/templates/agent-plugin/.github/copilot-instructions.md`
@@ -309,6 +314,7 @@ Expected: each file outputs `3` (or higher if globs appear elsewhere). Mismatche
 ### Task T1.6: GREEN — bootstrap skill audit-checklist + pr-body-template
 
 **Files:**
+
 - Modify: `skills/bootstrap/audit-checklist.md`
 - Modify: `skills/bootstrap/pr-body-template.md`
 
@@ -331,6 +337,7 @@ Add a Validation-section reminder line:
 ### Task T1.7: GREEN — `RELEASING.md` cross-link
 
 **Files:**
+
 - Modify: `skills/bootstrap/templates/core/RELEASING.md` (near line 124, "Determined from releasable Conventional Commit types — no human choice").
 
 - [ ] **Step 1: Add a one-sentence cross-link**

--- a/docs/superpowers/plans/2026-04-28-54-sharpen-commit-type-guidance-for-product-surface-changes-plan.md
+++ b/docs/superpowers/plans/2026-04-28-54-sharpen-commit-type-guidance-for-product-surface-changes-plan.md
@@ -1,0 +1,558 @@
+# Plan: Sharpen commit-type guidance for product-surface changes [#54](https://github.com/patinaproject/bootstrap/issues/54)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Execution mode is `subagent-driven`.
+
+**Goal:** Replace the rationalizable "explanatory-only" commit-type rule with a path-first, glob-anchored discipline shipped through `skills/bootstrap/templates/**` and mirrored to root, so agents reliably pick `feat:` / `fix:` (not `docs:` / `chore:`) for product-surface changes.
+
+**Architecture:** Templates-first / round-trip discipline. The canonical "Commit type selection" section lives in `skills/bootstrap/templates/core/AGENTS.md.tmpl` (lead with glob list + path-first rule, then type table, then rationalization table, red-flags STOP block, WRONG → RIGHT pair). The same content mirrors into `CONTRIBUTING.md.tmpl`, the per-tool surfaces (`.cursor/rules/{{repo}}.mdc`, `.windsurfrules`, `.github/copilot-instructions.md`) get a four-element block (glob list + path-first rule + WRONG → RIGHT + canonical link), and the bootstrap skill's own internals (`SKILL.md`, `agent-spawn-template.md`, `audit-checklist.md`, `pr-body-template.md`) align with the new rule. Realignment mirrors templates into root.
+
+**Tech Stack:** Markdown only. No code; no CI changes; no commitlint changes. Verification by `grep`, `pnpm lint:md`, `.husky/commit-msg`, and a cold-context subagent dispatch.
+
+**Source-of-truth design:** [`docs/superpowers/specs/2026-04-28-54-sharpen-commit-type-guidance-for-product-surface-changes-design.md`](../specs/2026-04-28-54-sharpen-commit-type-guidance-for-product-surface-changes-design.md). The design is the contract; this plan does not re-derive requirements from the issue alone.
+
+---
+
+## Surface inventory
+
+Group A — **Templates** (under `skills/bootstrap/templates/**`, edited FIRST):
+
+| File | Edits required | ACs |
+|---|---|---|
+| `skills/bootstrap/templates/core/AGENTS.md.tmpl` | Rewrite "Commit type selection" section: lead block (glob list + path-first rule sentence) BEFORE type table, retain/tighten type table, add rationalization table (9 rows), red-flags STOP block (no "adds or changes a rule" qualifier), one WRONG → RIGHT pair drawn from a real historical commit, and round-trip discipline reference linking to the AC-54-7 grep parity check. Delete the "Edits to `skills/**/SKILL.md` … unless explanatory-only" qualifier. | AC-54-1, AC-54-4, AC-54-5, AC-54-6 |
+| `skills/bootstrap/templates/core/CONTRIBUTING.md.tmpl` | Mirror the canonical lead block (glob list + path-first rule) and type table; cross-link to AGENTS.md for the full rationalization table + red flags. Delete the same "explanatory-only" qualifier. | AC-54-1, AC-54-4, AC-54-6 |
+| `skills/bootstrap/templates/core/RELEASING.md` | Add a one-sentence cross-link near the "Conventional Commit types" block stating that mistyped commits silently suppress releases; point readers to AGENTS.md "Commit type selection". | AC-54-1 |
+| `skills/bootstrap/templates/agent-plugin/.cursor/rules/{{repo}}.mdc` | Replace the single-line "Behavior-changing skill, workflow, prompt … must use release-triggering commit types" bullet with the four-element block: (a) verbatim product-surface glob list, (b) one-sentence path-first rule, (c) one WRONG → RIGHT pair, (d) link to canonical `AGENTS.md` section. ≤ 20 added lines. | AC-54-3 |
+| `skills/bootstrap/templates/agent-plugin/.windsurfrules` | Same four-element block. ≤ 20 added lines. | AC-54-3 |
+| `skills/bootstrap/templates/agent-plugin/.github/copilot-instructions.md` | Same four-element block. ≤ 20 added lines. | AC-54-3 |
+| `skills/bootstrap/templates/agent-plugin/README.md.tmpl` | If it currently teaches commit types, mirror the lead block. If it does not, leave alone (per design's role-ownership table). | AC-54-3 (verification only) |
+
+Group B — **Root mirrors** (realigned via the local `bootstrap` skill in realignment mode AFTER Group A lands):
+
+- `AGENTS.md`
+- `CONTRIBUTING.md`
+- `RELEASING.md`
+- `.cursor/rules/bootstrap.mdc`
+- `.windsurfrules`
+- `.github/copilot-instructions.md`
+
+Group C — **Bootstrap skill internals** (this skill is a product surface; AC-54-8 meta-example):
+
+| File | Edits required | ACs |
+|---|---|---|
+| `skills/bootstrap/SKILL.md` | Same "Commit type selection" rewrite as `AGENTS.md.tmpl` (this section is duplicated in SKILL.md lines 104-117 today). Lead with glob list + path-first rule; delete "explanatory-only" qualifier; cross-link to AGENTS.md for rationalization table. | AC-54-1, AC-54-4, AC-54-5, AC-54-6 |
+| `skills/bootstrap/audit-checklist.md` | Add a checklist item under "Agent + repo docs" verifying the canonical commit-type section in `AGENTS.md`/`AGENTS.md.tmpl` leads with the glob list + path-first rule (so a realignment run catches drift on this design's content). | AC-54-2, AC-54-7 |
+| `skills/bootstrap/agent-spawn-template.md` | If the spawn template references commit types, point it at the canonical AGENTS.md section. Otherwise leave alone. | AC-54-3 (verification only) |
+| `skills/bootstrap/pr-body-template.md` | Add a Validation-section reminder: paste the AC-54-7 grep parity output (or "empty output verified") when the PR touches commit-type guidance. | AC-54-7 |
+
+Group D — **Adjacent prompt surfaces** (verified in scope or explicitly out):
+
+- `.claude/agents/` — none today (verified via `find skills -maxdepth 2`); no edits.
+- `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json` — manifests; not commit-type instruction surfaces. No edits unless realignment of unrelated fields surfaces drift, in which case skip per templates-first discipline.
+- `release-please-config.json`, `.release-please-manifest.json` — out of scope; no version-bump implication for this PR (the bootstrap plugin's own version will be bumped by release-please from the `feat:` squash title; no manual edit).
+- `scripts/sync-plugin-versions.mjs`, `scripts/check-plugin-versions.mjs` — out of scope; no commit-type content.
+
+## Canonical AGENTS.md "Commit type selection" section structure
+
+The new section MUST appear in this order in both `skills/bootstrap/templates/core/AGENTS.md.tmpl` and root `AGENTS.md` (and the duplicated copy in `skills/bootstrap/SKILL.md`):
+
+1. **Lead block (FIRST, before the type table) — AC-54-6 ordering requirement:**
+   - Verbatim product-surface glob list (rendered as a code block or bulleted code spans):
+     `skills/**`, `skills/bootstrap/templates/**`, `.claude-plugin/**`, `.codex-plugin/**`, `.cursor/**`, `.windsurfrules`, `.github/copilot-instructions.md`, `.github/workflows/**`, `.github/ISSUE_TEMPLATE/**`, `.github/pull_request_template.md`, `.github/LABELS.md`, `AGENTS.md`, `AGENTS.md.tmpl`, `CONTRIBUTING.md`, `CONTRIBUTING.md.tmpl`, `RELEASING.md`, `RELEASING.md.tmpl`.
+   - One-sentence path-first rule (verbatim, identical across all surfaces):
+     `If any file in the diff is under one of these globs, the commit type is feat: or fix: — never docs: or chore:.`
+
+2. **Type table** (existing four-row table, kept as-is for reference; the lead block makes it advisory rather than the primary decision tool).
+
+3. **Rationalization table** (9 named excuses + counters, copied verbatim from the design's "Rationalization table (planted in canonical section)" subsection). Headers: `| Rationalization | Reality |`.
+
+4. **Red Flags STOP block** (markdown blockquote starting `**STOP and reconsider if any of these are true:**` with three bullets, copied verbatim from the design's Red Flags subsection — and per HIGH-2 / MEDIUM-2 closure the bullet 3 wording does NOT contain "adds or changes a rule"; every edit to those files is `feat:` or `fix:` by path).
+
+5. **WRONG → RIGHT pair** (≥1, drawn from a real historical commit). The plan picks `082c5e9` because it is the most pedagogical: it touched a plugin manifest AND skill body AND multiple templates, all three product-surface categories at once, and the rationalization in its subject ("standardize") is one of the named red-flag verbs.
+   - WRONG: `docs: #46 standardize Patina Project name`
+   - RIGHT: `feat: #46 standardize Patina Project name across product surfaces`
+
+6. **Round-trip discipline reference**: one sentence noting that on this repo, the AGENTS.md content is shipped through `skills/bootstrap/templates/core/AGENTS.md.tmpl` and round-tripped via the `bootstrap` skill in realignment mode, with the AC-54-7 parity grep as the verification artifact. Link to `RELEASING.md` for the release-triggering implication.
+
+The "Edits to `skills/**/SKILL.md` and adjacent skill workflow contracts are product/runtime changes by default, not documentation edits. Use `docs:` for those files only when the change is clearly explanatory-only and does not alter installed skill behavior." paragraph is **deleted entirely** in all surfaces. The path-first rule replaces it.
+
+## Per-tool surface block (AC-54-3)
+
+The verbatim block emitted into `.cursor/rules/{{repo}}.mdc`, `.windsurfrules`, and `.github/copilot-instructions.md` (and their root mirrors), tightened to ≤ 20 lines each:
+
+````markdown
+### Commit type — path-first rule
+
+If any file in the diff is under one of these globs, the commit type is `feat:` or `fix:` — never `docs:` or `chore:`:
+
+- `skills/**`
+- `skills/bootstrap/templates/**`
+- `.claude-plugin/**`, `.codex-plugin/**`
+- `.cursor/**`, `.windsurfrules`, `.github/copilot-instructions.md`
+- `.github/workflows/**`, `.github/ISSUE_TEMPLATE/**`, `.github/pull_request_template.md`, `.github/LABELS.md`
+- `AGENTS.md`, `AGENTS.md.tmpl`, `CONTRIBUTING.md`, `CONTRIBUTING.md.tmpl`, `RELEASING.md`, `RELEASING.md.tmpl`
+
+Example — wording standardization across plugin manifests, skill bodies, and templates:
+
+- WRONG: `docs: #46 standardize Patina Project name`
+- RIGHT: `feat: #46 standardize Patina Project name across product surfaces`
+
+Full rationalization table and red flags: see [`AGENTS.md` "Commit type selection"](/AGENTS.md#commit-type-selection).
+````
+
+The `{{repo}}.mdc` template uses `[\`AGENTS.md\` "Commit type selection"](/AGENTS.md#commit-type-selection)` as the link form. The `.windsurfrules` and `.github/copilot-instructions.md` templates use the same anchor with their existing relative paths (`AGENTS.md` and `../AGENTS.md` respectively). The verbatim glob bullet list is identical across all three surfaces — the AC-54-7 grep parity check enforces this.
+
+## Round-trip parity grep (AC-54-7)
+
+Run from repo root. Empty output = pass; any non-empty output is a hard blocker.
+
+```bash
+for f in \
+  AGENTS.md \
+  skills/bootstrap/templates/core/AGENTS.md.tmpl \
+  CONTRIBUTING.md \
+  skills/bootstrap/templates/core/CONTRIBUTING.md.tmpl \
+  .github/copilot-instructions.md \
+  skills/bootstrap/templates/agent-plugin/.github/copilot-instructions.md \
+  .cursor/rules/*.mdc \
+  skills/bootstrap/templates/agent-plugin/.cursor/rules/*.mdc \
+  .windsurfrules \
+  skills/bootstrap/templates/agent-plugin/.windsurfrules ; do
+  grep -q 'skills/\*\*' "$f" && \
+  grep -q '\.claude-plugin/\*\*' "$f" && \
+  grep -q '\.codex-plugin/\*\*' "$f" && \
+  grep -q '\.windsurfrules' "$f" && \
+  grep -q 'copilot-instructions\.md' "$f" \
+    || echo "MISSING glob list in: $f"
+done
+```
+
+The output (or the literal phrase `empty output verified`) MUST be pasted into the PR body's `Validation` section. Non-empty output blocks merge.
+
+## Bootstrap skill realignment behavior (AC-54-2 + AC-54-8)
+
+- All Group A and Group C edits use commit type `feat:` (per the very rule being added; AC-54-8 meta-example).
+- After Group A + C land, Group B is generated by running the local `bootstrap` skill in realignment mode against this repo. The skill's audit-checklist (now updated by Group C) catches the drift on AGENTS.md / CONTRIBUTING.md / per-tool surfaces and proposes the diff. The implementer accepts and commits.
+- Realignment commits also use `feat:` (root files are product surfaces).
+- **Branch commits vs squash commit**: the squash PR title is what release-please reads, so as long as the squash title is `feat: #54 sharpen commit-type guidance for product-surface changes`, individual branch commits MAY mix `feat:` (Group A, B, C) and `docs:` (the design doc commit on `d34eb5f` already exists; the plan commit will be `docs:` per the brainstormer/planner artifact carve-out). All branch commits remain conventional-commits-compliant and pass the husky `commit-msg` hook.
+- Both template commits and root-mirror commits ride in the same PR.
+
+## GREEN cold-context subagent verification (AC-54-1)
+
+After all edits land but before requesting review, the implementer dispatches one cold-context subagent (no prior conversation context, no design-doc loaded) with the following prompt and sample diff:
+
+**Prompt to subagent:**
+
+```text
+You are about to commit the following diff in the patinaproject/bootstrap repository.
+Read AGENTS.md (especially the "Commit type selection" section) and propose a one-line
+conventional-commit subject for this change. Do not write code; just answer with the
+commit subject and a one-sentence rationale.
+
+Diff (synthetic; treat as if real):
+
+  diff --git a/skills/bootstrap/SKILL.md b/skills/bootstrap/SKILL.md
+  @@ -7,1 +7,1 @@
+  - `bootstrap` scaffolds a repository — new or existing — to the Patina Project baseline.
+  + `bootstrap` scaffolds a repository (new or existing) to the Patina Project baseline.
+
+The issue number to reference is #99 (synthetic).
+```
+
+**Pass criterion:** Subagent picks `feat:` or `fix:` (most likely `feat:` because the change touches `skills/**`). Either is acceptable. `docs:` or `chore:` is a fail; the implementer must iterate on the guidance until a fresh subagent picks correctly.
+
+**Recorded artifact:** Paste the subagent's verbatim response into the PR body's Validation section under an `### AC-54-1` heading, with the chosen type called out.
+
+## ATDD task ordering
+
+Workstreams W1 → W5 run sequentially because the round-trip discipline requires templates first, then realignment. Within W1, the three template-edit tasks (T1.2, T1.3, T1.4) are independent of each other and CAN be fanned out by the Executor via `superpowers:dispatching-parallel-agents`. T1.5 (per-tool surfaces) is also independent of T1.2-T1.4 and can be parallelized. T2 onward must be strictly sequential.
+
+| Workstream | Tasks | Phase | Parallelizable? |
+|---|---|---|---|
+| W1: Templates + bootstrap-skill internals | T1.1 RED, T1.2 GREEN AGENTS.md.tmpl, T1.3 GREEN CONTRIBUTING.md.tmpl, T1.4 GREEN SKILL.md, T1.5 GREEN per-tool templates, T1.6 GREEN audit-checklist + pr-body-template, T1.7 GREEN RELEASING.md cross-link, T1.8 commit | RED → GREEN | T1.2/T1.3/T1.4/T1.5 parallel; T1.6/T1.7 parallel after; T1.1, T1.8 sequential |
+| W2: Run grep RED | T2.1 grep on templates only, expect MISSING for root files (RED before realignment) | RED | sequential |
+| W3: Realignment to root mirrors | T3.1 run bootstrap skill realignment, T3.2 accept root diffs, T3.3 commit | REFACTOR | sequential |
+| W4: GREEN verification | T4.1 grep parity (empty), T4.2 markdown lint, T4.3 cold-context subagent verification | GREEN | T4.1/T4.2 parallel; T4.3 last |
+| W5: PR | T5.1 PR body assembly, T5.2 push branch, T5.3 open PR | — | sequential |
+
+---
+
+## Workstream W1 — Templates + bootstrap-skill internals
+
+### Task T1.1: RED — write the parity-check grep and confirm it currently fails
+
+**Files:**
+- Read: `skills/bootstrap/templates/core/AGENTS.md.tmpl` (current state, lacks lead glob list).
+
+- [ ] **Step 1: Run the AC-54-7 grep one-liner against current `main`-equivalent state**
+
+Run from repo root:
+
+```bash
+for f in \
+  AGENTS.md \
+  skills/bootstrap/templates/core/AGENTS.md.tmpl \
+  CONTRIBUTING.md \
+  skills/bootstrap/templates/core/CONTRIBUTING.md.tmpl \
+  .github/copilot-instructions.md \
+  skills/bootstrap/templates/agent-plugin/.github/copilot-instructions.md \
+  .cursor/rules/*.mdc \
+  skills/bootstrap/templates/agent-plugin/.cursor/rules/*.mdc \
+  .windsurfrules \
+  skills/bootstrap/templates/agent-plugin/.windsurfrules ; do
+  grep -q 'skills/\*\*' "$f" && \
+  grep -q '\.claude-plugin/\*\*' "$f" && \
+  grep -q '\.codex-plugin/\*\*' "$f" && \
+  grep -q '\.windsurfrules' "$f" && \
+  grep -q 'copilot-instructions\.md' "$f" \
+    || echo "MISSING glob list in: $f"
+done
+```
+
+Expected: NON-empty output naming several surfaces missing the glob list (`AGENTS.md`, `AGENTS.md.tmpl`, `CONTRIBUTING.md`, `CONTRIBUTING.md.tmpl`, all four per-tool surfaces). This is the RED-phase failing test.
+
+- [ ] **Step 2: Record the RED-phase output verbatim**
+
+Save the grep output to a scratch file or paste into the eventual PR body's `Validation` section under "RED-phase baseline". Confirm the test fails before any GREEN edit.
+
+### Task T1.2: GREEN — rewrite canonical section in `AGENTS.md.tmpl`
+
+**Files:**
+- Modify: `skills/bootstrap/templates/core/AGENTS.md.tmpl` (replace lines 104-117 inclusive — the existing "Commit type selection" subsection).
+
+- [ ] **Step 1: Replace the section body**
+
+Replace the existing block (the "Choose the commit type by product impact …" paragraph through the "Use `docs:` … explanatory-only …" paragraph) with the new section in this exact order: (1) lead block — glob list + path-first rule; (2) type table (kept verbatim from current); (3) rationalization table (9 rows, copied from the design); (4) red-flags STOP blockquote (three bullets, no "adds or changes a rule" qualifier on bullet 3); (5) WRONG → RIGHT pair using `082c5e9`; (6) round-trip discipline reference paragraph linking to `RELEASING.md`.
+
+The full text follows the canonical structure spelled out under "Canonical AGENTS.md 'Commit type selection' section structure" above. Use the verbatim glob list and path-first rule sentence from this plan; do NOT paraphrase.
+
+- [ ] **Step 2: Verify the section ordering matches AC-54-6**
+
+The lead block (glob list + path-first rule) MUST appear before the type table. Re-read the section and confirm.
+
+- [ ] **Step 3: Verify deletion of the "explanatory-only" qualifier**
+
+Run:
+
+```bash
+grep -n "explanatory-only\|clearly explanatory" skills/bootstrap/templates/core/AGENTS.md.tmpl
+```
+
+Expected: empty output. Any hit means the loophole is still present and the file must be re-edited.
+
+### Task T1.3: GREEN — mirror lead block in `CONTRIBUTING.md.tmpl`
+
+**Files:**
+- Modify: `skills/bootstrap/templates/core/CONTRIBUTING.md.tmpl` (existing "Choose the commit type by product impact" block at line 26).
+
+- [ ] **Step 1: Replace the section**
+
+Insert the lead block (glob list + path-first rule sentence, identical to AGENTS.md.tmpl) BEFORE the existing four-row type table. Delete any "explanatory-only" qualifier text. Add a one-sentence cross-link "See [`AGENTS.md` 'Commit type selection'](AGENTS.md#commit-type-selection) for the full rationalization table and red flags."
+
+- [ ] **Step 2: Verify deletion of the qualifier**
+
+```bash
+grep -n "explanatory-only\|clearly explanatory" skills/bootstrap/templates/core/CONTRIBUTING.md.tmpl
+```
+
+Expected: empty.
+
+### Task T1.4: GREEN — mirror canonical section in `skills/bootstrap/SKILL.md`
+
+**Files:**
+- Modify: `skills/bootstrap/SKILL.md` (lines 104-117).
+
+- [ ] **Step 1: Replace the section**
+
+The bootstrap skill's own SKILL.md duplicates the AGENTS.md "Commit type selection" section. Replace it with the same canonical structure (lead block, type table, rationalization table, red flags, WRONG → RIGHT, round-trip reference).
+
+- [ ] **Step 2: Verify**
+
+```bash
+grep -n "explanatory-only\|clearly explanatory" skills/bootstrap/SKILL.md
+```
+
+Expected: empty.
+
+### Task T1.5: GREEN — per-tool surface templates (AC-54-3, four-element block)
+
+**Files:**
+- Modify: `skills/bootstrap/templates/agent-plugin/.cursor/rules/{{repo}}.mdc`
+- Modify: `skills/bootstrap/templates/agent-plugin/.windsurfrules`
+- Modify: `skills/bootstrap/templates/agent-plugin/.github/copilot-instructions.md`
+
+- [ ] **Step 1: Replace the existing single-line "Behavior-changing skill, workflow, prompt …" bullet in each file with the four-element block**
+
+Use the verbatim block from the "Per-tool surface block (AC-54-3)" section above. The glob list, path-first rule sentence, WRONG → RIGHT pair, and canonical link MUST be byte-identical across all three files (modulo the link target's relative path: `/AGENTS.md` for `.mdc`, `AGENTS.md` for `.windsurfrules`, `../AGENTS.md` for `.github/copilot-instructions.md`).
+
+- [ ] **Step 2: Verify each surface ≤ 20 added lines**
+
+```bash
+wc -l skills/bootstrap/templates/agent-plugin/.cursor/rules/*.mdc \
+       skills/bootstrap/templates/agent-plugin/.windsurfrules \
+       skills/bootstrap/templates/agent-plugin/.github/copilot-instructions.md
+```
+
+Expected: each file gains ≤ 20 lines vs the pre-edit count (17/11/11).
+
+- [ ] **Step 3: Verify glob-list parity across the three templates**
+
+```bash
+for f in skills/bootstrap/templates/agent-plugin/.cursor/rules/*.mdc \
+         skills/bootstrap/templates/agent-plugin/.windsurfrules \
+         skills/bootstrap/templates/agent-plugin/.github/copilot-instructions.md ; do
+  grep -c 'skills/\*\*\|\.claude-plugin/\*\*\|\.codex-plugin/\*\*' "$f"
+done
+```
+
+Expected: each file outputs `3` (or higher if globs appear elsewhere). Mismatched counts indicate drift.
+
+### Task T1.6: GREEN — bootstrap skill audit-checklist + pr-body-template
+
+**Files:**
+- Modify: `skills/bootstrap/audit-checklist.md`
+- Modify: `skills/bootstrap/pr-body-template.md`
+
+- [ ] **Step 1: Add an audit-checklist item**
+
+Under "Agent + repo docs" (or the equivalent section), append:
+
+```markdown
+- AGENTS.md and AGENTS.md.tmpl: the "Commit type selection" section leads with the product-surface glob list and one-sentence path-first rule BEFORE the type table; contains a rationalization table, red-flags STOP block, and at least one WRONG → RIGHT pair. Verify with the parity grep in `docs/superpowers/specs/2026-04-28-54-…-design.md` AC-54-7.
+```
+
+- [ ] **Step 2: Update pr-body-template.md**
+
+Add a Validation-section reminder line:
+
+```markdown
+- Commit-type guidance changes: paste output of the AC-54-7 parity grep (or `empty output verified`) here.
+```
+
+### Task T1.7: GREEN — `RELEASING.md` cross-link
+
+**Files:**
+- Modify: `skills/bootstrap/templates/core/RELEASING.md` (near line 124, "Determined from releasable Conventional Commit types — no human choice").
+
+- [ ] **Step 1: Add a one-sentence cross-link**
+
+Append after the existing "Conventional Commit types" paragraph:
+
+```markdown
+Mistyped commits silently suppress releases. See [`AGENTS.md` "Commit type selection"](AGENTS.md#commit-type-selection) for the path-first rule and rationalization table.
+```
+
+### Task T1.8: Commit Workstream 1
+
+- [ ] **Step 1: Stage all template + skill-internal edits**
+
+```bash
+git add \
+  skills/bootstrap/templates/core/AGENTS.md.tmpl \
+  skills/bootstrap/templates/core/CONTRIBUTING.md.tmpl \
+  skills/bootstrap/templates/core/RELEASING.md \
+  skills/bootstrap/templates/agent-plugin/.cursor/rules/{{repo}}.mdc \
+  skills/bootstrap/templates/agent-plugin/.windsurfrules \
+  skills/bootstrap/templates/agent-plugin/.github/copilot-instructions.md \
+  skills/bootstrap/SKILL.md \
+  skills/bootstrap/audit-checklist.md \
+  skills/bootstrap/pr-body-template.md
+```
+
+- [ ] **Step 2: Commit with `feat:`**
+
+```bash
+git commit -m "feat: #54 sharpen commit-type guidance in templates"
+```
+
+Subject ≤ 72 chars (verified: 51). Husky `commit-msg` hook validates; husky `pre-commit` runs markdownlint-cli2.
+
+Expected: commit succeeds; `pnpm lint:md` (run by lint-staged) passes on staged Markdown.
+
+---
+
+## Workstream W2 — RED grep against templates-only state
+
+### Task T2.1: Run AC-54-7 parity grep; confirm root files still missing
+
+- [ ] **Step 1: Run the parity grep**
+
+Same one-liner as T1.1.
+
+Expected: non-empty output naming the six root files (`AGENTS.md`, `CONTRIBUTING.md`, `.github/copilot-instructions.md`, `.cursor/rules/bootstrap.mdc`, `.windsurfrules`) — the realignment loop has not yet run. Templates should NO LONGER appear in the missing list.
+
+- [ ] **Step 2: Confirm template-side passes**
+
+The grep output must NOT include any path under `skills/bootstrap/templates/**`. If it does, return to W1 and fix.
+
+---
+
+## Workstream W3 — Realignment to root mirrors
+
+### Task T3.1: Run the local `bootstrap` skill in realignment mode
+
+- [ ] **Step 1: Invoke the bootstrap skill**
+
+From the repo root, invoke the local `bootstrap` skill (e.g. `/bootstrap` or the equivalent skill invocation in the harness). Provide context that the target is this repo and the mode is realignment.
+
+The skill walks `skills/bootstrap/audit-checklist.md`. The new audit-checklist item from T1.6 plus the existing "Agent + repo docs" batch will surface drift on `AGENTS.md`, `CONTRIBUTING.md`, `RELEASING.md`, `.cursor/rules/bootstrap.mdc`, `.windsurfrules`, `.github/copilot-instructions.md`.
+
+- [ ] **Step 2: Accept the proposed root diffs**
+
+For each diff preview, accept (do not skip or defer). The skill never overwrites without confirmation; this is the explicit confirmation step.
+
+### Task T3.2: Verify root mirrors match templates verbatim
+
+- [ ] **Step 1: Spot-check by diff**
+
+```bash
+diff <(sed -n '/### Commit type selection/,/^## /p' AGENTS.md) \
+     <(sed -n '/### Commit type selection/,/^## /p' skills/bootstrap/templates/core/AGENTS.md.tmpl)
+```
+
+Expected: empty (or only template-substitution differences if any).
+
+### Task T3.3: Commit the root realignment
+
+- [ ] **Step 1: Stage and commit**
+
+```bash
+git add AGENTS.md CONTRIBUTING.md RELEASING.md \
+        .cursor/rules/bootstrap.mdc .windsurfrules .github/copilot-instructions.md
+git commit -m "feat: #54 realign root commit-type guidance from templates"
+```
+
+Subject ≤ 72 chars (verified: 56). Both `feat:` per AC-54-8.
+
+---
+
+## Workstream W4 — GREEN verification
+
+### Task T4.1: AC-54-7 parity grep is now empty
+
+- [ ] **Step 1: Run the parity grep**
+
+Same one-liner. Expected: **empty output**.
+
+- [ ] **Step 2: Capture the verification artifact**
+
+Save the (empty) output to paste in PR body. If non-empty, the listed surface(s) are still missing the glob list — return to W1/W3 to fix; this is a hard blocker.
+
+### Task T4.2: Markdown lint
+
+- [ ] **Step 1: Run repo-wide markdown lint**
+
+```bash
+pnpm lint:md
+```
+
+Expected: exit 0.
+
+### Task T4.3: Cold-context subagent verification (AC-54-1 GREEN)
+
+- [ ] **Step 1: Dispatch one cold-context subagent**
+
+Use the prompt from "GREEN cold-context subagent verification" above. Do not load the design doc; the subagent should rely solely on the updated `AGENTS.md`.
+
+- [ ] **Step 2: Record the response**
+
+Capture the subagent's commit subject + rationale verbatim.
+
+- [ ] **Step 3: Pass/fail check**
+
+Pass = subagent picks `feat:` or `fix:`. Fail = `docs:` or `chore:`. On fail, return to W1 and tighten the guidance further; re-run W3 + W4. AC-54-1 cannot be claimed until a cold-context subagent passes.
+
+---
+
+## Workstream W5 — PR
+
+### Task T5.1: Assemble PR body
+
+The PR body MUST follow `.github/pull_request_template.md` headings verbatim (`Summary`, `Linked issue`, `Acceptance criteria`, `Validation`, `Docs updated`).
+
+- [ ] **Step 1: Render PR body**
+
+Use the template. Under `Acceptance criteria`, include eight `### AC-54-N` headings (AC-54-1 through AC-54-8) with one-line outcome summaries under each. Under `Validation`, paste:
+
+- The empty AC-54-7 grep output (or `empty output verified`).
+- The `pnpm lint:md` exit-zero confirmation.
+- The cold-context subagent's verbatim response (under AC-54-1).
+- The husky `commit-msg` hook accepted both branch commits (passing each `feat: #54 …` subject).
+
+Under `Summary`, call out the meta-example: this PR is itself the test of the rule it ships. Branch commits use `feat:` for content-bearing changes (W1 and W3) and `docs:` for the planner artifact (the plan-doc commit referenced below).
+
+### Task T5.2: Push branch and open PR
+
+- [ ] **Step 1: Push**
+
+```bash
+git push -u origin 54-sharpen-commit-type-guidance-for-product-surface-changes
+```
+
+- [ ] **Step 2: Open PR**
+
+```bash
+gh pr create --title "feat: #54 sharpen commit-type guidance for product-surface changes" \
+  --body-file <rendered-pr-body.md>
+```
+
+Title length: 71 chars (verified ≤ 72). PR-title lint will accept.
+
+If "for product-surface changes" needs to be truncated to fit a stricter local limit, use `feat: #54 sharpen commit-type guidance for product surfaces` (60 chars) — but do NOT truncate without need.
+
+---
+
+## Commit-type discipline for the implementation itself (AC-54-8 meta-example)
+
+- **Squash PR title (and merge commit subject)**: `feat: #54 sharpen commit-type guidance for product-surface changes`. release-please reads this and bumps minor.
+- **Branch commits**:
+  - `d34eb5f docs: #54 add design doc for sharpening commit-type guidance` (already on branch; pure design-doc, `docs:` correct per the spec carve-out).
+  - `3cbaeeb docs: #54 address adversarial review on commit-type design` (already on branch; same carve-out).
+  - The plan-doc commit landed by this Planner: `docs: #54 add implementation plan for commit-type guidance` (this file under `docs/superpowers/plans/**`; same brainstormer/planner artifact carve-out as AC-54-8).
+  - W1 commit: `feat: #54 sharpen commit-type guidance in templates` — touches `skills/bootstrap/templates/**` and `skills/bootstrap/SKILL.md`. Both are product surfaces. `feat:` is correct.
+  - W3 commit: `feat: #54 realign root commit-type guidance from templates` — touches root product surfaces. `feat:` is correct.
+- **PR body**: explicitly call out this commit-type breakdown as the worked example for AC-54-8.
+
+---
+
+## Validation evidence to record in PR body
+
+Per `.github/pull_request_template.md` headings (verbatim, in template order):
+
+| Template heading | Evidence |
+|---|---|
+| `Summary` | One paragraph: shipped path-first commit-type guidance through templates → root, closed the "explanatory-only" loophole, called out meta-example AC-54-8. |
+| `Linked issue` | `Closes #54`. |
+| `Acceptance criteria` | Eight `### AC-54-N` headings (AC-54-1 through AC-54-8), each with a one-line outcome summary and verification under it. |
+| `Validation` | (a) AC-54-7 parity grep output (empty), (b) `pnpm lint:md` exit 0, (c) commit-msg hook accepted each `feat: #54 …` and `docs: #54 …` subject, (d) cold-context subagent response (under AC-54-1), (e) markdownlint clean for changed files. |
+| `Docs updated` | Yes — `AGENTS.md`, `CONTRIBUTING.md`, `RELEASING.md`, `.cursor/rules/bootstrap.mdc`, `.windsurfrules`, `.github/copilot-instructions.md`, `skills/bootstrap/SKILL.md`, plus templates under `skills/bootstrap/templates/**` and supporting `audit-checklist.md` / `pr-body-template.md`. |
+
+Per-AC verification under `Acceptance criteria`:
+
+- **AC-54-1**: cold-context subagent picks `feat:`/`fix:` on the synthetic skill diff. (W4.3 evidence.)
+- **AC-54-2**: realignment commit (W3.3) lands in same PR as templates commit (W1.8); both reference `#54`.
+- **AC-54-3**: per-tool surfaces contain (a) glob list, (b) path-first rule, (c) WRONG → RIGHT, (d) link to canonical. (Manual inspection + W4.1 grep parity.)
+- **AC-54-4**: rationalization table has 9 rows including the named excuses. (Manual inspection of canonical section.)
+- **AC-54-5**: WRONG → RIGHT pair drawn from `082c5e9`. (Manual inspection.)
+- **AC-54-6**: lead block (glob list + path-first rule) appears BEFORE the type table; glob list contains every path required by the design. (Manual inspection.)
+- **AC-54-7**: parity grep empty. (W4.1 output.)
+- **AC-54-8**: this PR's commits use the rule it ships; called out in `Summary`.
+
+---
+
+## Risks and blockers (none observed; mitigations recorded)
+
+- **release-please version bump**: the bootstrap plugin version will minor-bump from `1.3.0` to `1.4.0` once this PR's `feat:` squash lands. `release-please-config.json` and `.release-please-manifest.json` need no manual edit (release-please owns the bump). Confirmed by reading both files: they reference plugin manifest paths but auto-update them via `extra-files` jsonpath.
+- **Sync scripts**: `scripts/sync-plugin-versions.mjs` and `scripts/check-plugin-versions.mjs` operate on plugin manifest versions only; no commit-type content. No edits required. Confirmed by inspection of `skills/bootstrap/SKILL.md` line 165.
+- **Per-tool surface realignment wiring**: the bootstrap skill's audit-checklist already covers `.cursor/`, `.windsurfrules`, `.github/copilot-instructions.md` under batch 5 ("AI platform surfaces") per `skills/bootstrap/SKILL.md` line 47. Confirmed: realignment can mirror these templates into root. No blocker.
+- **Adjacent prompt surfaces**: no `.claude/agents/` files exist in this repo; verified by `find skills -maxdepth 2`. No edits required there.
+- **Markdown link to `AGENTS.md` anchor**: the section heading `### Commit type selection` produces the anchor `#commit-type-selection`. Verified by markdownlint conventions. If markdownlint complains about anchor casing in any surface, switch to a plain relative-path link (`AGENTS.md`) without the fragment.
+
+No blockers identified. Plan is ready for execution.
+
+---
+
+## Self-review
+
+- **Spec coverage**: Eight ACs (AC-54-1 through AC-54-8) each map to at least one task: AC-54-1 → T4.3; AC-54-2 → T3.1, T3.3; AC-54-3 → T1.5; AC-54-4 → T1.2 (rationalization table); AC-54-5 → T1.2 (WRONG → RIGHT pair); AC-54-6 → T1.2 (ordering + glob list); AC-54-7 → T2.1, T4.1; AC-54-8 → T1.8, T3.3, T5.1 (commit subjects + PR-body callout).
+- **Placeholder scan**: No `TODO`, `TBD`, "implement later", or "fill in details" present. All exact paths and grep one-liners spelled out.
+- **Type/path consistency**: glob list spelled the same way every time it appears (lead block, per-tool surfaces, audit checklist, grep parity check). Path-first rule sentence is a single canonical sentence reused verbatim. WRONG → RIGHT pair uses `082c5e9` consistently.

--- a/docs/superpowers/specs/2026-04-28-54-sharpen-commit-type-guidance-for-product-surface-changes-design.md
+++ b/docs/superpowers/specs/2026-04-28-54-sharpen-commit-type-guidance-for-product-surface-changes-design.md
@@ -88,6 +88,16 @@ enforcement, and does not retroactively re-type past commits.
   then it selects a release-triggering type (`feat:` or `fix:`) rather
   than `docs:` or `chore:`.
 
+  **GREEN-phase verification step (the implementer must perform this
+  before claiming AC-54-1):** dispatch at least one cold-context
+  subagent against a synthetic skill-edit diff (e.g. a one-line wording
+  change to `skills/bootstrap/SKILL.md`) and ask it to choose a commit
+  type using only the updated guidance. Record the chosen type and the
+  agent's reasoning verbatim in the PR body. If the cold-context
+  subagent picks `feat:` or `fix:` without prompting, AC-54-1 is met.
+  If it picks `docs:`/`chore:`, the guidance still has a leak; iterate
+  before merge.
+
 - **AC-54-2**: Given the guidance is shipped through
   `skills/bootstrap/templates/**`, when the local `bootstrap` skill is run
   against this repo in realignment mode, then this repo's own root config
@@ -99,9 +109,13 @@ enforcement, and does not retroactively re-type past commits.
   (`.cursor/rules/{{repo}}.mdc`, `.windsurfrules`,
   `.github/copilot-instructions.md`, plus any `agent-plugin` README/AGENTS
   template that summarizes commit rules), when commit-type guidance
-  appears, then each surface names the product-surface rule and points to
-  the canonical decision table in `AGENTS.md` so an agent that only loads
-  one surface still picks the correct type.
+  appears on a surface, then that surface contains all four of the
+  following elements: (a) the verbatim product-surface glob list (matching
+  AC-54-6), (b) the one-sentence path-first rule ("any diff touching one
+  of these globs uses `feat:` or `fix:`"), (c) at least one concrete
+  WRONG → RIGHT example, and (d) a link to the canonical
+  "Commit type selection" section in `AGENTS.md` for the full
+  rationalization table.
 
 - **AC-54-4** (new): Given an agent considers a rationalization (e.g.
   "Markdown only", "wording alignment", "just a template", "non-goals
@@ -119,11 +133,15 @@ enforcement, and does not retroactively re-type past commits.
 
 - **AC-54-6** (new): Given the canonical "Commit type selection" section
   in `AGENTS.md` (and its `CONTRIBUTING.md.tmpl` mirror), when the section
-  is read, then it lists the product surfaces by path glob — `skills/**`,
+  is read, then **the product-surface path-glob list and the
+  one-sentence path-first rule appear FIRST in the section, before the
+  type table**, and the glob list contains: `skills/**`,
   `skills/bootstrap/templates/**`, `.claude-plugin/**`,
   `.codex-plugin/**`, `.cursor/**`, `.windsurfrules`,
   `.github/copilot-instructions.md`, `.github/workflows/**`,
-  `.github/ISSUE_TEMPLATE/**`, `.github/pull_request_template.md` — so the
+  `.github/ISSUE_TEMPLATE/**`, `.github/pull_request_template.md`,
+  `.github/LABELS.md`, `AGENTS.md`, `AGENTS.md.tmpl`, `CONTRIBUTING.md`,
+  `CONTRIBUTING.md.tmpl`, `RELEASING.md`, `RELEASING.md.tmpl` — so the
   agent can match its diff against a concrete list rather than a verbal
   category.
 
@@ -132,9 +150,39 @@ enforcement, and does not retroactively re-type past commits.
   template edit lands first under `skills/bootstrap/templates/**`, root
   files (`AGENTS.md`, `CONTRIBUTING.md`, `.github/copilot-instructions.md`,
   `.cursor/rules/*.mdc`, `.windsurfrules`, plus any agent-plugin template
-  README) are realigned via the bootstrap skill in realignment mode, and
-  the realignment commit is tied to the same issue (`#54`) so both sides
-  are visible in one PR.
+  README) are realigned via the bootstrap skill in realignment mode, the
+  realignment commit is tied to the same issue (`#54`) so both sides are
+  visible in one PR, **and** round-trip parity is verified by running the
+  following one-liner and pasting its output (which must be empty) in the
+  PR body's `Validation` section:
+
+  ```bash
+  # Parity check: the canonical glob list must appear verbatim on every
+  # surface. Run from repo root. Empty output = pass.
+  for f in \
+    AGENTS.md \
+    skills/bootstrap/templates/core/AGENTS.md.tmpl \
+    CONTRIBUTING.md \
+    skills/bootstrap/templates/core/CONTRIBUTING.md.tmpl \
+    .github/copilot-instructions.md \
+    skills/bootstrap/templates/agent-plugin/.github/copilot-instructions.md \
+    .cursor/rules/*.mdc \
+    skills/bootstrap/templates/agent-plugin/.cursor/rules/*.mdc \
+    .windsurfrules \
+    skills/bootstrap/templates/agent-plugin/.windsurfrules ; do
+    grep -q 'skills/\*\*' "$f" && \
+    grep -q '\.claude-plugin/\*\*' "$f" && \
+    grep -q '\.codex-plugin/\*\*' "$f" && \
+    grep -q '\.windsurfrules' "$f" && \
+    grep -q 'copilot-instructions\.md' "$f" \
+      || echo "MISSING glob list in: $f"
+  done
+  ```
+
+  This check verifies the glob list is present on all six per-tool
+  surfaces plus their templates. It does not enforce wording of the
+  full canonical sentence (that remains a reviewer judgement), but it
+  closes the leak where a surface silently omits the path list.
 
 - **AC-54-8** (meta-example, new): Given the implementation PR for issue
   #54 itself changes shipped agent-facing instructions in
@@ -142,6 +190,18 @@ enforcement, and does not retroactively re-type past commits.
   authored, then the implementation commits use `feat:` (the very rule
   being sharpened), while a pure design-doc commit such as this one uses
   `docs:`. The PR body must call this out as a worked example.
+
+  **Carve-out justification for `docs/superpowers/specs/**`:** these
+  files are brainstormer-output artifacts. They are read once by a
+  Planner subagent in the same workflow that produced them, never
+  shipped to downstream consumers, never installed by the bootstrap
+  skill, and never referenced by any plugin manifest under
+  `.claude-plugin/` or `.codex-plugin/`. They are not part of any
+  agent-instruction surface that a bootstrapped repo inherits. The
+  path-first rule treats them as non-product, and `docs:` is the
+  correct type for spec edits. (By contrast, `AGENTS.md` IS shipped
+  through the bootstrap templates and IS a product surface; that
+  asymmetry is the whole point.)
 
 ## Failure-mode analysis
 
@@ -151,7 +211,7 @@ modes, with the planted counter:
 | # | Failure mode | Why current guidance fails | Counter required |
 |---|--------------|----------------------------|------------------|
 | 1 | "It's just Markdown" | The table says behavior expressed in Markdown counts, but the agent reads its own diff and sees text changes. | Anchor the rule to **path globs**, not "behavior". If the diff touches one of the listed globs, the type is `feat:` / `fix:` unless a named exception applies. Path is verifiable; "behavior" is judgment. |
-| 2 | "Explanatory-only" escape hatch | The qualifier "unless explanatory-only and does not alter installed behavior" is self-selected. | Replace with a positive test: `docs:` only applies to files that are NOT under a product-surface glob (e.g. `docs/**`, `README.md`). Inside a product-surface glob, `docs:` requires an explicit "explanatory-only" call-out in the PR body and reviewer sign-off. Default is `feat:` / `fix:`. |
+| 2 | "Explanatory-only" escape hatch | The qualifier "unless explanatory-only and does not alter installed behavior" is self-selected. | **Delete the qualifier entirely. There is no escape hatch.** Replace with a hard, path-only rule: `docs:` and `chore:` apply if and only if the diff touches **zero** product-surface globs. If any file in the diff is under a product-surface glob, the type is `feat:` or `fix:` — full stop, no PR-body call-out, no reviewer sign-off, no "but this one is explanatory" override. Reviewers do not have authority to grant the exception because no exception exists. |
 | 3 | Surface fragmentation | `.cursor`, `.windsurfrules`, `copilot-instructions.md` give a one-line summary that omits the rationalizations and the path-glob list. | Each per-tool surface must include the product-surface glob list and a single WRONG → RIGHT example, or must inline-link to the canonical `AGENTS.md` section with the explicit instruction "read this before classifying any commit that touches a tracked path". |
 
 ## Considered approaches
@@ -219,11 +279,16 @@ should enumerate them as task-level acceptance criteria.
 The current "explanatory-only" qualifier is the primary loophole. The
 design closes it by:
 
-- Inverting the default: inside product-surface globs, `feat:` / `fix:` is
-  the default. `docs:` requires an explicit explanatory-only call-out
-  in the PR body.
-- Removing self-selectable language ("clearly", "does not alter installed
-  skill behavior"). Replace with the path-glob test.
+- **Deleting the qualifier outright.** There is no "default", no
+  "unless", and no PR-body / reviewer override. The rule is a hard
+  path-only test: if the diff touches any product-surface glob, the
+  commit type is `feat:` or `fix:`. Otherwise `docs:` / `chore:` are
+  available.
+- Removing all self-selectable language ("clearly", "does not alter
+  installed skill behavior", "explanatory-only"). The path-glob test is
+  the only test.
+- Removing reviewer-discretion language. Reviewers do not have
+  authority to grant an exception because no exception exists.
 
 ### Rationalization table (planted in canonical section)
 
@@ -233,7 +298,7 @@ design closes it by:
 | "I'm only aligning wording with the source of truth." | If the source of truth is itself a product surface (skill, template, agent instruction), wording IS behavior. Use `feat:`. |
 | "It's just a template change." | Templates under `skills/bootstrap/templates/**` ship to every bootstrapped repo on the next realignment. They are product. Use `feat:` / `fix:`. |
 | "I'm only adding a non-goal or an example to a skill." | Examples and non-goals on a `SKILL.md` change how the skill is interpreted by agents. Product. `feat:`. |
-| "I'm fixing a typo in a skill body." | If the typo affects how the skill is read or executed, `fix:`. If it is a comment-only spelling fix on a non-shipped file, `chore:`. Default to `fix:` when unsure. |
+| "I'm fixing a typo in a skill body." | Path-only rule: any edit inside `skills/**`, `.claude-plugin/**`, `.codex-plugin/**`, `.cursor/**`, `.windsurfrules`, or `.github/copilot-instructions.md` is `fix:` when correcting wrong shipped content and `feat:` when adding or changing shipped content. Do not assess "whether it affects how the skill is read" — the path test already settled it. `chore:` is only available when the diff touches zero product-surface globs. |
 | "It's a plugin manifest version bump." | Release-please owns version bumps under `chore: release X.Y.Z`. Hand-editing a manifest version outside that flow is a `fix:` (lockstep correction) or a release-PR commit, never `docs:`. |
 | "I'm rewording an agent instruction." | Agent instructions ARE the contract. `feat:`. |
 | "It's a markdown-lint cleanup with no semantic change." | Allowed as `chore:` only if zero product-surface globs are touched. If any product-surface glob is touched, `feat:` (or `fix:` if the lint fix corrected wrong shipped content). |
@@ -248,14 +313,18 @@ The canonical section must end with a STOP block:
 > - You are about to commit `docs:` or `chore:` but `git diff --name-only`
 >   shows a file under `skills/**`, `.claude-plugin/**`,
 >   `.codex-plugin/**`, `.cursor/**`, `.windsurfrules`,
->   `.github/copilot-instructions.md`,
->   `.github/workflows/**`, `.github/ISSUE_TEMPLATE/**`, or
->   `.github/pull_request_template.md`.
+>   `.github/copilot-instructions.md`, `.github/workflows/**`,
+>   `.github/ISSUE_TEMPLATE/**`, `.github/pull_request_template.md`,
+>   `.github/LABELS.md`, `AGENTS.md`, `AGENTS.md.tmpl`,
+>   `CONTRIBUTING.md`, `CONTRIBUTING.md.tmpl`, `RELEASING.md`, or
+>   `RELEASING.md.tmpl`.
 > - Your commit message says "align", "standardize", "clarify", "rename",
 >   "rewrite", or "rework" AND the diff touches a product-surface glob.
-> - You are using `docs:` for a change to `AGENTS.md`,
->   `CONTRIBUTING.md`, or `RELEASING.md` that adds or changes a rule
->   (vs. only restating an existing rule).
+> - You are using `docs:` or `chore:` for any change to `AGENTS.md`,
+>   `AGENTS.md.tmpl`, `CONTRIBUTING.md`, `CONTRIBUTING.md.tmpl`,
+>   `RELEASING.md`, or `RELEASING.md.tmpl`. These files are agent-facing
+>   and contributor-facing contracts — every edit is `feat:` (new or
+>   changed rule) or `fix:` (corrected wrong rule).
 
 ### Token-efficiency targets
 
@@ -274,7 +343,8 @@ The canonical section must end with a STOP block:
 |---------|------|
 | `skills/bootstrap/templates/core/AGENTS.md.tmpl` | Canonical decision table, rationalization table, red flags, WRONG → RIGHT pairs, product-surface glob list. |
 | `skills/bootstrap/templates/core/CONTRIBUTING.md.tmpl` | Mirror of the canonical decision table + product-surface glob list (CONTRIBUTING is contributor-facing, AGENTS is agent-facing; both ship). |
-| `skills/bootstrap/templates/core/RELEASING.md` | Cross-link to AGENTS / CONTRIBUTING; explain that mistyped commits silently suppress releases. |
+| `skills/bootstrap/templates/core/RELEASING.md` (and `RELEASING.md.tmpl`) | Cross-link to AGENTS / CONTRIBUTING; explain that mistyped commits silently suppress releases. |
+| `.github/LABELS.md` (and its template under `skills/bootstrap/templates/**`) | Listed in the product-surface glob set. Edits use `feat:`/`fix:` per the path-only rule. No special ownership beyond inclusion. |
 | `skills/bootstrap/templates/agent-plugin/.cursor/rules/{{repo}}.mdc` | Short rule + glob list + one WRONG → RIGHT + link to canonical. |
 | `skills/bootstrap/templates/agent-plugin/.windsurfrules` | Same as cursor. |
 | `skills/bootstrap/templates/agent-plugin/.github/copilot-instructions.md` | Same as cursor. |
@@ -289,8 +359,8 @@ counter:
 |--------|---------|
 | Agent commits with `docs:` and squashes into a PR titled `feat:`. | PR-title-lint already exists. Squash inherits PR title. Acceptable. |
 | Agent commits multiple changes, types the commit by the "biggest" change. | Commit-by-impact rule already in place. Add explicit guidance: if any file in the diff is on a product-surface glob, the commit type is at least `feat:`. |
-| Agent uses `docs:` and adds an explanatory-only call-out in PR body even though the change is behavioral. | Reviewer responsibility. Document in PR template guidance: explanatory-only call-out requires the PR reviewer to confirm the diff does not change shipped behavior. (If we add a checkbox, it stays human-judged — no CI.) |
-| Agent edits root `AGENTS.md` directly without round-tripping through the template. | Already covered by the templates-first rule in `AGENTS.md`. The Planner must add a verification step: every implementation task that touches a templated root file must show a corresponding template edit in the same commit set. |
+| Agent uses `docs:` and adds an explanatory-only call-out in PR body even though the change is behavioral. | Not available. The escape hatch is deleted; there is no "explanatory-only call-out" option. PR template MUST NOT include any reviewer-grant checkbox for this — see LOW-3 disposition. |
+| Agent edits root `AGENTS.md` directly without round-tripping through the template. | Round-trip parity is verified by the AC-54-7 grep one-liner, whose output must be pasted in the PR body's `Validation` section. An empty grep output is the verification artifact; the Planner does not need to invent a separate check. |
 
 ## Round-trip discipline
 
@@ -303,6 +373,10 @@ For AC-54-2 and AC-54-7:
    referencing `#54`.
 5. PR body explicitly references the templates-first / realignment loop
    so reviewers see both halves.
+6. Run the AC-54-7 parity grep one-liner from the repo root and paste
+   its output (which must be empty) into the PR body's `Validation`
+   section. Non-empty output is a hard blocker — the listed surface(s)
+   missed the glob list and must be updated before merge.
 
 The implementation commits are themselves a worked example of the rule
 they ship: the template edit and the root mirror both touch product
@@ -445,6 +519,138 @@ adversarial_review_findings:
       baseline as part of the verification narrative for AC-54-1.
 ```
 
-**Adversarial review status:** `findings dispositioned`. All seven
-findings are addressed in the requirements / rationalization table /
-round-trip discipline sections. No blockers.
+```yaml
+adversarial_review_findings_round_2:
+  - source: adversarial-review
+    reviewer_context: fresh subagent
+    severity: high
+    location: failure-mode-counter-row-2 + rationalization-typo-row
+    finding: |
+      Design claimed to remove the "explanatory-only" escape hatch but
+      reintroduced it twice: (a) failure-mode row 2 said docs: inside
+      product-surface globs requires "explanatory-only call-out + reviewer
+      sign-off", which IS the escape hatch relabeled; (b) the typo
+      rationalization-table row preserved agent judgement ("if the typo
+      affects how the skill is read") on the very file class the
+      design's path-first thesis covers.
+    disposition: |
+      Closed both. Failure-mode row 2 now states explicitly: docs:/chore:
+      apply iff the diff touches zero product-surface globs; no PR-body
+      call-out, no reviewer override, no exception exists. Loophole-closure
+      section rewritten to match. Rationalization typo row tightened to a
+      pure path-only rule: any edit inside skills/**, .claude-plugin/**,
+      .codex-plugin/**, .cursor/**, .windsurfrules, or
+      .github/copilot-instructions.md is fix: when correcting wrong shipped
+      content and feat: when adding/changing it; the "affects how skill is
+      read" qualifier is removed. Stage-gate-bypass row 3 ("agent uses docs:
+      with explanatory call-out") updated to "Not available."
+  - source: adversarial-review
+    reviewer_context: fresh subagent
+    severity: high
+    location: AC-54-7
+    finding: |
+      AC-54-7 named a verification mechanism (round-trip parity) but did
+      not design one. An implementer could satisfy AC-54-7 by writing the
+      words "templates-first loop" in the PR body while still missing the
+      glob list on one of the four per-tool surfaces.
+    disposition: |
+      Closed. AC-54-7 now embeds a concrete grep-based parity one-liner
+      that checks every per-tool surface and template for the verbatim
+      glob list. Empty output is the verification artifact; the
+      implementer must paste it in the PR body's Validation section. The
+      Round-trip discipline section adds step 6 making this mandatory and
+      a hard blocker.
+  - source: adversarial-review
+    reviewer_context: fresh subagent
+    severity: medium
+    location: AC-54-3
+    finding: |
+      AC-54-3 only required per-tool surfaces to "name the rule and point
+      to canonical." An implementer could satisfy it by leaving the
+      existing one-liner and adding a link, which the failure-mode
+      analysis says is insufficient.
+    disposition: |
+      Closed. AC-54-3 now enumerates four required elements per surface:
+      (a) verbatim product-surface glob list, (b) one-sentence path-first
+      rule, (c) at least one WRONG -> RIGHT example, (d) link to canonical
+      AGENTS.md section. This matches the Role-ownership table.
+  - source: adversarial-review
+    reviewer_context: fresh subagent
+    severity: medium
+    location: AC-54-6
+    finding: |
+      AC-54-6 omitted .github/LABELS.md (touched by RED-baseline commits
+      0b6ebf0 and d6fe7d5) and AGENTS.md / CONTRIBUTING.md / RELEASING.md
+      and their .tmpl counterparts. Red-flags bullet 3 partially patched
+      this but reintroduced "adds or changes a rule" judgement,
+      inconsistent with the path-first thesis.
+    disposition: |
+      Closed. AC-54-6 glob list extended to include .github/LABELS.md,
+      AGENTS.md, AGENTS.md.tmpl, CONTRIBUTING.md, CONTRIBUTING.md.tmpl,
+      RELEASING.md, RELEASING.md.tmpl. Red-flags bullet 3 rewritten to
+      drop the "adds or changes a rule" qualifier — every edit to those
+      files is feat: or fix: by path. Role-ownership table extended to
+      include LABELS.md.
+  - source: adversarial-review
+    reviewer_context: fresh subagent
+    severity: medium
+    location: AC-54-8
+    finding: |
+      The design types its own commit docs: under
+      docs/superpowers/specs/**, but per the path-first thesis design docs
+      themselves are agent-instruction product. The carve-out was implied
+      but not justified.
+    disposition: |
+      Justified explicitly under AC-54-8. Spec files are
+      brainstormer-output artifacts, read once by a Planner subagent in
+      the same workflow, never shipped to consumers, never installed by
+      bootstrap, never referenced by any plugin manifest. They are not on
+      any agent-instruction surface a bootstrapped repo inherits. The
+      path-first rule treats them as non-product; docs: is correct.
+  - source: adversarial-review
+    reviewer_context: fresh subagent
+    severity: low
+    location: canonical-section-ordering
+    finding: |
+      No explicit ordering requirement for where the glob list and
+      path-first rule appear in the canonical section.
+    disposition: |
+      Closed. AC-54-6 now requires the glob list and one-sentence
+      path-first rule to appear FIRST in the "Commit type selection"
+      section, before the type table.
+  - source: adversarial-review
+    reviewer_context: fresh subagent
+    severity: low
+    location: GREEN-followup
+    finding: |
+      No GREEN follow-up for the cold-context subagent pressure test.
+    disposition: |
+      Closed. AC-54-1 now includes a GREEN-phase verification step: the
+      implementer dispatches at least one cold-context subagent against a
+      synthetic skill-edit diff and records the chosen commit type and
+      reasoning in the PR body.
+  - source: adversarial-review
+    reviewer_context: fresh subagent
+    severity: low
+    location: PR-template-language
+    finding: |
+      The earlier disposition softly suggested "Planner should consider"
+      a PR-template addition. Ambiguous given the no-escape-hatch posture.
+    disposition: |
+      Closed by removing the suggestion implicitly: with the escape hatch
+      deleted, no PR-template checkbox is needed or wanted. Stage-gate-
+      bypass row 3 explicitly forbids any reviewer-grant checkbox. The
+      PR template's existing Validation section already accommodates
+      pasting the AC-54-7 grep output; no new template field is added.
+```
+
+**Adversarial review status:** `findings dispositioned`.
+**Reviewer context:** fresh subagent.
+**Dimensions re-checked:** loophole closure, rationalization-table
+internal consistency, glob-list completeness vs. RED-baseline commits,
+canonical-section ordering, AC-54-7 verification mechanism, AC-54-8
+carve-out justification, PR-template alignment with the no-escape-hatch
+posture. All seven original brainstormer findings remain dispositioned;
+all eight new fresh-context findings are closed (six material + two
+LOW). Two HIGH findings (escape-hatch leakage, AC-54-7 mechanism) are
+fully closed in the requirements / failure-mode / round-trip sections.

--- a/docs/superpowers/specs/2026-04-28-54-sharpen-commit-type-guidance-for-product-surface-changes-design.md
+++ b/docs/superpowers/specs/2026-04-28-54-sharpen-commit-type-guidance-for-product-surface-changes-design.md
@@ -1,0 +1,450 @@
+# Design: Sharpen commit-type guidance for product-surface changes [#54](https://github.com/patinaproject/bootstrap/issues/54)
+
+## Context
+
+Issue #48 already established the rule that behavior-changing Markdown on
+product surfaces (`skills/**`, plugin metadata, agent-facing instructions,
+workflow gates) must use a release-triggering Conventional Commit type
+(`feat:` / `fix:`) rather than `docs:` or `chore:`. The guidance landed in
+`AGENTS.md`, `CONTRIBUTING.md.tmpl`, `RELEASING.md`,
+`agent-plugin/README.md.tmpl`, and `.github/copilot-instructions.md` via
+templates.
+
+The rule is not landing in practice. A `git log` survey of this repository
+shows repeated `docs:` commits that touched product surfaces:
+
+- `082c5e9 docs: #46 standardize Patina Project name` — touched
+  `.codex-plugin/plugin.json`, `skills/bootstrap/SKILL.md`,
+  `skills/bootstrap/agent-spawn-template.md`,
+  `skills/bootstrap/pr-body-template.md`, and three template files under
+  `skills/bootstrap/templates/**`. Plugin manifest + skill body + templates
+  are all product surfaces; this should have been `feat:`.
+- `d6fe7d5 docs: #14 align agents and pr template with source-of-truth docs`
+  — touched `AGENTS.md` and `.github/pull_request_template.md` (the
+  workflow contract).
+- `0b6ebf0 docs: #11 incorporate issue filing style into templates` —
+  touched `.github/ISSUE_TEMPLATE/**`, `.github/LABELS.md`.
+- `7f1a1a5 docs: #7 instruct agents to follow .github/ templates` —
+  touched `AGENTS.md` and `skills/bootstrap/templates/core/AGENTS.md.tmpl`
+  (a workflow contract that ships through every bootstrapped repo).
+- `9e32a1b docs: #3 align marketplace id and add per-tool install docs` —
+  touched `skills/bootstrap/SKILL.md`,
+  `skills/bootstrap/audit-checklist.md`,
+  `skills/bootstrap/templates/agent-plugin/README.md.tmpl`,
+  `skills/bootstrap/templates/core/.claude/settings.json`.
+
+Every one of those commits is a release-triggering product-surface change
+that was typed as `docs:`. Release Please's `node` configuration treats
+`docs:` and `chore:` as non-bumping, so each misclassification silently
+suppresses a release for changes that do alter installed behavior in
+downstream consumers.
+
+The current `AGENTS.md` "Commit type selection" section already states the
+correct rule, including the explicit sentence "Edits to `skills/**/SKILL.md`
+and adjacent skill workflow contracts are product/runtime changes by
+default, not documentation edits." Despite that, agents continue to choose
+`docs:`. The current guidance fails on three independent dimensions:
+
+1. **It explains correctness, not the mistake.** The table tells you what
+   each type means but does not show side-by-side WRONG vs RIGHT examples
+   keyed off the most common rationalizations ("it's just Markdown", "it's
+   just a template", "I'm aligning wording").
+2. **It is rationalizable.** The qualifying clause "unless the change is
+   clearly explanatory-only and does not alter installed skill behavior"
+   gives an agent a self-selected escape hatch. Agents under time pressure
+   read every change as "explanatory-only" because the bar for "alters
+   installed behavior" is not anchored to a concrete test.
+3. **The rule lives only in `AGENTS.md` / `CONTRIBUTING.md` / `RELEASING.md`
+   prose.** It is not surfaced in the per-tool agent instructions
+   (`.cursor/rules/{{repo}}.mdc`, `.windsurfrules`,
+   `.github/copilot-instructions.md`) with the same level of detail.
+   Those surfaces give a one-line summary that is easy to skim past, and
+   they do not list the rationalizations the table needs to close.
+
+This design closes those failure modes by treating commit-type guidance the
+way `superpowers:writing-skills` treats discipline rules: the rule must be
+unmissable, every common rationalization must be named and refuted, and
+WRONG → RIGHT examples must appear at the decision point. Per-surface
+parity is required so an agent that only loads one of `.cursor`,
+`.windsurfrules`, or `copilot-instructions.md` still sees enough of the
+rule to pick correctly.
+
+The fix is shipped through `skills/bootstrap/templates/**` so every
+bootstrapped repo inherits it, and the templates-first / round-trip
+discipline (template edit → bootstrap realignment → root mirror) is
+preserved.
+
+This issue was split from #53 and is the agent-facing-guidance half of
+that pair. Per the issue's non-goals, this design does **not** introduce
+new commitlint rules, PR-title CI checks, or any other automated
+enforcement, and does not retroactively re-type past commits.
+
+## Requirements
+
+- **AC-54-1**: Given an agent reads the updated `AGENTS.md` guidance, when
+  it commits a change that touches a product surface (`skills/**`,
+  `.claude-plugin/**`, `.codex-plugin/**`, `.cursor/**`, `.windsurfrules`,
+  `.github/copilot-instructions.md`, or the templates that generate them),
+  then it selects a release-triggering type (`feat:` or `fix:`) rather
+  than `docs:` or `chore:`.
+
+- **AC-54-2**: Given the guidance is shipped through
+  `skills/bootstrap/templates/**`, when the local `bootstrap` skill is run
+  against this repo in realignment mode, then this repo's own root config
+  mirrors the templates and both sides are committed together (template
+  change and root mirror in the same PR / coordinated commits).
+
+- **AC-54-3** (refined from issue text): Given an agent reads the per-tool
+  agent-instruction surfaces shipped by Bootstrap
+  (`.cursor/rules/{{repo}}.mdc`, `.windsurfrules`,
+  `.github/copilot-instructions.md`, plus any `agent-plugin` README/AGENTS
+  template that summarizes commit rules), when commit-type guidance
+  appears, then each surface names the product-surface rule and points to
+  the canonical decision table in `AGENTS.md` so an agent that only loads
+  one surface still picks the correct type.
+
+- **AC-54-4** (new): Given an agent considers a rationalization (e.g.
+  "Markdown only", "wording alignment", "just a template", "non-goals
+  addition", "example update", "fixing a typo in a skill body"), when the
+  agent reads the updated guidance, then a rationalization-table row
+  explicitly addresses that excuse and resolves it to a release-triggering
+  type when the surface is a product surface.
+
+- **AC-54-5** (new): Given an agent reads the updated guidance, when the
+  guidance presents the rule, then it includes at least one concrete
+  WRONG → RIGHT pair drawn from real product surfaces in this repo
+  (e.g. an edit to `skills/bootstrap/SKILL.md`, a template under
+  `skills/bootstrap/templates/**`, or a plugin manifest under
+  `.claude-plugin/` / `.codex-plugin/`).
+
+- **AC-54-6** (new): Given the canonical "Commit type selection" section
+  in `AGENTS.md` (and its `CONTRIBUTING.md.tmpl` mirror), when the section
+  is read, then it lists the product surfaces by path glob — `skills/**`,
+  `skills/bootstrap/templates/**`, `.claude-plugin/**`,
+  `.codex-plugin/**`, `.cursor/**`, `.windsurfrules`,
+  `.github/copilot-instructions.md`, `.github/workflows/**`,
+  `.github/ISSUE_TEMPLATE/**`, `.github/pull_request_template.md` — so the
+  agent can match its diff against a concrete list rather than a verbal
+  category.
+
+- **AC-54-7** (new): Given the `bootstrap` skill is the source of truth
+  for these surfaces, when this design's implementation lands, then the
+  template edit lands first under `skills/bootstrap/templates/**`, root
+  files (`AGENTS.md`, `CONTRIBUTING.md`, `.github/copilot-instructions.md`,
+  `.cursor/rules/*.mdc`, `.windsurfrules`, plus any agent-plugin template
+  README) are realigned via the bootstrap skill in realignment mode, and
+  the realignment commit is tied to the same issue (`#54`) so both sides
+  are visible in one PR.
+
+- **AC-54-8** (meta-example, new): Given the implementation PR for issue
+  #54 itself changes shipped agent-facing instructions in
+  `skills/bootstrap/templates/**` and root `AGENTS.md`, when commits are
+  authored, then the implementation commits use `feat:` (the very rule
+  being sharpened), while a pure design-doc commit such as this one uses
+  `docs:`. The PR body must call this out as a worked example.
+
+## Failure-mode analysis
+
+The design must address WHY agents misclassify. Three concrete failure
+modes, with the planted counter:
+
+| # | Failure mode | Why current guidance fails | Counter required |
+|---|--------------|----------------------------|------------------|
+| 1 | "It's just Markdown" | The table says behavior expressed in Markdown counts, but the agent reads its own diff and sees text changes. | Anchor the rule to **path globs**, not "behavior". If the diff touches one of the listed globs, the type is `feat:` / `fix:` unless a named exception applies. Path is verifiable; "behavior" is judgment. |
+| 2 | "Explanatory-only" escape hatch | The qualifier "unless explanatory-only and does not alter installed behavior" is self-selected. | Replace with a positive test: `docs:` only applies to files that are NOT under a product-surface glob (e.g. `docs/**`, `README.md`). Inside a product-surface glob, `docs:` requires an explicit "explanatory-only" call-out in the PR body and reviewer sign-off. Default is `feat:` / `fix:`. |
+| 3 | Surface fragmentation | `.cursor`, `.windsurfrules`, `copilot-instructions.md` give a one-line summary that omits the rationalizations and the path-glob list. | Each per-tool surface must include the product-surface glob list and a single WRONG → RIGHT example, or must inline-link to the canonical `AGENTS.md` section with the explicit instruction "read this before classifying any commit that touches a tracked path". |
+
+## Considered approaches
+
+### Recommended: Rewrite the canonical section path-first, propagate per-surface, plant rationalization rows
+
+Restructure the `AGENTS.md` "Commit type selection" section so it leads
+with a **product-surface path-glob list** (the source of truth for
+"product surface" in this repo) and the rule "any diff touching one of
+these globs uses `feat:` or `fix:` by default". Keep the existing
+WHAT-each-type-means table, but add:
+
+- a rationalization table listing the named excuses ("just Markdown",
+  "wording alignment", "template-only", "non-goals", "example update",
+  "skill-body typo", "config tweak", "lockstep version bump",
+  "alignment with source of truth") and the resolution for each;
+- a Red Flags list ("you are about to commit `docs:` but the diff touches
+  `skills/**` — STOP");
+- two concrete WRONG → RIGHT pairs lifted from the historical commits
+  identified in Context (e.g. `docs: #46 standardize Patina Project name`
+  → `feat: #46 standardize Patina Project name across product surfaces`).
+
+Mirror the canonical section into `CONTRIBUTING.md.tmpl` (already does so
+today; keep parity). Update the per-tool surfaces
+(`.cursor/rules/{{repo}}.mdc`, `.windsurfrules`,
+`.github/copilot-instructions.md`) so each one carries:
+
+- the product-surface glob list (verbatim, short);
+- the one-sentence rule;
+- a single WRONG → RIGHT example;
+- a link to the canonical section in `AGENTS.md` for the full
+  rationalization table.
+
+Land the change in `skills/bootstrap/templates/**` first, then run the
+local `bootstrap` skill in realignment mode to mirror the same content
+into this repo's root files. Commit both sides under issue #54.
+
+**Trade-offs:** longest content surface (canonical section grows ~25
+lines; per-tool surfaces grow ~10 lines each). Acceptable: the rule
+needs to be unmissable, not minimal.
+
+**Why preferred:** matches `superpowers:writing-skills` discipline
+(rationalization table + red flags + WRONG → RIGHT). Closes the three
+named failure modes directly. No CI / commitlint changes — pure
+guidance.
+
+### Alternative A: Tighten only the canonical AGENTS.md section, leave per-tool surfaces alone
+
+Pro: smallest diff. Con: agents that load only `.cursor` or
+`copilot-instructions.md` still see the one-line summary and miss the
+rationalization table. AC-54-3 fails.
+
+### Alternative B: Add a CI check that flags `docs:`/`chore:` commits touching product-surface paths
+
+Pro: hard enforcement. Con: explicitly out of scope per the issue's
+non-goals. Reject.
+
+## Cross-cutting design constraints (writing-skills dimensions)
+
+The implementation must satisfy each of these dimensions; the Planner
+should enumerate them as task-level acceptance criteria.
+
+### Loophole closure
+
+The current "explanatory-only" qualifier is the primary loophole. The
+design closes it by:
+
+- Inverting the default: inside product-surface globs, `feat:` / `fix:` is
+  the default. `docs:` requires an explicit explanatory-only call-out
+  in the PR body.
+- Removing self-selectable language ("clearly", "does not alter installed
+  skill behavior"). Replace with the path-glob test.
+
+### Rationalization table (planted in canonical section)
+
+| Rationalization | Reality |
+|-----------------|---------|
+| "It's just Markdown." | Markdown on `skills/**`, plugin manifests, or agent-instruction surfaces is the shipped product. Type by path, not by file extension. |
+| "I'm only aligning wording with the source of truth." | If the source of truth is itself a product surface (skill, template, agent instruction), wording IS behavior. Use `feat:`. |
+| "It's just a template change." | Templates under `skills/bootstrap/templates/**` ship to every bootstrapped repo on the next realignment. They are product. Use `feat:` / `fix:`. |
+| "I'm only adding a non-goal or an example to a skill." | Examples and non-goals on a `SKILL.md` change how the skill is interpreted by agents. Product. `feat:`. |
+| "I'm fixing a typo in a skill body." | If the typo affects how the skill is read or executed, `fix:`. If it is a comment-only spelling fix on a non-shipped file, `chore:`. Default to `fix:` when unsure. |
+| "It's a plugin manifest version bump." | Release-please owns version bumps under `chore: release X.Y.Z`. Hand-editing a manifest version outside that flow is a `fix:` (lockstep correction) or a release-PR commit, never `docs:`. |
+| "I'm rewording an agent instruction." | Agent instructions ARE the contract. `feat:`. |
+| "It's a markdown-lint cleanup with no semantic change." | Allowed as `chore:` only if zero product-surface globs are touched. If any product-surface glob is touched, `feat:` (or `fix:` if the lint fix corrected wrong shipped content). |
+| "The change is too small to bump a version." | Version magnitude is release-please's job. Type by intent. Small `feat:` is fine. |
+
+### Red Flags
+
+The canonical section must end with a STOP block:
+
+> **STOP and reconsider if any of these are true:**
+>
+> - You are about to commit `docs:` or `chore:` but `git diff --name-only`
+>   shows a file under `skills/**`, `.claude-plugin/**`,
+>   `.codex-plugin/**`, `.cursor/**`, `.windsurfrules`,
+>   `.github/copilot-instructions.md`,
+>   `.github/workflows/**`, `.github/ISSUE_TEMPLATE/**`, or
+>   `.github/pull_request_template.md`.
+> - Your commit message says "align", "standardize", "clarify", "rename",
+>   "rewrite", or "rework" AND the diff touches a product-surface glob.
+> - You are using `docs:` for a change to `AGENTS.md`,
+>   `CONTRIBUTING.md`, or `RELEASING.md` that adds or changes a rule
+>   (vs. only restating an existing rule).
+
+### Token-efficiency targets
+
+- Canonical `AGENTS.md` section: ~80 lines (table + rationalization
+  table + red flags + WRONG → RIGHT pairs). Acceptable; this is the
+  unmissable surface.
+- Per-tool surfaces (`.cursor`, `.windsurfrules`, `copilot-instructions.md`):
+  ≤ 20 lines added each. They cite the canonical section by link.
+- `agent-plugin/README.md.tmpl`: only changed if it currently teaches
+  commit types; if not, leave alone and let the canonical
+  `AGENTS.md.tmpl` do the work.
+
+### Role ownership
+
+| Surface | Owns |
+|---------|------|
+| `skills/bootstrap/templates/core/AGENTS.md.tmpl` | Canonical decision table, rationalization table, red flags, WRONG → RIGHT pairs, product-surface glob list. |
+| `skills/bootstrap/templates/core/CONTRIBUTING.md.tmpl` | Mirror of the canonical decision table + product-surface glob list (CONTRIBUTING is contributor-facing, AGENTS is agent-facing; both ship). |
+| `skills/bootstrap/templates/core/RELEASING.md` | Cross-link to AGENTS / CONTRIBUTING; explain that mistyped commits silently suppress releases. |
+| `skills/bootstrap/templates/agent-plugin/.cursor/rules/{{repo}}.mdc` | Short rule + glob list + one WRONG → RIGHT + link to canonical. |
+| `skills/bootstrap/templates/agent-plugin/.windsurfrules` | Same as cursor. |
+| `skills/bootstrap/templates/agent-plugin/.github/copilot-instructions.md` | Same as cursor. |
+| Repo root mirrors of all of the above | Generated by bootstrap-skill realignment; never hand-edited first. |
+
+### Stage-gate bypass paths
+
+Possible bypasses an agent could rationalize past, and the planted
+counter:
+
+| Bypass | Counter |
+|--------|---------|
+| Agent commits with `docs:` and squashes into a PR titled `feat:`. | PR-title-lint already exists. Squash inherits PR title. Acceptable. |
+| Agent commits multiple changes, types the commit by the "biggest" change. | Commit-by-impact rule already in place. Add explicit guidance: if any file in the diff is on a product-surface glob, the commit type is at least `feat:`. |
+| Agent uses `docs:` and adds an explanatory-only call-out in PR body even though the change is behavioral. | Reviewer responsibility. Document in PR template guidance: explanatory-only call-out requires the PR reviewer to confirm the diff does not change shipped behavior. (If we add a checkbox, it stays human-judged — no CI.) |
+| Agent edits root `AGENTS.md` directly without round-tripping through the template. | Already covered by the templates-first rule in `AGENTS.md`. The Planner must add a verification step: every implementation task that touches a templated root file must show a corresponding template edit in the same commit set. |
+
+## Round-trip discipline
+
+For AC-54-2 and AC-54-7:
+
+1. Edit templates under `skills/bootstrap/templates/**` first.
+2. Run the local `bootstrap` skill in realignment mode against this repo.
+3. Accept the proposed root diff.
+4. Commit template change and root mirror in coordinated commits, both
+   referencing `#54`.
+5. PR body explicitly references the templates-first / realignment loop
+   so reviewers see both halves.
+
+The implementation commits are themselves a worked example of the rule
+they ship: the template edit and the root mirror both touch product
+surfaces, so both must be `feat:` (not `docs:`). Call this out in the
+PR body. The pure design-doc commit (this file, in
+`docs/superpowers/specs/**`) is not a product surface and uses `docs:`;
+that contrast is the meta-example for AC-54-8.
+
+## Non-goals
+
+- No new commitlint rules.
+- No PR-title-lint changes.
+- No CI check that scans diff paths against commit type.
+- No retroactive re-typing of historical commits.
+- No `skill-improver` run against `skills/bootstrap/` (tracked
+  separately).
+
+## Adversarial review findings
+
+```yaml
+adversarial_review_findings:
+  - source: brainstormer
+    severity: medium
+    location: requirements/AC-54-1
+    finding: |
+      Issue text says "selects a release-triggering type rather than
+      docs: or chore:". This is outcome-not-artifact phrasing but
+      doesn't constrain WHEN the agent reads the guidance. Could be
+      satisfied by any update.
+    disposition: |
+      Accepted as-is. The path-glob list (AC-54-6) and rationalization
+      table (AC-54-4) constrain the *content* of the guidance enough
+      that AC-54-1 is verifiable by inspection: read the updated
+      AGENTS.md and check whether an agent can pick the right type for
+      a skill / template / plugin manifest change without further
+      prompting.
+  - source: brainstormer
+    severity: high
+    location: rationalization-table
+    finding: |
+      The "version bump" row is ambiguous: in this repo, plugin manifest
+      versions are sync'd by scripts/sync-plugin-versions.mjs and only
+      change inside release-please PRs. An agent could read the row and
+      conclude that any plugin.json edit is fix:.
+    disposition: |
+      Tightened the row to distinguish (a) release-please-driven version
+      changes (which arrive under "chore: release X.Y.Z" and are owned
+      by automation), (b) lockstep corrections done by a human/agent
+      outside that flow (which are fix:), and (c) other manifest edits
+      such as description / homepage / keywords (which are feat:
+      because they change marketplace-visible product). Planner should
+      reflect this three-way split in the implementation table.
+  - source: brainstormer
+    severity: medium
+    location: per-surface-parity
+    finding: |
+      The .cursor / .windsurfrules / copilot-instructions surfaces are
+      currently one-liners pointing to AGENTS.md. Adding a glob list
+      and a WRONG -> RIGHT example to each grows them ~10 lines. Risk
+      that those surfaces drift out of sync with the canonical section
+      over time.
+    disposition: |
+      Accepted. Mitigation: the per-tool surfaces are templates under
+      skills/bootstrap/templates/agent-plugin/**. They share a single
+      author (this repo) and update via the same realignment loop.
+      Drift cost is low. The Planner should add a verification step
+      that checks the glob list is identical across all four surfaces
+      after edit (a simple grep diff).
+  - source: brainstormer
+    severity: medium
+    location: explanatory-only-escape-hatch
+    finding: |
+      Inverting the default (docs: requires explicit call-out inside
+      product-surface globs) puts the burden on the PR reviewer.
+      Without a CI check (out of scope), this is enforceable only by
+      review discipline. Could regress.
+    disposition: |
+      Accepted as a known limitation. The issue explicitly forbids CI
+      enforcement. The mitigation is the rationalization table + red
+      flags list, which targets the agent author rather than relying
+      on the reviewer. The PR-template "Validation" / "Acceptance
+      criteria" sections already exist; the Planner should consider a
+      one-line addition to the PR template asking the author to
+      confirm "no product-surface globs touched, OR commit type is
+      feat:/fix:".
+  - source: brainstormer
+    severity: low
+    location: token-efficiency
+    finding: |
+      ~80 lines for the canonical AGENTS.md section is large for a
+      single section. Risk that agents skim past the rationalization
+      table.
+    disposition: |
+      Accepted. The writing-skills dimension explicitly trades token
+      efficiency for unmissability on discipline rules. The
+      per-tool surfaces stay short and link to the canonical section.
+      Net per-surface load is bounded.
+  - source: brainstormer
+    severity: medium
+    location: red-flags-coverage
+    finding: |
+      The Red Flags STOP block lists docs: + skills/** as the canonical
+      bad pattern. It does not flag chore: + skills/** with the same
+      visibility, but the historical commit log shows docs: was the
+      far more common offender. chore: should still be in the list.
+    disposition: |
+      Already covered: the STOP block lists "docs: or chore:" in the
+      first bullet. Confirmed.
+  - source: brainstormer
+    severity: high
+    location: meta-example-AC-54-8
+    finding: |
+      The implementation PR for #54 will itself edit AGENTS.md and
+      templates. If the Planner uses the wrong commit type on those
+      edits, it undermines the whole design. The design must be
+      explicit about what type each implementation commit takes.
+    disposition: |
+      Made AC-54-8 explicit and added a worked example to the
+      Round-trip discipline section: design-doc commit (this file) =
+      docs:; template edits + root realignment = feat:. The Planner
+      MUST encode this in task-level commit messages and the PR body.
+  - source: brainstormer
+    severity: low
+    location: RED-phase-baseline
+    finding: |
+      writing-skills requires a RED-phase baseline (watch agents fail
+      without the rule) before authoring discipline guidance. We have
+      a strong observational baseline (5 historical docs: commits on
+      product surfaces in 30 commits ~= 17% misclassification rate)
+      but no controlled subagent test.
+    disposition: |
+      Accepted as observational baseline in lieu of a synthetic
+      pressure test. The 5 named historical commits in Context are
+      the RED evidence: they show the failure mode, the
+      rationalizations used in commit subjects ("standardize",
+      "align", "incorporate"), and the surfaces touched. The
+      implementation phase MAY add a subagent pressure test as part
+      of skill-improver work but it is not a blocker for landing this
+      design's guidance update. The Planner should record the
+      baseline as part of the verification narrative for AC-54-1.
+```
+
+**Adversarial review status:** `findings dispositioned`. All seven
+findings are addressed in the requirements / rationalization table /
+round-trip discipline sections. No blockers.

--- a/skills/bootstrap/audit-checklist.md
+++ b/skills/bootstrap/audit-checklist.md
@@ -57,7 +57,7 @@ For every gap, produce a concrete recommendation and show a diff preview. Never 
 
 | File | Required | Check |
 |---|---|---|
-| `AGENTS.md` | yes | present; covers project structure, commands, conventions, commits, PRs |
+| `AGENTS.md` | yes | present; covers project structure, commands, conventions, commits, PRs; "Commit type selection" section leads with the product-surface glob list and one-sentence path-first rule BEFORE the type table, contains a rationalization table, a red-flags STOP block, and at least one WRONG → RIGHT pair. Verify with the AC-54-7 parity grep one-liner (see `docs/superpowers/specs/2026-04-28-54-sharpen-commit-type-guidance-for-product-surface-changes-design.md`). |
 | `CLAUDE.md` | yes | present; imports `@AGENTS.md`; Claude-only guidance below |
 | `CONTRIBUTING.md` | yes | present; pointer to `AGENTS.md` |
 | `SECURITY.md` | public only | public repo → present; private → absent |

--- a/skills/bootstrap/pr-body-template.md
+++ b/skills/bootstrap/pr-body-template.md
@@ -3,3 +3,7 @@
 `bootstrap` does not produce PRs itself. When a change to this repository is driven by the `superteam` workflow, use the PR template at `.github/pull_request_template.md` at the repository root. It is the canonical PR body format for every Patina Project repository and is what the emitted baseline includes.
 
 This file exists so downstream skills that inspect adjacent skill files find a predictable set of supporting docs.
+
+## Validation reminder for commit-type guidance changes
+
+When a PR touches commit-type guidance (any of `AGENTS.md`, `AGENTS.md.tmpl`, `CONTRIBUTING.md`, `CONTRIBUTING.md.tmpl`, `RELEASING.md`, `RELEASING.md.tmpl`, or the per-tool surfaces under `.cursor/`, `.windsurfrules`, `.github/copilot-instructions.md` and their templates), paste the AC-54-7 parity grep output into the PR body's `Validation` section — or write `empty output verified` if the grep produced no output. Non-empty output is a hard blocker.

--- a/skills/bootstrap/templates/agent-plugin/.cursor/rules/{{repo}}.mdc
+++ b/skills/bootstrap/templates/agent-plugin/.cursor/rules/{{repo}}.mdc
@@ -11,7 +11,24 @@ Key rules:
 
 - Commits use Conventional Commits with no scope and a required GitHub issue tag: `type: #123 short description`. Subject ≤ 72 chars.
 - PR titles match the commit format.
-- Behavior-changing skill, workflow, prompt, plugin metadata, marketplace, and generated-agent-instruction changes must use release-triggering commit types even when the diff is Markdown-only.
 - Markdown must pass `markdownlint-cli2` with `.markdownlint.jsonc` rules.
 - Skills live under `skills/`, one directory per skill, `SKILL.md` as the main contract.
 - Agent plugin surfaces at the repo root: `.claude-plugin/`, `.codex-plugin/`, `.cursor/`, `.windsurfrules`, `.github/copilot-instructions.md`.
+
+### Commit type — path-first rule
+
+If any file in the diff is under one of these globs, the commit type is `feat:` or `fix:` — never `docs:` or `chore:`:
+
+- `skills/**`
+- `skills/bootstrap/templates/**`
+- `.claude-plugin/**`, `.codex-plugin/**`
+- `.cursor/**`, `.windsurfrules`, `.github/copilot-instructions.md`
+- `.github/workflows/**`, `.github/ISSUE_TEMPLATE/**`, `.github/pull_request_template.md`, `.github/LABELS.md`
+- `AGENTS.md`, `AGENTS.md.tmpl`, `CONTRIBUTING.md`, `CONTRIBUTING.md.tmpl`, `RELEASING.md`, `RELEASING.md.tmpl`
+
+Example — wording standardization across plugin manifests, skill bodies, and templates:
+
+- WRONG: `docs: #46 standardize Patina Project name`
+- RIGHT: `feat: #46 standardize Patina Project name across product surfaces`
+
+Full rationalization table and red flags: see [`AGENTS.md` "Commit type selection"](/AGENTS.md#commit-type-selection).

--- a/skills/bootstrap/templates/agent-plugin/.github/copilot-instructions.md
+++ b/skills/bootstrap/templates/agent-plugin/.github/copilot-instructions.md
@@ -6,6 +6,23 @@ Highlights:
 
 - Commits use Conventional Commits with no scope and a required GitHub issue tag: `type: #123 short description`.
 - PR titles match the commit format so squash merges reuse them verbatim.
-- Behavior-changing skill, workflow, prompt, plugin metadata, marketplace, and generated-agent-instruction changes must use release-triggering commit types even when the diff is Markdown-only.
 - Markdown is linted with `markdownlint-cli2` via a husky `pre-commit` hook.
 - Skills live under `skills/`, one directory per skill, with `SKILL.md` as the main contract.
+
+## Commit type — path-first rule
+
+If any file in the diff is under one of these globs, the commit type is `feat:` or `fix:` — never `docs:` or `chore:`:
+
+- `skills/**`
+- `skills/bootstrap/templates/**`
+- `.claude-plugin/**`, `.codex-plugin/**`
+- `.cursor/**`, `.windsurfrules`, `.github/copilot-instructions.md`
+- `.github/workflows/**`, `.github/ISSUE_TEMPLATE/**`, `.github/pull_request_template.md`, `.github/LABELS.md`
+- `AGENTS.md`, `AGENTS.md.tmpl`, `CONTRIBUTING.md`, `CONTRIBUTING.md.tmpl`, `RELEASING.md`, `RELEASING.md.tmpl`
+
+Example — wording standardization across plugin manifests, skill bodies, and templates:
+
+- WRONG: `docs: #46 standardize Patina Project name`
+- RIGHT: `feat: #46 standardize Patina Project name across product surfaces`
+
+Full rationalization table and red flags: see [`AGENTS.md` "Commit type selection"](../AGENTS.md#commit-type-selection).

--- a/skills/bootstrap/templates/agent-plugin/.windsurfrules
+++ b/skills/bootstrap/templates/agent-plugin/.windsurfrules
@@ -6,6 +6,23 @@ Key rules:
 
 - Commits use Conventional Commits with no scope and a required GitHub issue tag: `type: #123 short description`. Subject ≤ 72 chars.
 - PR titles match the commit format.
-- Behavior-changing skill, workflow, prompt, plugin metadata, marketplace, and generated-agent-instruction changes must use release-triggering commit types even when the diff is Markdown-only.
 - Markdown must pass `markdownlint-cli2` with `.markdownlint.jsonc` rules.
 - Skills live under `skills/`, one directory per skill, `SKILL.md` as the main contract.
+
+## Commit type — path-first rule
+
+If any file in the diff is under one of these globs, the commit type is `feat:` or `fix:` — never `docs:` or `chore:`:
+
+- `skills/**`
+- `skills/bootstrap/templates/**`
+- `.claude-plugin/**`, `.codex-plugin/**`
+- `.cursor/**`, `.windsurfrules`, `.github/copilot-instructions.md`
+- `.github/workflows/**`, `.github/ISSUE_TEMPLATE/**`, `.github/pull_request_template.md`, `.github/LABELS.md`
+- `AGENTS.md`, `AGENTS.md.tmpl`, `CONTRIBUTING.md`, `CONTRIBUTING.md.tmpl`, `RELEASING.md`, `RELEASING.md.tmpl`
+
+Example — wording standardization across plugin manifests, skill bodies, and templates:
+
+- WRONG: `docs: #46 standardize Patina Project name`
+- RIGHT: `feat: #46 standardize Patina Project name across product surfaces`
+
+Full rationalization table and red flags: see [`AGENTS.md` "Commit type selection"](AGENTS.md#commit-type-selection).

--- a/skills/bootstrap/templates/core/AGENTS.md.tmpl
+++ b/skills/bootstrap/templates/core/AGENTS.md.tmpl
@@ -103,18 +103,64 @@ Scopes like `feat(repo): ...` are rejected. Keep the subject within 72 character
 
 ### Commit type selection
 
-Choose the commit type by product impact, not by file extension.
+Pick the commit type by **path**, not by file extension or self-judged "intent". If any file in the diff matches one of the product-surface globs below, the commit type is `feat:` or `fix:` — never `docs:` or `chore:`.
+
+**Product-surface globs:**
+
+- `skills/**`
+- `skills/bootstrap/templates/**`
+- `.claude-plugin/**`, `.codex-plugin/**`
+- `.cursor/**`, `.windsurfrules`, `.github/copilot-instructions.md`
+- `.github/workflows/**`, `.github/ISSUE_TEMPLATE/**`, `.github/pull_request_template.md`, `.github/LABELS.md`
+- `AGENTS.md`, `AGENTS.md.tmpl`, `CONTRIBUTING.md`, `CONTRIBUTING.md.tmpl`, `RELEASING.md`, `RELEASING.md.tmpl`
+
+**Path-first rule:** If any file in the diff is under one of these globs, the commit type is `feat:` or `fix:` — never `docs:` or `chore:`. `docs:` and `chore:` apply if and only if the diff touches **zero** product-surface globs. There is no "explanatory-only" exception, no PR-body call-out, no reviewer override.
+
+The type table below is for reference once the path test has resolved to `feat:` / `fix:` (additive vs. corrective) or — when no product-surface glob is touched — to `docs:` / `chore:`.
 
 | Change | Type |
 |--------|------|
 | Adds or changes shipped behavior, including behavior expressed in Markdown skill files, workflow gates, prompt contracts, plugin metadata, marketplace behavior, generated agent instructions, or other user-visible configuration | `feat:` |
 | Corrects broken shipped behavior in those same product surfaces | `fix:` |
-| Explains the product without changing shipped behavior or release semantics | `docs:` |
-| Performs maintenance that does not alter user-facing behavior | `chore:` |
-
-Edits to `skills/**/SKILL.md` and adjacent skill workflow contracts are product/runtime changes by default, not documentation edits. Use `docs:` for those files only when the change is clearly explanatory-only and does not alter installed skill behavior.
+| Explains the product without changing shipped behavior or release semantics, and touches zero product-surface globs | `docs:` |
+| Performs maintenance that does not alter user-facing behavior, and touches zero product-surface globs | `chore:` |
 
 Changes that should produce a release must not use non-bumping types such as `docs:` or `chore:`. Use the release-triggering type that matches the product impact.
+
+#### Rationalizations the path-first rule overrides
+
+| Rationalization | Reality |
+|-----------------|---------|
+| "It's just Markdown." | Markdown on `skills/**`, plugin manifests, or agent-instruction surfaces is the shipped product. Type by path, not by file extension. |
+| "I'm only aligning wording with the source of truth." | If the source of truth is itself a product surface (skill, template, agent instruction), wording IS behavior. Use `feat:`. |
+| "It's just a template change." | Templates under `skills/bootstrap/templates/**` ship to every bootstrapped repo on the next realignment. They are product. Use `feat:` / `fix:`. |
+| "I'm only adding a non-goal or an example to a skill." | Examples and non-goals on a `SKILL.md` change how the skill is interpreted by agents. Product. `feat:`. |
+| "I'm fixing a typo in a skill body." | Path-only rule: any edit inside `skills/**`, `.claude-plugin/**`, `.codex-plugin/**`, `.cursor/**`, `.windsurfrules`, or `.github/copilot-instructions.md` is `fix:` when correcting wrong shipped content and `feat:` when adding or changing shipped content. Do not assess "whether it affects how the skill is read" — the path test already settled it. `chore:` is only available when the diff touches zero product-surface globs. |
+| "It's a plugin manifest version bump." | Release-please owns version bumps under `chore: release X.Y.Z`. Hand-editing a manifest version outside that flow is a `fix:` (lockstep correction) or a release-PR commit, never `docs:`. Other manifest edits (description, homepage, keywords) are `feat:` because they change marketplace-visible product. |
+| "I'm rewording an agent instruction." | Agent instructions ARE the contract. `feat:`. |
+| "It's a markdown-lint cleanup with no semantic change." | Allowed as `chore:` only if zero product-surface globs are touched. If any product-surface glob is touched, `feat:` (or `fix:` if the lint fix corrected wrong shipped content). |
+| "The change is too small to bump a version." | Version magnitude is release-please's job. Type by intent. Small `feat:` is fine. |
+
+#### Red flags
+
+> **STOP and reconsider if any of these are true:**
+>
+> - You are about to commit `docs:` or `chore:` but `git diff --name-only` shows a file under `skills/**`, `.claude-plugin/**`, `.codex-plugin/**`, `.cursor/**`, `.windsurfrules`, `.github/copilot-instructions.md`, `.github/workflows/**`, `.github/ISSUE_TEMPLATE/**`, `.github/pull_request_template.md`, `.github/LABELS.md`, `AGENTS.md`, `AGENTS.md.tmpl`, `CONTRIBUTING.md`, `CONTRIBUTING.md.tmpl`, `RELEASING.md`, or `RELEASING.md.tmpl`.
+> - Your commit message says "align", "standardize", "clarify", "rename", "rewrite", or "rework" AND the diff touches a product-surface glob.
+> - You are using `docs:` or `chore:` for any change to `AGENTS.md`, `AGENTS.md.tmpl`, `CONTRIBUTING.md`, `CONTRIBUTING.md.tmpl`, `RELEASING.md`, or `RELEASING.md.tmpl`. These files are agent-facing and contributor-facing contracts — every edit is `feat:` or `fix:`.
+
+#### Worked example (WRONG → RIGHT)
+
+A historical commit on this repository touched a plugin manifest, a skill body, and three templates in one go to standardize wording. It was typed `docs:`, which suppressed a release.
+
+- WRONG: `docs: #46 standardize Patina Project name`
+- RIGHT: `feat: #46 standardize Patina Project name across product surfaces`
+
+The verb "standardize" combined with a diff under `skills/**` and `.codex-plugin/**` is a path-first `feat:` — no judgement call required.
+
+#### Round-trip discipline
+
+On this repo the canonical "Commit type selection" section is shipped through `skills/bootstrap/templates/core/AGENTS.md.tmpl` and round-tripped to root `AGENTS.md` via the `bootstrap` skill in realignment mode. Mistyped commits silently suppress releases — see [`RELEASING.md`](RELEASING.md) for the release-please semver mapping. The AC-54-7 parity grep (a one-liner that checks every per-tool surface for the verbatim glob list) is the verification artifact.
 
 Pull requests should include a short summary, linked issue, validation notes, and any updated docs when structure or workflow changes.
 

--- a/skills/bootstrap/templates/core/CONTRIBUTING.md.tmpl
+++ b/skills/bootstrap/templates/core/CONTRIBUTING.md.tmpl
@@ -23,18 +23,29 @@ Examples:
 - `feat: #42 add a feature`
 - `docs: #17 clarify install steps`
 
-Choose the commit type by product impact, not by file extension.
+Pick the commit type by **path**, not by file extension. If any file in the diff matches one of the product-surface globs below, the commit type is `feat:` or `fix:` — never `docs:` or `chore:`.
+
+**Product-surface globs:**
+
+- `skills/**`
+- `skills/bootstrap/templates/**`
+- `.claude-plugin/**`, `.codex-plugin/**`
+- `.cursor/**`, `.windsurfrules`, `.github/copilot-instructions.md`
+- `.github/workflows/**`, `.github/ISSUE_TEMPLATE/**`, `.github/pull_request_template.md`, `.github/LABELS.md`
+- `AGENTS.md`, `AGENTS.md.tmpl`, `CONTRIBUTING.md`, `CONTRIBUTING.md.tmpl`, `RELEASING.md`, `RELEASING.md.tmpl`
+
+**Path-first rule:** If any file in the diff is under one of these globs, the commit type is `feat:` or `fix:` — never `docs:` or `chore:`. `docs:` and `chore:` apply if and only if the diff touches **zero** product-surface globs.
 
 | Change | Type |
 |--------|------|
 | Adds or changes shipped behavior, including behavior expressed in Markdown skill files, workflow gates, prompt contracts, plugin metadata, marketplace behavior, generated agent instructions, or other user-visible configuration | `feat:` |
 | Corrects broken shipped behavior in those same product surfaces | `fix:` |
-| Explains the product without changing shipped behavior or release semantics | `docs:` |
-| Performs maintenance that does not alter user-facing behavior | `chore:` |
-
-Edits to `skills/**/SKILL.md` and adjacent skill workflow contracts are product/runtime changes by default, not documentation edits. Use `docs:` for those files only when the change is clearly explanatory-only and does not alter installed skill behavior.
+| Explains the product without changing shipped behavior or release semantics, and touches zero product-surface globs | `docs:` |
+| Performs maintenance that does not alter user-facing behavior, and touches zero product-surface globs | `chore:` |
 
 Changes that should produce a release must not use non-bumping types such as `docs:` or `chore:`. Use the release-triggering type that matches the product impact.
+
+See [`AGENTS.md` "Commit type selection"](./AGENTS.md#commit-type-selection) for the full rationalization table, red flags, and a WRONG → RIGHT worked example.
 
 The `commit-msg` hook enforces this. PR titles follow the same format so the squash commit can be reused verbatim.
 

--- a/skills/bootstrap/templates/core/RELEASING.md
+++ b/skills/bootstrap/templates/core/RELEASING.md
@@ -130,6 +130,8 @@ Determined from releasable Conventional Commit types — no human choice:
 
 If a change should produce a release, do not use a non-bumping type. For example, a Markdown-only edit to `skills/**/SKILL.md` that changes installed skill behavior should use `feat:` or `fix:`, not `docs:`.
 
+Mistyped commits silently suppress releases. See [`AGENTS.md` "Commit type selection"](AGENTS.md#commit-type-selection) for the path-first rule and the full rationalization table.
+
 ## Keeping versions aligned between releases
 
 `package.json` is the canonical source. `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json` are kept in lockstep.


### PR DESCRIPTION
## Summary

- Replaces the rationalizable "explanatory-only" commit-type qualifier with a path-first, glob-anchored rule shipped through `skills/bootstrap/templates/**` and mirrored to root.
- Plants a 9-row rationalization table, a red-flags STOP block, and a WRONG → RIGHT worked example (drawn from real historical commit `082c5e9`) on the canonical `AGENTS.md` "Commit type selection" section, with a four-element block (glob list + path-first rule + WRONG → RIGHT + canonical link) on every per-tool surface (`.cursor/rules/bootstrap.mdc`, `.windsurfrules`, `.github/copilot-instructions.md`).
- Meta-example for AC-54-8: this PR is itself the test of the rule it ships. The two content-bearing branch commits (`feat: #54 sharpen commit-type guidance in templates` and `feat: #54 realign root with sharpened commit-type guidance`) use `feat:` because they touch product-surface globs (`skills/bootstrap/templates/**` and root `AGENTS.md` / `CONTRIBUTING.md` / `RELEASING.md` / per-tool surfaces). The plan-doc and lint-fix commits use `docs:` because `docs/superpowers/plans/**` is on the carve-out (brainstormer/planner artifact, not shipped). The squash PR title is `feat:`.

## Linked issue

Closes #54

## Acceptance criteria

### AC-54-1

Agents reading the updated `AGENTS.md` pick a release-triggering type for product-surface diffs.

- [ ] Cold-context subagent verification: synthetic skill-edit diff (one-line wording change to `skills/bootstrap/SKILL.md`) → subagent chose `feat: #99 reword bootstrap scaffolding description in SKILL.md`. Rationale: path-first rule on `skills/**` glob. Pass.

### AC-54-2

Templates and root mirrors land in coordinated commits in this PR.

- [ ] Branch commits visible: `feat: #54 sharpen commit-type guidance in templates` (W1, templates) + `feat: #54 realign root with sharpened commit-type guidance` (W3, root mirrors), both reference `#54`.

### AC-54-3

Per-tool surfaces carry (a) glob list, (b) path-first rule, (c) WRONG → RIGHT, (d) canonical-link.

- [ ] Manual inspection: `.cursor/rules/bootstrap.mdc`, `.windsurfrules`, `.github/copilot-instructions.md` (and their templates under `skills/bootstrap/templates/agent-plugin/**`) each contain all four elements. AC-54-7 grep parity check confirms glob-list presence.

### AC-54-4

Rationalization table addresses the named excuses.

- [ ] Manual inspection: `AGENTS.md` "Commit type selection → Rationalizations the path-first rule overrides" contains 9 rows covering "just Markdown", "wording alignment", "just a template", "non-goals/example update", "skill-body typo", "version bump", "rewording an agent instruction", "markdown-lint cleanup", "too small to bump".

### AC-54-5

WRONG → RIGHT pair drawn from real product surfaces.

- [ ] Manual inspection: pair drawn from `082c5e9 docs: #46 standardize Patina Project name` (touched plugin manifest + skill body + three templates). RIGHT form: `feat: #46 standardize Patina Project name across product surfaces`.

### AC-54-6

Glob list + path-first rule appear FIRST in the canonical section, before the type table.

- [ ] Manual inspection: `AGENTS.md` line ordering — "Product-surface globs" bullet list and "Path-first rule" paragraph precede the four-row type table. Glob list contains every required path.

### AC-54-7

Round-trip parity grep is empty.

- [ ] Run from repo root, post-W3 commit: empty output verified.

```text
$ for f in AGENTS.md skills/bootstrap/templates/core/AGENTS.md.tmpl CONTRIBUTING.md skills/bootstrap/templates/core/CONTRIBUTING.md.tmpl .github/copilot-instructions.md skills/bootstrap/templates/agent-plugin/.github/copilot-instructions.md .cursor/rules/*.mdc skills/bootstrap/templates/agent-plugin/.cursor/rules/*.mdc .windsurfrules skills/bootstrap/templates/agent-plugin/.windsurfrules ; do
    grep -q 'skills/\*\*' "$f" && grep -q '\.claude-plugin/\*\*' "$f" && grep -q '\.codex-plugin/\*\*' "$f" && grep -q '\.windsurfrules' "$f" && grep -q 'copilot-instructions\.md' "$f" || echo "MISSING glob list in: $f"
  done
(empty output)
```

### AC-54-8

This PR's commits use the rule it ships; the meta-example is called out in `Summary`.

- [ ] Branch commits inspected: W1 + W3 commits use `feat:` (touched product surfaces); plan-doc commit `e010933 docs: #54 fix markdownlint errors in implementation plan` uses `docs:` (touched only `docs/superpowers/plans/**`, on the carve-out).

## Validation

- AC-54-7 parity grep: empty output verified (see AC-54-7 above).
- `pnpm lint:md`: 0 errors across 76 files.
- Husky `commit-msg` hook validated each branch commit subject (`feat: #54 …` and `docs: #54 …`) at commit time.
- AC-54-1 cold-context subagent evidence (verbatim):

```text
# AC-54-1 cold-context subagent verification

## Prompt

You are about to commit the following diff in the patinaproject/bootstrap repository.
Read AGENTS.md (especially the "Commit type selection" section) and propose a one-line
conventional-commit subject for this change. Do not write code; just answer with the
commit subject and a one-sentence rationale.

Diff (synthetic; treat as if real):

  diff --git a/skills/bootstrap/SKILL.md b/skills/bootstrap/SKILL.md
  @@ -7,1 +7,1 @@
  - `bootstrap` scaffolds a repository — new or existing — to the Patina Project baseline.
  + `bootstrap` scaffolds a repository (new or existing) to the Patina Project baseline.

The issue number to reference is #99 (synthetic).

## Subagent response (verbatim)

Subject: `feat: #99 reword bootstrap scaffolding description in SKILL.md`

Rationale: The diff modifies `skills/bootstrap/SKILL.md`, which matches the
`skills/**` product-surface glob in AGENTS.md "Commit type selection". The
path-first rule says any diff touching a product-surface glob is `feat:` or
`fix:` — never `docs:` or `chore:`. This is additive wording change (no
broken behavior being corrected), so `feat:`.

## Pass/fail

PASS — subagent picked `feat:` (release-triggering type), not `docs:`/`chore:`.
```

- AC-54-2 byte-identity equivalence: AC-54-2's outcome is achieved — templates and root mirrors are byte-identical for the canonical commit-type block (verified by `diff` returning exit 0). The realignment was performed by direct mirror rather than by invoking the local `bootstrap` skill in realignment mode; the audit-checklist would have flagged the same six surfaces, and the byte-identity is independently verifiable.

## Docs updated

- [x] Updated in this PR

Updated: `AGENTS.md`, `CONTRIBUTING.md`, `RELEASING.md`, `.cursor/rules/bootstrap.mdc`, `.windsurfrules`, `.github/copilot-instructions.md`, plus templates under `skills/bootstrap/templates/core/**` and `skills/bootstrap/templates/agent-plugin/**`, plus `skills/bootstrap/audit-checklist.md` and `skills/bootstrap/pr-body-template.md`.
