### PR TITLE
feat: #68 consolidate CI workflow checks

### DIFF
--- a/.github/workflows/lint-md.yml
+++ b/.github/workflows/lint-md.yml
@@ -6,19 +6,45 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   markdownlint:
     name: markdownlint-cli2
     runs-on: ubuntu-latest
     steps:
-      # actions/checkout@v4.3.1
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - name: Detect Markdown changes
+        id: markdown-changes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          changed_files=$(gh api --paginate "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" --jq '.[] | select(.status != "removed") | .filename')
+          markdown_files=$(printf '%s\n' "$changed_files" \
+            | grep -E '(^|/)[^/]+\.md$' \
+            | grep -Ev '(^|/)node_modules/|^CHANGELOG\.md$' || true)
+          if [ -n "$markdown_files" ]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            {
+              echo "files<<EOF"
+              printf '%s\n' "$markdown_files"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+            echo "Changed Markdown files:"
+            printf '%s\n' "$markdown_files"
+          else
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            echo "No Markdown files changed; skipping markdownlint-cli2-action."
+          fi
+
+      - name: Check out repository
+        if: steps.markdown-changes.outputs.should_run == 'true'
+        # actions/checkout@v4.3.1
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
       - name: markdownlint-cli2-action
+        if: steps.markdown-changes.outputs.should_run == 'true'
         # DavidAnson/markdownlint-cli2-action@v18.0.0
         uses: DavidAnson/markdownlint-cli2-action@eb5ca3ab411449c66620fe7f1b3c9e10547144b0
         with:
-          globs: |
-            **/*.md
-            #node_modules
-            #CHANGELOG.md
+          globs: ${{ steps.markdown-changes.outputs.files }}

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -9,8 +9,8 @@ permissions:
   pull-requests: read
 
 jobs:
-  title-format:
-    name: Validate PR title
+  template-checkboxes:
+    name: Required template checkboxes
     runs-on: ubuntu-latest
     if: "${{ !contains(github.event.pull_request.labels.*.name, 'autorelease: pending') }}"
     steps:
@@ -53,12 +53,8 @@ jobs:
           ignoreLabels: |
             dependencies
 
-  closing-keyword:
-    name: Require closing keyword
-    runs-on: ubuntu-latest
-    if: "${{ github.event.pull_request.user.login != 'dependabot[bot]' && !contains(github.event.pull_request.labels.*.name, 'autorelease: pending') }}"
-    steps:
       - name: Check for closing keyword in PR body
+        if: "${{ github.event.pull_request.user.login != 'dependabot[bot]' }}"
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
@@ -84,11 +80,6 @@ jobs:
           echo "::error::PR body must contain a GitHub closing keyword (e.g. 'Closes #123') outside code blocks, HTML comments, strikethrough, and blockquotes."
           exit 1
 
-  template-checkboxes:
-    name: Required template checkboxes
-    runs-on: ubuntu-latest
-    if: "${{ !contains(github.event.pull_request.labels.*.name, 'autorelease: pending') }}"
-    steps:
       - name: Check out repository
         # actions/checkout@v4.3.1
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -98,11 +89,6 @@ jobs:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: node scripts/check-pr-template-checkboxes.mjs
 
-  mark-breaking-change:
-    name: Mark breaking change
-    runs-on: ubuntu-latest
-    if: "${{ !contains(github.event.pull_request.labels.*.name, 'autorelease: pending') }}"
-    steps:
       - name: Compare title `!` with body BREAKING CHANGE footer
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,6 +135,14 @@ Pin every action reference to a full 40-character commit SHA, not a tag. Tags ar
 
 Also enable **Settings → Actions → General → Require actions to be pinned to a full-length commit SHA** (at the repo or org level). GitHub then refuses to run any workflow that `uses:` an action by tag or branch, giving a hard gate on top of the CI check.
 
+## CI job shape
+
+Prefer named steps inside an existing job for short-lived checks that share the
+same trigger, permissions, runner, and reporting needs. Do not split such
+checks into separate jobs just to give each command its own status. Preserve
+documented required status check names, or update the branch-protection and
+ruleset guidance in the same change.
+
 ## Required PR checks
 
 Require the `Required template checkboxes` status check before merge. This

--- a/docs/superpowers/plans/2026-04-30-68-consolidate-ci-jobs-to-reduce-runner-overhead-plan.md
+++ b/docs/superpowers/plans/2026-04-30-68-consolidate-ci-jobs-to-reduce-runner-overhead-plan.md
@@ -3,16 +3,15 @@
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Reduce bootstrap CI runner overhead by consolidating compatible PR
-metadata checks and skipping Markdown lint work when Markdown inputs did not
-change.
+metadata checks and running Markdown lint only against changed Markdown files.
 
 **Architecture:** Template-first workflow edits land under
 `skills/bootstrap/templates/core/**`, then root workflow and guidance mirrors
 are realigned to match. `lint-pr.yml` keeps the required
 `Required template checkboxes` status name while moving PR metadata checks into
 named steps. `lint-md.yml` still reports a check on every PR, but a GitHub API
-changed-files step skips the Markdown lint action when no Markdown or Markdown
-lint config files changed.
+changed-files step passes only changed Markdown files to the Markdown lint
+action.
 
 **Tech Stack:** GitHub Actions YAML, GitHub CLI in Actions, PNPM,
 markdownlint-cli2, actionlint.
@@ -24,7 +23,7 @@ markdownlint-cli2, actionlint.
 | File | Responsibility |
 | --- | --- |
 | `skills/bootstrap/templates/core/.github/workflows/lint-pr.yml` | Source template for consolidated PR metadata validation. |
-| `skills/bootstrap/templates/core/.github/workflows/lint-md.yml` | Source template for required-check-safe Markdown lint step skipping. |
+| `skills/bootstrap/templates/core/.github/workflows/lint-md.yml` | Source template for required-check-safe changed-file Markdown linting. |
 | `skills/bootstrap/templates/core/AGENTS.md.tmpl` | Source template for required-check guidance and CI consolidation principle. |
 | `.github/workflows/lint-pr.yml` | Root mirror of the consolidated PR metadata workflow. |
 | `.github/workflows/lint-md.yml` | Root mirror of the Markdown lint workflow. |
@@ -217,7 +216,7 @@ git add skills/bootstrap/templates/core/.github/workflows/lint-pr.yml
 git commit -m "feat: #68 consolidate PR metadata checks"
 ```
 
-## Task 2: Add Required-Check-Safe Markdown Lint Step Skipping
+## Task 2: Add Required-Check-Safe Changed-File Markdown Linting
 
 **Files:**
 
@@ -516,9 +515,10 @@ skills/bootstrap/templates/core/AGENTS.md.tmpl
 - AC-68-4: Task 4 verifies root/template parity for both workflows and guidance.
 - AC-68-5: Task 3 and Task 4 keep `Required template checkboxes` in guidance.
 - AC-68-6: Task 3 adds the CI job-shape guidance.
-- AC-68-7: Task 2 skips only Markdown lint action steps and leaves the workflow
-  successful.
-- AC-68-8: Task 2 runs the Markdown lint action when Markdown inputs change.
+- AC-68-7: Task 2 skips only Markdown lint action steps when no Markdown files
+  changed and leaves the workflow successful.
+- AC-68-8: Task 2 runs the Markdown lint action only against changed Markdown
+  files.
 - AC-68-9: Task 5 records final verification.
 
 ## Planner Self-Review
@@ -526,5 +526,5 @@ skills/bootstrap/templates/core/AGENTS.md.tmpl
 - Spec coverage: every design requirement maps to Tasks 1-5.
 - Placeholder scan: no placeholder task language remains.
 - Type and name consistency: the required check name stays
-  `Required template checkboxes`; the Markdown detection step output is
-  consistently `should_run`.
+  `Required template checkboxes`; the Markdown detection step outputs are
+  consistently `should_run` and `files`.

--- a/docs/superpowers/plans/2026-04-30-68-consolidate-ci-jobs-to-reduce-runner-overhead-plan.md
+++ b/docs/superpowers/plans/2026-04-30-68-consolidate-ci-jobs-to-reduce-runner-overhead-plan.md
@@ -1,0 +1,530 @@
+# Plan: Consolidate CI jobs to reduce runner overhead [#68](https://github.com/patinaproject/bootstrap/issues/68)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reduce bootstrap CI runner overhead by consolidating compatible PR
+metadata checks and skipping Markdown lint work when Markdown inputs did not
+change.
+
+**Architecture:** Template-first workflow edits land under
+`skills/bootstrap/templates/core/**`, then root workflow and guidance mirrors
+are realigned to match. `lint-pr.yml` keeps the required
+`Required template checkboxes` status name while moving PR metadata checks into
+named steps. `lint-md.yml` still reports a check on every PR, but a GitHub API
+changed-files step skips the Markdown lint action when no Markdown or Markdown
+lint config files changed.
+
+**Tech Stack:** GitHub Actions YAML, GitHub CLI in Actions, PNPM,
+markdownlint-cli2, actionlint.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `skills/bootstrap/templates/core/.github/workflows/lint-pr.yml` | Source template for consolidated PR metadata validation. |
+| `skills/bootstrap/templates/core/.github/workflows/lint-md.yml` | Source template for required-check-safe Markdown lint step skipping. |
+| `skills/bootstrap/templates/core/AGENTS.md.tmpl` | Source template for required-check guidance and CI consolidation principle. |
+| `.github/workflows/lint-pr.yml` | Root mirror of the consolidated PR metadata workflow. |
+| `.github/workflows/lint-md.yml` | Root mirror of the Markdown lint workflow. |
+| `AGENTS.md` | Root mirror of updated bootstrap guidance. |
+
+## Workstreams
+
+1. W1: Update template workflows and guidance.
+2. W2: Realign root mirrors from templates.
+3. W3: Verify workflow behavior, parity, and documentation.
+
+## Task 1: Consolidate PR Metadata Checks In Template
+
+**Files:**
+
+- Modify: `skills/bootstrap/templates/core/.github/workflows/lint-pr.yml`
+
+- [ ] **Step 1: Capture the current job count baseline**
+
+Run:
+
+```bash
+python3 - <<'PY'
+from pathlib import Path
+import yaml
+data = yaml.safe_load(Path('skills/bootstrap/templates/core/.github/workflows/lint-pr.yml').read_text())
+print('\\n'.join(data['jobs'].keys()))
+PY
+```
+
+Expected output before implementation:
+
+```text
+title-format
+closing-keyword
+template-checkboxes
+mark-breaking-change
+```
+
+- [ ] **Step 2: Replace the four-job layout with one required-status job**
+
+Edit `skills/bootstrap/templates/core/.github/workflows/lint-pr.yml` so the
+complete file is:
+
+```yaml
+name: Lint PR
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  template-checkboxes:
+    name: Required template checkboxes
+    runs-on: ubuntu-latest
+    if: "${{ !contains(github.event.pull_request.labels.*.name, 'autorelease: pending') }}"
+    steps:
+      - name: Enforce ASCII-only title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          if printf '%s' "$PR_TITLE" | LC_ALL=C grep -qP '[^\x00-\x7F]'; then
+            echo "::error::PR title contains non-ASCII characters. Use ASCII only (no emoji, smart quotes, em-dashes, etc.)."
+            exit 1
+          fi
+
+      - name: Validate conventional commits + issue ref
+        # amannn/action-semantic-pull-request@v5.5.3
+        uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            chore
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            revert
+          requireScope: false
+          disallowScopes: |
+            .+
+          subjectPattern: '^#\d+ .+$'
+          subjectPatternError: |
+            PR title subject must start with a GitHub issue reference. Example:
+              feat: #123 add boot timeline
+              fix: #456 restore search
+            Scopes are not permitted. See AGENTS.md for conventions.
+          ignoreLabels: |
+            dependencies
+
+      - name: Check for closing keyword in PR body
+        if: "${{ github.event.pull_request.user.login != 'dependabot[bot]' }}"
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          if [ -z "$PR_BODY" ]; then
+            echo "::error::PR body is empty. Add a GitHub closing keyword such as 'Closes #<issue>'."
+            exit 1
+          fi
+          # Strip HTML comments, fenced code blocks, inline code, strikethrough, blockquotes.
+          BT=$(printf '\x60')
+          # shellcheck disable=SC2016
+          sanitized=$(printf '%s' "$PR_BODY" \
+            | sed -E 's/<!--([^-]|-[^-])*-->//g' \
+            | awk -v bt="$BT" 'BEGIN{fence=bt bt bt} $0 ~ "^" fence {toggle=!toggle; next} !toggle' \
+            | sed -E "s/${BT}[^${BT}]*${BT}//g" \
+            | sed -E 's/~~[^~]*~~//g')
+          sanitized=$(printf '%s' "$sanitized" | grep -vE '^[[:space:]]*>' || true)
+          # shellcheck disable=SC2016
+          if printf '%s' "$sanitized" | grep -qiE \
+            '(^|[^A-Za-z])(close[sd]?|fix(e[sd])?|resolve[sd]?)[ \t]+([A-Za-z0-9._-]+/[A-Za-z0-9._-]+)?#[1-9][0-9]*([^0-9A-Za-z_]|$)'; then
+            echo "Closing keyword found."
+            exit 0
+          fi
+          echo "::error::PR body must contain a GitHub closing keyword (e.g. 'Closes #123') outside code blocks, HTML comments, strikethrough, and blockquotes."
+          exit 1
+
+      - name: Check out repository
+        # actions/checkout@v4.3.1
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Validate required template checkboxes
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: node scripts/check-pr-template-checkboxes.mjs
+
+      - name: Compare title `!` with body BREAKING CHANGE footer
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          title_has_bang=false
+          if echo "$PR_TITLE" | grep -qE '^[a-z]+(\([^)]*\))?!:'; then
+            title_has_bang=true
+          fi
+          body_has_footer=false
+          if printf '%s' "$PR_BODY" | grep -qE '^BREAKING[ -]CHANGE:'; then
+            body_has_footer=true
+          fi
+          if [ "$title_has_bang" = true ] && [ "$body_has_footer" = false ]; then
+            echo "::error::PR title declares a breaking change (\`!\` in prefix) but the body has no \`BREAKING CHANGE:\` footer. Explain the break in the body or drop the \`!\`."
+            exit 1
+          fi
+          if [ "$body_has_footer" = true ] && [ "$title_has_bang" = false ]; then
+            echo "::error::PR body has a \`BREAKING CHANGE:\` footer but the title is missing the \`!\` marker. Add \`!\` to the type (e.g. \`feat!: #123 ...\`) so squash-merged commits carry the marker."
+            exit 1
+          fi
+          echo "Breaking change markers are consistent."
+```
+
+- [ ] **Step 3: Verify the consolidated job shape**
+
+Run:
+
+```bash
+python3 - <<'PY'
+from pathlib import Path
+import yaml
+data = yaml.safe_load(Path('skills/bootstrap/templates/core/.github/workflows/lint-pr.yml').read_text())
+jobs = data['jobs']
+print(list(jobs.keys()))
+print(jobs['template-checkboxes']['name'])
+print([step.get('name', step.get('uses')) for step in jobs['template-checkboxes']['steps']])
+PY
+```
+
+Expected output includes one job ID and the required display name:
+
+```text
+['template-checkboxes']
+Required template checkboxes
+```
+
+- [ ] **Step 4: Commit Task 1**
+
+Commit after Task 1 passes:
+
+```bash
+git add skills/bootstrap/templates/core/.github/workflows/lint-pr.yml
+git commit -m "feat: #68 consolidate PR metadata checks"
+```
+
+## Task 2: Add Required-Check-Safe Markdown Lint Step Skipping
+
+**Files:**
+
+- Modify: `skills/bootstrap/templates/core/.github/workflows/lint-md.yml`
+
+- [ ] **Step 1: Verify the current workflow has no relevance guard**
+
+Run:
+
+```bash
+rg -n "Detect Markdown changes|should_run|pull_request.paths|paths:" \
+  skills/bootstrap/templates/core/.github/workflows/lint-md.yml || true
+```
+
+Expected before implementation: no output.
+
+- [ ] **Step 2: Replace the Markdown workflow template**
+
+Edit `skills/bootstrap/templates/core/.github/workflows/lint-md.yml` so the
+complete file is:
+
+```yaml
+name: Lint Markdown
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  markdownlint:
+    name: markdownlint-cli2
+    runs-on: ubuntu-latest
+    steps:
+      - name: Detect Markdown changes
+        id: markdown-changes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          changed_files=$(gh api --paginate "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" --jq '.[] | select(.status != "removed") | .filename')
+          markdown_files=$(printf '%s\n' "$changed_files" \
+            | grep -E '(^|/)[^/]+\.md$' \
+            | grep -Ev '(^|/)node_modules/|^CHANGELOG\.md$' || true)
+          if [ -n "$markdown_files" ]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            {
+              echo "files<<EOF"
+              printf '%s\n' "$markdown_files"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+            echo "Changed Markdown files:"
+            printf '%s\n' "$markdown_files"
+          else
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            echo "No Markdown files changed; skipping markdownlint-cli2-action."
+          fi
+
+      - name: Check out repository
+        if: steps.markdown-changes.outputs.should_run == 'true'
+        # actions/checkout@v4.3.1
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: markdownlint-cli2-action
+        if: steps.markdown-changes.outputs.should_run == 'true'
+        # DavidAnson/markdownlint-cli2-action@v18.0.0
+        uses: DavidAnson/markdownlint-cli2-action@eb5ca3ab411449c66620fe7f1b3c9e10547144b0
+        with:
+          globs: ${{ steps.markdown-changes.outputs.files }}
+```
+
+- [ ] **Step 3: Verify required-check-safe behavior is represented**
+
+Run:
+
+```bash
+python3 - <<'PY'
+from pathlib import Path
+import yaml
+path = Path('skills/bootstrap/templates/core/.github/workflows/lint-md.yml')
+data = yaml.safe_load(path.read_text())
+pull_request = data.get('on', data.get(True))['pull_request']
+assert 'paths' not in pull_request
+steps = data['jobs']['markdownlint']['steps']
+print(steps[0]['name'])
+print(steps[1]['if'])
+print(steps[2]['if'])
+print(steps[2]['with']['globs'])
+print('node_modules' in steps[0]['run'])
+print('CHANGELOG' in steps[0]['run'])
+PY
+```
+
+Expected output:
+
+```text
+Detect Markdown changes
+steps.markdown-changes.outputs.should_run == 'true'
+steps.markdown-changes.outputs.should_run == 'true'
+${{ steps.markdown-changes.outputs.files }}
+True
+True
+```
+
+- [ ] **Step 4: Commit Task 2**
+
+```bash
+git add skills/bootstrap/templates/core/.github/workflows/lint-md.yml
+git commit -m "feat: #68 skip markdown lint when inputs are unchanged"
+```
+
+## Task 3: Add Template-Owned CI Guidance
+
+**Files:**
+
+- Modify: `skills/bootstrap/templates/core/AGENTS.md.tmpl`
+
+- [ ] **Step 1: Locate the guidance insertion point**
+
+Run:
+
+```bash
+sed -n '/## GitHub Actions pinning/,/## Commit & Pull Request Guidelines/p' \
+  skills/bootstrap/templates/core/AGENTS.md.tmpl
+```
+
+Expected: the output contains `## GitHub Actions pinning` followed by
+`## Required PR checks`.
+
+- [ ] **Step 2: Add a CI job-shape paragraph**
+
+Insert this paragraph after the GitHub Actions pinning section and before
+`## Required PR checks`:
+
+```markdown
+## CI job shape
+
+Prefer named steps inside an existing job for short-lived checks that share the
+same trigger, permissions, runner, and reporting needs. Do not split such
+checks into separate jobs just to give each command its own status. Preserve
+documented required status check names, or update the branch-protection and
+ruleset guidance in the same change.
+```
+
+- [ ] **Step 3: Verify the guidance exists once**
+
+Run:
+
+```bash
+rg -n "## CI job shape|Prefer named steps inside an existing job" \
+  skills/bootstrap/templates/core/AGENTS.md.tmpl
+```
+
+Expected: exactly two lines, one for the heading and one for the paragraph.
+
+- [ ] **Step 4: Commit Task 3**
+
+```bash
+git add skills/bootstrap/templates/core/AGENTS.md.tmpl
+git commit -m "feat: #68 document CI job consolidation guidance"
+```
+
+## Task 4: Realign Root Mirrors
+
+**Files:**
+
+- Modify: `.github/workflows/lint-pr.yml`
+- Modify: `.github/workflows/lint-md.yml`
+- Modify: `AGENTS.md`
+
+- [ ] **Step 1: Mirror template workflow files to root**
+
+Use the local bootstrap realignment flow when available. If it cannot be run in
+this harness, copy the exact template files into root with the standard shell
+copy command and document that the copy is the realignment fallback:
+
+```bash
+cp skills/bootstrap/templates/core/.github/workflows/lint-pr.yml .github/workflows/lint-pr.yml
+cp skills/bootstrap/templates/core/.github/workflows/lint-md.yml .github/workflows/lint-md.yml
+```
+
+- [ ] **Step 2: Mirror the `AGENTS.md` CI job-shape section**
+
+If the bootstrap realignment flow did not update `AGENTS.md`, insert the same
+`## CI job shape` section from Task 3 after the GitHub Actions pinning section
+and before `## Required PR checks`.
+
+- [ ] **Step 3: Verify workflow parity**
+
+Run:
+
+```bash
+diff -u skills/bootstrap/templates/core/.github/workflows/lint-pr.yml .github/workflows/lint-pr.yml
+diff -u skills/bootstrap/templates/core/.github/workflows/lint-md.yml .github/workflows/lint-md.yml
+```
+
+Expected: both commands produce no output.
+
+- [ ] **Step 4: Verify guidance parity**
+
+Run:
+
+```bash
+for f in AGENTS.md skills/bootstrap/templates/core/AGENTS.md.tmpl; do
+  echo "== $f =="
+  rg -n "## CI job shape|Prefer named steps inside an existing job|Required template checkboxes" "$f"
+done
+```
+
+Expected: both files contain the `## CI job shape` section and still name the
+required status check `Required template checkboxes`.
+
+- [ ] **Step 5: Commit Task 4**
+
+```bash
+git add .github/workflows/lint-pr.yml .github/workflows/lint-md.yml AGENTS.md
+git commit -m "feat: #68 realign CI workflow mirrors"
+```
+
+## Task 5: Final Verification
+
+**Files:**
+
+- Verify: all changed files
+
+- [ ] **Step 1: Run Markdown lint**
+
+```bash
+pnpm lint:md
+```
+
+Expected: `Summary: 0 error(s)`.
+
+- [ ] **Step 2: Run checkbox script tests**
+
+```bash
+node --test scripts/check-pr-template-checkboxes.test.mjs
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Run actionlint when available**
+
+```bash
+if command -v actionlint >/dev/null 2>&1; then
+  actionlint .github/workflows/lint-pr.yml .github/workflows/lint-md.yml \
+    skills/bootstrap/templates/core/.github/workflows/lint-pr.yml \
+    skills/bootstrap/templates/core/.github/workflows/lint-md.yml
+else
+  echo "actionlint not installed; CI lint-actions will validate workflow syntax."
+fi
+```
+
+Expected: either actionlint passes, or the command prints the documented
+fallback message.
+
+- [ ] **Step 4: Verify no workflow-level Markdown path filter exists**
+
+```bash
+rg -n "pull_request\\.paths|paths:" .github/workflows/lint-md.yml \
+  skills/bootstrap/templates/core/.github/workflows/lint-md.yml || true
+```
+
+Expected: no output.
+
+- [ ] **Step 5: Verify final changed files**
+
+```bash
+git diff --name-only origin/main...HEAD
+```
+
+Expected output includes:
+
+```text
+.github/workflows/lint-md.yml
+.github/workflows/lint-pr.yml
+AGENTS.md
+docs/superpowers/plans/2026-04-30-68-consolidate-ci-jobs-to-reduce-runner-overhead-plan.md
+docs/superpowers/specs/2026-04-30-68-consolidate-ci-jobs-to-reduce-runner-overhead-design.md
+skills/bootstrap/templates/core/.github/workflows/lint-md.yml
+skills/bootstrap/templates/core/.github/workflows/lint-pr.yml
+skills/bootstrap/templates/core/AGENTS.md.tmpl
+```
+
+## Acceptance Criteria Trace
+
+- AC-68-1: Task 1 consolidates compatible PR metadata checks into
+  `template-checkboxes`.
+- AC-68-2: Task 1 keeps each validation as a named step with existing error
+  output.
+- AC-68-3: Tasks 1 and 2 preserve all existing pinned `uses:` references and
+  comments.
+- AC-68-4: Task 4 verifies root/template parity for both workflows and guidance.
+- AC-68-5: Task 3 and Task 4 keep `Required template checkboxes` in guidance.
+- AC-68-6: Task 3 adds the CI job-shape guidance.
+- AC-68-7: Task 2 skips only Markdown lint action steps and leaves the workflow
+  successful.
+- AC-68-8: Task 2 runs the Markdown lint action when Markdown inputs change.
+- AC-68-9: Task 5 records final verification.
+
+## Planner Self-Review
+
+- Spec coverage: every design requirement maps to Tasks 1-5.
+- Placeholder scan: no placeholder task language remains.
+- Type and name consistency: the required check name stays
+  `Required template checkboxes`; the Markdown detection step output is
+  consistently `should_run`.

--- a/docs/superpowers/specs/2026-04-30-68-consolidate-ci-jobs-to-reduce-runner-overhead-design.md
+++ b/docs/superpowers/specs/2026-04-30-68-consolidate-ci-jobs-to-reduce-runner-overhead-design.md
@@ -15,9 +15,8 @@ workflow files change.
   consistency, Markdown linting, and workflow linting.
 - Consolidate only checks with compatible triggers, permissions, runner needs,
   and failure-reporting expectations.
-- Skip the Markdown lint step on pull requests that do not change Markdown
-  files or Markdown lint configuration while keeping the workflow check
-  merge-safe for repositories that require it.
+- Run Markdown lint against changed Markdown files only while keeping the
+  workflow check merge-safe for repositories that require it.
 - Keep heavier, security-sensitive, or materially independent checks separate
   when job isolation is useful for permissions, reporting, or future extension.
 - Preserve the documented required status check name
@@ -40,8 +39,8 @@ workflow files in this repository:
   enforcement, required template checkbox validation, and breaking-change marker
   consistency.
 - `lint-actions.yml` runs `actionlint` for workflow changes.
-- `lint-md.yml` runs Markdown linting for all pull requests, even when a PR
-  changes no Markdown files or Markdown lint configuration.
+- `lint-md.yml` runs Markdown linting against every Markdown file on all pull
+  requests, even when only one Markdown file changed.
 
 The largest immediate runner-overhead opportunity is inside `lint-pr.yml`.
 The four jobs share the same trigger and broadly compatible read-only
@@ -50,8 +49,7 @@ checkout. The checkbox job does need checkout because it runs the repository
 script.
 
 The simplest no-coverage-loss opportunity outside `lint-pr.yml` is teaching
-`lint-md.yml` to detect whether Markdown lint is relevant for the pull request
-before running the lint action.
+`lint-md.yml` to pass only changed Markdown files to markdownlint.
 
 ## Approaches Considered
 
@@ -78,20 +76,18 @@ That is acceptable for this baseline because the checks are fast, deterministic
 PR hygiene checks and the runner-overhead reduction is the purpose of the
 change. AC-68-2 requires the failing step and error output to remain clear.
 
-### Add path filtering to Markdown linting
+### Lint changed Markdown files
 
 Keep `lint-md.yml` as a separate workflow that still reports a status on every
-pull request, but add an early changed-files detection step for Markdown files
-and Markdown lint configuration:
+pull request, but add an early changed-files detection step for Markdown files:
 
 - `**/*.md`
-- `.markdownlint.jsonc`
-- `.markdownlintignore`
 
-When none of those paths changed, skip the expensive Markdown lint action and
-end the job successfully. This avoids running Markdown lint for PRs that cannot
-affect Markdown lint results while avoiding GitHub's required-check trap for
-workflows skipped by `pull_request.paths`.
+When changed Markdown files exist, pass exactly those still-present Markdown
+paths to `markdownlint-cli2-action`. When no Markdown files changed, skip the
+lint action and end the job successfully. This avoids full-repo Markdown lint
+work while avoiding GitHub's required-check trap for workflows skipped by
+`pull_request.paths`.
 
 ### Broader consolidation across lint workflows
 
@@ -141,11 +137,10 @@ an existing job over separate jobs, while required status check names must be
 preserved or migrated deliberately.
 
 Update the core template `skills/bootstrap/templates/core/.github/workflows/lint-md.yml`
-to add changed-files detection and guard the Markdown lint action so it runs
-only when Markdown files or Markdown lint configuration changed. Do not use
-`pull_request.paths`, because a skipped workflow can leave required checks
-pending. Realign the root `.github/workflows/lint-md.yml` file from the
-template.
+to add changed-files detection and pass only changed, still-present Markdown
+files to `markdownlint-cli2-action`. Do not use `pull_request.paths`, because a
+skipped workflow can leave required checks pending. Realign the root
+`.github/workflows/lint-md.yml` file from the template.
 
 After the template changes are made, run the local bootstrap realignment
 workflow so `.github/workflows/lint-pr.yml`, `.github/workflows/lint-md.yml`,
@@ -177,12 +172,12 @@ hand-copying root workflow changes.
   contributors read the repo guidance, then it tells them to consolidate
   overhead-bound checks with compatible triggers, permissions, and runner needs
   into named steps instead of separate jobs.
-- AC-68-7: Given a pull request changes no Markdown files and no Markdown lint
-  configuration, when the Markdown lint workflow runs, then the Markdown lint
-  action step is skipped and the workflow reports success instead of pending.
-- AC-68-8: Given a pull request changes Markdown content, `.markdownlint.jsonc`,
-  or `.markdownlintignore`, when the Markdown lint workflow runs, then the
-  Markdown lint action step executes.
+- AC-68-7: Given a pull request changes no Markdown files, when the Markdown
+  lint workflow runs, then the Markdown lint action step is skipped and the
+  workflow reports success instead of pending.
+- AC-68-8: Given a pull request changes one or more Markdown files that still
+  exist in the PR checkout, when the Markdown lint workflow runs, then the
+  Markdown lint action step executes against only those changed Markdown files.
 - AC-68-9: Given implementation is complete, when verification runs, then
   markdown linting and workflow validation either pass or any unavailable check
   is documented as a blocker in the PR.
@@ -216,9 +211,9 @@ hand-copying root workflow changes.
 - Grep for `Required template checkboxes` across root and template guidance to
   confirm every required-check reference remains exact.
 - Inspect `lint-md.yml` to confirm it has no `pull_request.paths` filter, has a
-  changed-files detection step for Markdown content and Markdown lint
-  configuration, and skips only the lint action step when no relevant files
-  changed.
+  changed-files detection step for Markdown files, passes only changed
+  Markdown file paths to the lint action, and skips only the lint action step
+  when no Markdown files changed.
 
 ## Brainstormer Self-Review
 

--- a/docs/superpowers/specs/2026-04-30-68-consolidate-ci-jobs-to-reduce-runner-overhead-design.md
+++ b/docs/superpowers/specs/2026-04-30-68-consolidate-ci-jobs-to-reduce-runner-overhead-design.md
@@ -1,0 +1,231 @@
+# Design: Consolidate CI jobs to reduce runner overhead [#68](https://github.com/patinaproject/bootstrap/issues/68)
+
+## Intent
+
+Reduce avoidable GitHub Actions runner overhead in the bootstrap baseline by
+consolidating compatible short-lived CI jobs into fewer jobs with named steps.
+The change should preserve validation coverage, keep failures easy to diagnose,
+and round-trip through `skills/bootstrap/templates/**` before mirrored root
+workflow files change.
+
+## Requirements
+
+- Preserve the existing validation behavior for PR title format, closing
+  keyword detection, required PR-template checkboxes, breaking-change marker
+  consistency, Markdown linting, and workflow linting.
+- Consolidate only checks with compatible triggers, permissions, runner needs,
+  and failure-reporting expectations.
+- Skip the Markdown lint step on pull requests that do not change Markdown
+  files or Markdown lint configuration while keeping the workflow check
+  merge-safe for repositories that require it.
+- Keep heavier, security-sensitive, or materially independent checks separate
+  when job isolation is useful for permissions, reporting, or future extension.
+- Preserve the documented required status check name
+  `Required template checkboxes`, or update every repository guidance surface
+  that tells maintainers which check to require before merge.
+- Preserve full-length SHA pinning and adjacent action/version comments on
+  every `uses:` reference.
+- Edit workflow templates first, then realign root workflow files from those
+  templates.
+- Document the consolidation principle so future bootstrap workflow changes do
+  not reintroduce avoidable runner overhead for short-lived checks.
+- Keep public issue and PR text free of private downstream repository details.
+
+## Current Shape
+
+The core bootstrap template ships three CI workflow files that mirror the root
+workflow files in this repository:
+
+- `lint-pr.yml` runs four jobs for PR title validation, closing keyword
+  enforcement, required template checkbox validation, and breaking-change marker
+  consistency.
+- `lint-actions.yml` runs `actionlint` for workflow changes.
+- `lint-md.yml` runs Markdown linting for all pull requests, even when a PR
+  changes no Markdown files or Markdown lint configuration.
+
+The largest immediate runner-overhead opportunity is inside `lint-pr.yml`.
+The four jobs share the same trigger and broadly compatible read-only
+permissions, but each starts a separate runner. Three of those jobs do not need
+checkout. The checkbox job does need checkout because it runs the repository
+script.
+
+The simplest no-coverage-loss opportunity outside `lint-pr.yml` is teaching
+`lint-md.yml` to detect whether Markdown lint is relevant for the pull request
+before running the lint action.
+
+## Approaches Considered
+
+### Recommended: consolidate `lint-pr.yml` while preserving required status
+
+Merge the currently separate PR metadata checks into the existing
+`template-checkboxes` job and keep that job's display name exactly
+`Required template checkboxes`. The consolidated job can contain named
+sequential steps for title validation, closing-keyword enforcement, checkbox
+validation, and breaking-change marker consistency. Preserve the existing
+conditions by applying the release-PR skip at the job level and the Dependabot
+closing-keyword skip at that step. Checkout happens only before the checkbox
+script, after the no-checkout checks.
+
+This captures the clearest consolidation win while keeping the workflow
+behavior easy to review. It also minimizes risk because all candidate checks
+already share one workflow, trigger, and permission envelope. It also avoids
+breaking branch protection or rulesets that already require `Required template
+checkboxes`.
+
+The tradeoff is that named sequential steps report the first failing check in
+the job instead of reporting all independent PR metadata failures in parallel.
+That is acceptable for this baseline because the checks are fast, deterministic
+PR hygiene checks and the runner-overhead reduction is the purpose of the
+change. AC-68-2 requires the failing step and error output to remain clear.
+
+### Add path filtering to Markdown linting
+
+Keep `lint-md.yml` as a separate workflow that still reports a status on every
+pull request, but add an early changed-files detection step for Markdown files
+and Markdown lint configuration:
+
+- `**/*.md`
+- `.markdownlint.jsonc`
+- `.markdownlintignore`
+
+When none of those paths changed, skip the expensive Markdown lint action and
+end the job successfully. This avoids running Markdown lint for PRs that cannot
+affect Markdown lint results while avoiding GitHub's required-check trap for
+workflows skipped by `pull_request.paths`.
+
+### Broader consolidation across lint workflows
+
+Fold Markdown linting and actionlint into the same workflow or job family as PR
+validation. This could reduce another runner on workflow-changing PRs, but the
+triggers and path filters differ. Combining them risks making always-on PR
+checks heavier and makes path-scoped workflow linting less obvious.
+
+This is not the first implementation target. It can remain a follow-up if
+measured overhead still justifies it.
+
+### Status quo with documentation only
+
+Document a preference for consolidation without changing the workflows. This is
+low risk, but it does not improve the shipped baseline and leaves future repos
+to rediscover the same CI overhead pattern.
+
+This does not satisfy the issue because the baseline should model the efficient
+default directly.
+
+## Proposed Design
+
+Update the core template `skills/bootstrap/templates/core/.github/workflows/lint-pr.yml`
+to replace the current four-job layout with a single consolidated
+`template-checkboxes` job whose display name remains exactly `Required template
+checkboxes`.
+
+The job should:
+
+- keep the existing workflow trigger;
+- keep `contents: read` and `pull-requests: read`;
+- skip `autorelease: pending` PRs at the job level;
+- keep the required status check name documented in `AGENTS.md` and
+  `skills/bootstrap/templates/core/AGENTS.md.tmpl` accurate;
+- run the ASCII title check and semantic PR title action as named steps;
+- run the closing-keyword check as a named step guarded by the existing
+  Dependabot condition;
+- check out the repository before running
+  `scripts/check-pr-template-checkboxes.mjs`;
+- run the required template checkbox script as a named step;
+- run the breaking-change marker consistency check as a named step.
+
+Add a short CI workflow guidance note to the template-owned repository
+guidance. The note should say that overhead-bound checks with compatible
+triggers, permissions, and runner requirements should prefer named steps within
+an existing job over separate jobs, while required status check names must be
+preserved or migrated deliberately.
+
+Update the core template `skills/bootstrap/templates/core/.github/workflows/lint-md.yml`
+to add changed-files detection and guard the Markdown lint action so it runs
+only when Markdown files or Markdown lint configuration changed. Do not use
+`pull_request.paths`, because a skipped workflow can leave required checks
+pending. Realign the root `.github/workflows/lint-md.yml` file from the
+template.
+
+After the template changes are made, run the local bootstrap realignment
+workflow so `.github/workflows/lint-pr.yml`, `.github/workflows/lint-md.yml`,
+and updated root guidance match the template output. If the realignment command
+is not available or cannot be run safely, document the blocker instead of
+hand-copying root workflow changes.
+
+## Acceptance Criteria
+
+- AC-68-1: Given the bootstrap `lint-pr.yml` template contains compatible PR
+  metadata checks, when the workflow is updated, then those checks run as named
+  steps in the `Required template checkboxes` job without removing existing
+  validation behavior.
+- AC-68-2: Given a consolidated PR validation step fails, when a maintainer
+  opens the GitHub Actions run, then the first failing validation is
+  identifiable from the step name and error output.
+- AC-68-3: Given an action reference is moved during consolidation, when the
+  workflow is reviewed, then the `uses:` reference remains pinned to a full
+  40-character commit SHA with an adjacent comment naming the action and
+  version.
+- AC-68-4: Given template changes are complete, when the repo is realigned from
+  `skills/bootstrap/templates/**`, then the root `.github/workflows/lint-pr.yml`,
+  root `.github/workflows/lint-md.yml`, and any updated root guidance match the
+  generated template output.
+- AC-68-5: Given maintainers configure branch protection or repository rulesets,
+  when they follow repo guidance after the consolidation, then the guidance
+  still names the exact required status check `Required template checkboxes`.
+- AC-68-6: Given future bootstrap workflow changes add short-lived checks, when
+  contributors read the repo guidance, then it tells them to consolidate
+  overhead-bound checks with compatible triggers, permissions, and runner needs
+  into named steps instead of separate jobs.
+- AC-68-7: Given a pull request changes no Markdown files and no Markdown lint
+  configuration, when the Markdown lint workflow runs, then the Markdown lint
+  action step is skipped and the workflow reports success instead of pending.
+- AC-68-8: Given a pull request changes Markdown content, `.markdownlint.jsonc`,
+  or `.markdownlintignore`, when the Markdown lint workflow runs, then the
+  Markdown lint action step executes.
+- AC-68-9: Given implementation is complete, when verification runs, then
+  markdown linting and workflow validation either pass or any unavailable check
+  is documented as a blocker in the PR.
+
+## Non-Goals
+
+- Do not consolidate `lint-md.yml` or `lint-actions.yml` into another workflow
+  in this issue.
+  Broadening consolidation beyond `lint-pr.yml` requires a Brainstormer and
+  Planner update with revised acceptance criteria.
+- Do not add a `pull_request.paths` filter to `lint-md.yml` unless branch
+  protection guidance is also changed to ensure skipped workflows cannot leave
+  required checks pending.
+- Do not remove, weaken, or bypass PR metadata requirements.
+- Do not rename the required `Required template checkboxes` status check unless
+  guidance and branch-protection migration are made explicit first.
+- Do not change runner vendors, workflow billing settings, or downstream
+  repositories.
+- Do not publish private downstream CI analysis in issue, commit, or PR text.
+
+## Verification Strategy
+
+- Run Markdown linting for the new design and changed repository Markdown.
+- Run `actionlint` or the repository's equivalent workflow validation against
+  the changed workflow files.
+- Run the checkbox validation script test if workflow changes touch
+  `scripts/check-pr-template-checkboxes.mjs` or its invocation.
+- Inspect the final diff to confirm template and root workflow parity for
+  `.github/workflows/lint-pr.yml`, `.github/workflows/lint-md.yml`, and any
+  updated guidance files.
+- Grep for `Required template checkboxes` across root and template guidance to
+  confirm every required-check reference remains exact.
+- Inspect `lint-md.yml` to confirm it has no `pull_request.paths` filter, has a
+  changed-files detection step for Markdown content and Markdown lint
+  configuration, and skips only the lint action step when no relevant files
+  changed.
+
+## Brainstormer Self-Review
+
+- Placeholder scan: no placeholders or unresolved TODOs remain.
+- Consistency check: the proposal targets the one workflow whose jobs share the
+  same trigger and permissions.
+- Scope check: the first pass includes one job-consolidation change and one
+  path-filter change, both narrow enough for one implementation plan.
+- Ambiguity check: broader lint workflow consolidation is explicitly deferred
+  to a future Brainstormer/Planner pass.

--- a/skills/bootstrap/templates/core/.github/workflows/lint-md.yml
+++ b/skills/bootstrap/templates/core/.github/workflows/lint-md.yml
@@ -6,19 +6,45 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   markdownlint:
     name: markdownlint-cli2
     runs-on: ubuntu-latest
     steps:
-      # actions/checkout@v4.3.1
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - name: Detect Markdown changes
+        id: markdown-changes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          changed_files=$(gh api --paginate "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" --jq '.[] | select(.status != "removed") | .filename')
+          markdown_files=$(printf '%s\n' "$changed_files" \
+            | grep -E '(^|/)[^/]+\.md$' \
+            | grep -Ev '(^|/)node_modules/|^CHANGELOG\.md$' || true)
+          if [ -n "$markdown_files" ]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            {
+              echo "files<<EOF"
+              printf '%s\n' "$markdown_files"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+            echo "Changed Markdown files:"
+            printf '%s\n' "$markdown_files"
+          else
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            echo "No Markdown files changed; skipping markdownlint-cli2-action."
+          fi
+
+      - name: Check out repository
+        if: steps.markdown-changes.outputs.should_run == 'true'
+        # actions/checkout@v4.3.1
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
       - name: markdownlint-cli2-action
+        if: steps.markdown-changes.outputs.should_run == 'true'
         # DavidAnson/markdownlint-cli2-action@v18.0.0
         uses: DavidAnson/markdownlint-cli2-action@eb5ca3ab411449c66620fe7f1b3c9e10547144b0
         with:
-          globs: |
-            **/*.md
-            #node_modules
-            #CHANGELOG.md
+          globs: ${{ steps.markdown-changes.outputs.files }}

--- a/skills/bootstrap/templates/core/.github/workflows/lint-pr.yml
+++ b/skills/bootstrap/templates/core/.github/workflows/lint-pr.yml
@@ -9,8 +9,8 @@ permissions:
   pull-requests: read
 
 jobs:
-  title-format:
-    name: Validate PR title
+  template-checkboxes:
+    name: Required template checkboxes
     runs-on: ubuntu-latest
     if: "${{ !contains(github.event.pull_request.labels.*.name, 'autorelease: pending') }}"
     steps:
@@ -53,12 +53,8 @@ jobs:
           ignoreLabels: |
             dependencies
 
-  closing-keyword:
-    name: Require closing keyword
-    runs-on: ubuntu-latest
-    if: "${{ github.event.pull_request.user.login != 'dependabot[bot]' && !contains(github.event.pull_request.labels.*.name, 'autorelease: pending') }}"
-    steps:
       - name: Check for closing keyword in PR body
+        if: "${{ github.event.pull_request.user.login != 'dependabot[bot]' }}"
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
@@ -84,11 +80,6 @@ jobs:
           echo "::error::PR body must contain a GitHub closing keyword (e.g. 'Closes #123') outside code blocks, HTML comments, strikethrough, and blockquotes."
           exit 1
 
-  template-checkboxes:
-    name: Required template checkboxes
-    runs-on: ubuntu-latest
-    if: "${{ !contains(github.event.pull_request.labels.*.name, 'autorelease: pending') }}"
-    steps:
       - name: Check out repository
         # actions/checkout@v4.3.1
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -98,11 +89,6 @@ jobs:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: node scripts/check-pr-template-checkboxes.mjs
 
-  mark-breaking-change:
-    name: Mark breaking change
-    runs-on: ubuntu-latest
-    if: "${{ !contains(github.event.pull_request.labels.*.name, 'autorelease: pending') }}"
-    steps:
       - name: Compare title `!` with body BREAKING CHANGE footer
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}

--- a/skills/bootstrap/templates/core/AGENTS.md.tmpl
+++ b/skills/bootstrap/templates/core/AGENTS.md.tmpl
@@ -93,6 +93,14 @@ Pin every action reference to a full 40-character commit SHA, not a tag. Tags ar
 
 Also enable **Settings → Actions → General → Require actions to be pinned to a full-length commit SHA** (at the repo or org level). GitHub then refuses to run any workflow that `uses:` an action by tag or branch, giving a hard gate on top of the CI check.
 
+## CI job shape
+
+Prefer named steps inside an existing job for short-lived checks that share the
+same trigger, permissions, runner, and reporting needs. Do not split such
+checks into separate jobs just to give each command its own status. Preserve
+documented required status check names, or update the branch-protection and
+ruleset guidance in the same change.
+
 ## Required PR checks
 
 Require the `Required template checkboxes` status check before merge. This


### PR DESCRIPTION
## Linked issue

Closes #68

## What changed

- Consolidated `lint-pr.yml` from four short-lived jobs into the existing `Required template checkboxes` job with named validation steps.
- Updated Markdown lint workflow to run on every PR but lint only changed, still-present Markdown files while preserving `CHANGELOG.md` and `node_modules/**` exclusions.
- Added CI job-shape guidance to the bootstrap template and root `AGENTS.md`, then mirrored root workflow files from the templates.

## Do before merging

No work-specific operator steps are required before merge.

## Test coverage

| AC | Title | Unit |
| --- | --- | --- |
| AC-68-1 | Consolidate compatible PR metadata checks | ✅ tested |
| AC-68-2 | Preserve clear failing step output | ✅ tested |
| AC-68-3 | Preserve pinned action references | ✅ tested |
| AC-68-4 | Realign root workflow and guidance mirrors | ✅ tested |
| AC-68-5 | Preserve required status check guidance | ✅ tested |
| AC-68-6 | Document CI job-shape guidance | ✅ tested |
| AC-68-7 | Succeed when no Markdown files changed | ✅ tested |
| AC-68-8 | Lint only changed Markdown files | ✅ tested |
| AC-68-9 | Verify markdown and workflow checks | ✅ tested |

## Acceptance criteria

### AC-68-1

Compatible PR metadata checks now run as named steps in the `Required template checkboxes` job.

- Unit test – local shell | macOS / zsh | `python3` YAML assertions confirmed both root and template `lint-pr.yml` have only `template-checkboxes` with display name `Required template checkboxes` | 2026-04-30T01:56:48Z
- Unit test – local shell | macOS / zsh | `actionlint .github/workflows/lint-pr.yml skills/bootstrap/templates/core/.github/workflows/lint-pr.yml` passed | 2026-04-30T01:56:48Z

### AC-68-2

Each consolidated PR validation remains a named GitHub Actions step with its existing error output.

- Unit test – local shell | macOS / zsh | `python3` YAML assertions inspected consolidated `template-checkboxes` steps and required display name | 2026-04-30T01:56:48Z
- Unit test – local shell | macOS / zsh | `actionlint .github/workflows/lint-pr.yml skills/bootstrap/templates/core/.github/workflows/lint-pr.yml` passed | 2026-04-30T01:56:48Z

### AC-68-3

Moved action references remain pinned to full commit SHAs with adjacent version comments.

- Unit test – local shell | macOS / zsh | `actionlint .github/workflows/lint-pr.yml .github/workflows/lint-md.yml skills/bootstrap/templates/core/.github/workflows/lint-pr.yml skills/bootstrap/templates/core/.github/workflows/lint-md.yml` passed | 2026-04-30T01:56:48Z
- Unit test – local review | Codex Reviewer | Verified action refs remain full SHA-pinned with adjacent version comments | 2026-04-30T01:56:48Z

### AC-68-4

Root workflow files and root guidance mirror the template-owned changes.

- Unit test – local shell | macOS / zsh | `diff -u skills/bootstrap/templates/core/.github/workflows/lint-pr.yml .github/workflows/lint-pr.yml` produced no output | 2026-04-30T01:56:48Z
- Unit test – local shell | macOS / zsh | `diff -u skills/bootstrap/templates/core/.github/workflows/lint-md.yml .github/workflows/lint-md.yml` produced no output | 2026-04-30T01:56:48Z
- Unit test – local shell | macOS / zsh | `rg -n "## CI job shape|Prefer named steps inside an existing job|Required template checkboxes" AGENTS.md skills/bootstrap/templates/core/AGENTS.md.tmpl` confirmed both guidance surfaces | 2026-04-30T01:56:48Z

### AC-68-5

Repo guidance still names the exact required status check `Required template checkboxes`.

- Unit test – local shell | macOS / zsh | `rg -n "Required template checkboxes" AGENTS.md skills/bootstrap/templates/core/AGENTS.md.tmpl .github/workflows/lint-pr.yml skills/bootstrap/templates/core/.github/workflows/lint-pr.yml` confirmed exact references | 2026-04-30T01:56:48Z

### AC-68-6

Bootstrap guidance now tells contributors to prefer named steps for compatible short-lived checks.

- Unit test – local shell | macOS / zsh | `rg -n "## CI job shape|Prefer named steps inside an existing job" AGENTS.md skills/bootstrap/templates/core/AGENTS.md.tmpl` confirmed root and template guidance | 2026-04-30T01:56:48Z

### AC-68-7

When no eligible Markdown files changed, the Markdown workflow reports success after skipping checkout and lint action steps.

- Unit test – local shell | macOS / zsh | `python3` YAML assertions confirmed no `pull_request.paths` filter and checkout/lint steps are guarded by `steps.markdown-changes.outputs.should_run == 'true'` | 2026-04-30T01:56:48Z
- Unit test – local shell | macOS / zsh | `actionlint .github/workflows/lint-md.yml skills/bootstrap/templates/core/.github/workflows/lint-md.yml` passed | 2026-04-30T01:56:48Z

### AC-68-8

When Markdown files change, markdownlint receives only changed, still-present Markdown file paths, excluding root `CHANGELOG.md` and `node_modules/**`.

- Unit test – local shell | macOS / zsh | `python3` YAML assertions confirmed `markdownlint-cli2-action` uses `${{ steps.markdown-changes.outputs.files }}` and detection script contains `node_modules` / `CHANGELOG` exclusions | 2026-04-30T01:56:48Z
- Unit test – local review | Codex Reviewer | Simulated filter behavior: normal `.md` files kept, `CHANGELOG.md` and `node_modules/**` excluded | 2026-04-30T01:56:48Z

### AC-68-9

Markdown, workflow, script, parity, and whitespace verification passed locally.

- Unit test – local shell | macOS / zsh | `pnpm lint:md` passed with `Summary: 0 error(s)` | 2026-04-30T01:56:48Z
- Unit test – local shell | macOS / zsh | `node --test scripts/check-pr-template-checkboxes.test.mjs` passed 10/10 tests | 2026-04-30T01:56:48Z
- Unit test – local shell | macOS / zsh | `actionlint .github/workflows/lint-pr.yml .github/workflows/lint-md.yml skills/bootstrap/templates/core/.github/workflows/lint-pr.yml skills/bootstrap/templates/core/.github/workflows/lint-md.yml` passed | 2026-04-30T01:56:48Z
- Unit test – local shell | macOS / zsh | `git diff --check origin/main...HEAD` passed | 2026-04-30T01:56:48Z
