### PR TITLE
fix: #72 require lint checks in rulesets

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -3,9 +3,6 @@ name: Actions
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
-    paths:
-      - ".github/workflows/**"
-      - ".github/actionlint.yaml"
 
 permissions:
   contents: read

--- a/docs/superpowers/plans/2026-04-30-72-require-lint-checks-in-branch-rulesets-plan.md
+++ b/docs/superpowers/plans/2026-04-30-72-require-lint-checks-in-branch-rulesets-plan.md
@@ -1,0 +1,277 @@
+# Plan: Require Lint checks in branch rulesets [#72](https://github.com/patinaproject/bootstrap/issues/72)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enforce the GitHub Actions `Lint` check in repository rulesets and make the actionlint workflow safe to require on every pull request.
+
+**Architecture:** Use the live GitHub ruleset API for repository enforcement and keep file changes limited to the bootstrap-owned actionlint workflow template plus its mirrored root output. Treat PR publication as the final proof point for shared `Lint` context behavior.
+
+**Tech Stack:** GitHub CLI/API, GitHub Actions rulesets, YAML workflows, markdownlint, actionlint, bootstrap template realignment discipline.
+
+---
+
+## File Structure
+
+- Modify: `skills/bootstrap/templates/core/.github/workflows/actions.yml`
+  Source template for the actionlint workflow.
+- Modify: `.github/workflows/actions.yml`
+  Mirrored root workflow produced from the template realignment loop.
+- Verify: GitHub repository ruleset `Required Lint checks`
+  Repository-owned branch ruleset requiring GitHub Actions `Lint`.
+- Verify: GitHub pull request checks
+  Latest-head evidence that the required `Lint` context behaves as intended.
+
+## Task 1: Capture Ruleset Enforcement
+
+**Files:**
+
+- Verify: GitHub repository rulesets
+
+- [ ] **Step 1: Inspect inherited and repository rulesets**
+
+Run:
+
+```bash
+gh api 'repos/{owner}/{repo}/rulesets?includes_parents=true' \
+  --jq '.[] | {id,name,source_type,enforcement,target,rules}'
+```
+
+Expected: inherited branch rulesets are visible. If no active rule requires
+`Lint`, continue to Step 2.
+
+- [ ] **Step 2: Confirm GitHub Actions app integration ID**
+
+Run against a recent pull request commit with GitHub Actions checks:
+
+```bash
+gh api repos/{owner}/{repo}/commits/<sha>/check-runs \
+  --jq '.check_runs[] | select(.app.slug=="github-actions") | .app | {id,slug,name}' \
+  | sort -u
+```
+
+Expected: the app is GitHub Actions and its integration ID is available for the
+ruleset payload.
+
+- [ ] **Step 3: Create or update repository ruleset**
+
+If inherited org rulesets cannot be edited from the current token, create a
+repo-owned active ruleset:
+
+```bash
+gh api repos/{owner}/{repo}/rulesets --method POST --input - <<'JSON'
+{
+  "name": "Required Lint checks",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["~DEFAULT_BRANCH", "refs/heads/production"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "required_status_checks": [
+          {
+            "context": "Lint",
+            "integration_id": <github-actions-integration-id>
+          }
+        ]
+      }
+    }
+  ]
+}
+JSON
+```
+
+Expected: response shows an active branch ruleset with
+`required_status_checks` for `Lint` and the GitHub Actions integration.
+
+- [ ] **Step 4: Verify ruleset**
+
+Run:
+
+```bash
+gh api repos/{owner}/{repo}/rulesets/<ruleset-id> \
+  --jq '{id,name,source_type,enforcement,conditions,rules}'
+```
+
+Expected: `Required Lint checks` is active, applies to `~DEFAULT_BRANCH` and
+`refs/heads/production`, and requires `Lint` from GitHub Actions.
+
+## Task 2: Remove Actionlint Path Filter Through Template Realignment
+
+**Files:**
+
+- Modify: `skills/bootstrap/templates/core/.github/workflows/actions.yml`
+- Modify: `.github/workflows/actions.yml`
+
+- [ ] **Step 1: Edit source template first**
+
+Remove only the pull request `paths` filter from:
+
+```yaml
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+```
+
+Expected: the source template has no `paths:` key under `pull_request`.
+
+- [ ] **Step 2: Realign root workflow from the template**
+
+Use the local bootstrap realignment discipline for the workflow batch. If no
+non-interactive runner exists, record the evidence used for the accepted root
+diff:
+
+```bash
+diff -u \
+  skills/bootstrap/templates/core/.github/workflows/actions.yml \
+  .github/workflows/actions.yml
+```
+
+Expected: no diff between the source template and root workflow after applying
+the accepted root workflow update. If realignment cannot be run safely, record
+that blocker in the PR body.
+
+- [ ] **Step 3: Verify no workflow path filter remains**
+
+Run:
+
+```bash
+rg -n "paths:" \
+  .github/workflows/actions.yml \
+  skills/bootstrap/templates/core/.github/workflows/actions.yml
+```
+
+Expected: no matches and exit code `1`.
+
+## Task 3: Local Verification
+
+**Files:**
+
+- Verify: `.github/workflows/*.yml`
+- Verify: `skills/bootstrap/templates/core/.github/workflows/*.yml`
+- Verify: Markdown artifacts changed for #72
+
+- [ ] **Step 1: Run actionlint**
+
+Run:
+
+```bash
+tmpdir=$(mktemp -d)
+(
+  cd "$tmpdir" || exit 1
+  bash <(curl -sL https://raw.githubusercontent.com/rhysd/actionlint/v1.7.12/scripts/download-actionlint.bash) 1.7.12 >/dev/null
+)
+"$tmpdir/actionlint" -color .github/workflows/*.yml skills/bootstrap/templates/core/.github/workflows/*.yml
+lint_exit=$?
+rm -rf "$tmpdir"
+exit "$lint_exit"
+```
+
+Expected: exit code `0`.
+
+- [ ] **Step 2: Run markdown lint**
+
+Run after dependencies are installed:
+
+```bash
+pnpm lint:md
+```
+
+Expected: exit code `0`. If dependencies are not installed, run
+`pnpm install` first and keep unrelated lockfile churn out of the diff.
+
+- [ ] **Step 3: Confirm root/template parity**
+
+Run:
+
+```bash
+diff -u \
+  skills/bootstrap/templates/core/.github/workflows/actions.yml \
+  .github/workflows/actions.yml
+```
+
+Expected: exit code `0`.
+
+## Task 4: Review Workflow-Contract Risks
+
+**Files:**
+
+- Review: `docs/superpowers/specs/2026-04-30-72-require-lint-checks-in-branch-rulesets-design.md`
+- Review: `docs/superpowers/plans/2026-04-30-72-require-lint-checks-in-branch-rulesets-plan.md`
+- Review: workflow diffs and ruleset evidence
+
+- [ ] **Step 1: Run workflow-contract pressure review**
+
+Check the design's required dimensions:
+
+- RED baseline is documented by the initial missing ruleset requirement and
+  path-filtered workflow.
+- GREEN behavior is documented by active ruleset output and no `paths:` matches.
+- Duplicate `Lint` contexts are treated as a live PR verification gate.
+- Template/root parity is backed by diff output.
+- No unrelated workflow behavior was changed.
+
+Expected: no implementation-level, plan-level, or spec-level blockers remain.
+
+## Task 5: Publish PR And Verify Latest Head
+
+**Files:**
+
+- Publish: branch `72-require-lint-checks-in-branch-rulesets`
+- Publish: PR for issue #72
+
+- [ ] **Step 1: Push branch**
+
+Run:
+
+```bash
+git push -u origin 72-require-lint-checks-in-branch-rulesets
+```
+
+Expected: branch exists on origin and tracks the remote branch.
+
+- [ ] **Step 2: Create PR with repository template**
+
+Use `.github/pull_request_template.md` headings in order. The title must be:
+
+```text
+fix: #72 require lint checks in rulesets
+```
+
+Expected: PR body includes `Closes #72`, the template's sections, verification
+commands, and `### AC-72-1`, `### AC-72-2`, and `### AC-72-3` outcomes.
+
+- [ ] **Step 3: Verify latest-head checks and mergeability**
+
+Run after checks start:
+
+```bash
+gh pr view <pr> --json headRefOid,mergeStateStatus,reviewDecision,statusCheckRollup
+```
+
+Expected: latest pushed SHA is visible. Required GitHub Actions `Lint` checks
+are not bypassed. If shared `Lint` contexts behave ambiguously, halt and route
+a follow-up design change instead of claiming AC-72-1 complete.
+
+## Acceptance Criteria Trace
+
+- AC-72-1: Task 1 configures and verifies ruleset enforcement; Task 5 verifies
+  latest-head PR behavior.
+- AC-72-2: Task 2 removes the actionlint workflow `paths` filter; Task 3 checks
+  no `paths:` key remains.
+- AC-72-3: Task 2 records template-first realignment evidence; Task 3 confirms
+  root/template parity.
+
+## Planner Self-Review
+
+- Spec coverage: R1-R7 map to Tasks 1-5.
+- Placeholder scan: no `TBD`, `TODO`, or vague implementation placeholders
+  remain.
+- Type and name consistency: the required status-check context remains `Lint`;
+  the ruleset name remains `Required Lint checks`.

--- a/docs/superpowers/specs/2026-04-30-72-require-lint-checks-in-branch-rulesets-design.md
+++ b/docs/superpowers/specs/2026-04-30-72-require-lint-checks-in-branch-rulesets-design.md
@@ -1,0 +1,110 @@
+# Design: Require Lint checks in branch rulesets [#72](https://github.com/patinaproject/bootstrap/issues/72)
+
+## Summary
+
+Require the GitHub Actions `Lint` check in repository rulesets and make the
+actionlint workflow safe to require by ensuring it runs for every pull request.
+The source template and mirrored root workflow must stay aligned.
+
+## Context
+
+Issue #72 was filed after discovering two merge-readiness gaps:
+
+- the active inherited branch rulesets for this repository did not include a
+  `required_status_checks` rule for `Lint`;
+- `.github/workflows/actions.yml` used a pull request `paths` filter, so a
+  required `Lint` check from that workflow could stay pending when a pull
+  request did not touch workflow files.
+
+This repository treats `skills/bootstrap/templates/**` as the source of truth
+for baseline files, so the actionlint workflow change must be made in the
+template first and mirrored into the root workflow.
+
+## Requirements
+
+- R1: A protected-branch ruleset must require the GitHub Actions `Lint` status
+  check before merge.
+- R2: The required `Lint` context must come from the GitHub Actions app so it
+  matches the check-run context emitted by the repository workflows.
+- R3: The actionlint workflow must not use a pull request `paths` filter,
+  because a skipped workflow can leave a required check pending.
+- R4: The template workflow at
+  `skills/bootstrap/templates/core/.github/workflows/actions.yml` and the root
+  workflow at `.github/workflows/actions.yml` must stay in parity.
+- R5: The change must not alter unrelated release or markdown lint behavior.
+- R6: If inherited organization rulesets cannot be edited from the current
+  token, a repository-owned ruleset may enforce the same required check for
+  `~DEFAULT_BRANCH` and `refs/heads/production`.
+
+## Acceptance Criteria
+
+- AC-72-1: Given a pull request targets a protected branch, when branch
+  protection or repository rulesets evaluate merge readiness, then the GitHub
+  Actions `Lint` status check is required.
+- AC-72-2: Given the actionlint workflow exists, when a pull request is opened,
+  edited, synchronized, or reopened, then the workflow is not skipped by a pull
+  request `paths` filter.
+- AC-72-3: Given the bootstrap repository mirrors baseline config from
+  templates, when the actionlint workflow changes, then the source template and
+  root workflow remain aligned.
+
+## Design
+
+Add or update ruleset enforcement so the repository has an active branch
+ruleset requiring the `Lint` check context from GitHub Actions. The intended
+protected refs are the default branch and production branch:
+
+- `~DEFAULT_BRANCH`
+- `refs/heads/production`
+
+Remove the `paths` filter from the actionlint workflow trigger in both the
+source template and mirrored root workflow. The workflow should continue to run
+on the same pull request activity types:
+
+- `opened`
+- `edited`
+- `synchronize`
+- `reopened`
+
+Do not rename workflow jobs or status contexts as part of this change. The
+required status-check context is `Lint`, matching the current job names across
+the repository's CI workflows.
+
+## Workflow-Contract Pressure Tests
+
+This change touches workflow-contract surfaces, so review must check the
+following dimensions before publish:
+
+- RED baseline: confirm the pre-change ruleset state lacks a required
+  `Lint` status-check rule and the actionlint workflow contains a `paths`
+  filter.
+- GREEN behavior: confirm the active ruleset requires `Lint` and `paths:` is
+  absent from both actionlint workflow copies.
+- Rationalization resistance: reject arguments that a path-filtered workflow is
+  acceptable for a required check because it saves runner time.
+- Red flags: ensure `Lint` is not renamed, ensure ruleset enforcement is active,
+  and ensure root/template workflow copies stay aligned.
+- Token efficiency: keep new guidance minimal; do not add broad CI doctrine when
+  the concrete invariant is enough.
+- Role ownership: `Finisher` owns live ruleset verification and PR publish-state
+  checks; `Executor` owns file changes and command verification.
+- Stage-gate bypass paths: do not treat the live ruleset mutation alone as
+  complete without the branch workflow/template diff and PR evidence.
+
+## Non-Goals
+
+- Do not change unrelated release workflow behavior.
+- Do not change markdown lint globs or workflow naming.
+- Do not manually apply or remove Release Please reserved labels.
+- Do not require editing inherited organization rulesets when repository-level
+  enforcement can satisfy the issue.
+
+## Verification Plan
+
+- Inspect the active ruleset and confirm a `required_status_checks` rule for
+  `Lint` with the GitHub Actions integration.
+- Run `rg -n "paths:" .github/workflows/actions.yml skills/bootstrap/templates/core/.github/workflows/actions.yml`
+  and expect no matches.
+- Run `actionlint` against root and template workflows, or document that
+  `actionlint` is unavailable and rely on CI.
+- Review `git diff` to confirm root/template workflow parity.

--- a/docs/superpowers/specs/2026-04-30-72-require-lint-checks-in-branch-rulesets-design.md
+++ b/docs/superpowers/specs/2026-04-30-72-require-lint-checks-in-branch-rulesets-design.md
@@ -30,11 +30,16 @@ template first and mirrored into the root workflow.
   because a skipped workflow can leave a required check pending.
 - R4: The template workflow at
   `skills/bootstrap/templates/core/.github/workflows/actions.yml` and the root
-  workflow at `.github/workflows/actions.yml` must stay in parity.
+  workflow at `.github/workflows/actions.yml` must stay in parity through the
+  repository's template-first realignment loop.
 - R5: The change must not alter unrelated release or markdown lint behavior.
 - R6: If inherited organization rulesets cannot be edited from the current
   token, a repository-owned ruleset may enforce the same required check for
   `~DEFAULT_BRANCH` and `refs/heads/production`.
+- R7: Because issue #68 intentionally preserved the shared required check name
+  `Lint` across CI workflows, this issue must verify the live ruleset behavior
+  on a pull request and halt if GitHub does not treat the shared GitHub Actions
+  `Lint` context as the intended merge gate.
 
 ## Acceptance Criteria
 
@@ -51,15 +56,27 @@ template first and mirrored into the root workflow.
 ## Design
 
 Add or update ruleset enforcement so the repository has an active branch
-ruleset requiring the `Lint` check context from GitHub Actions. The intended
-protected refs are the default branch and production branch:
+ruleset requiring the `Lint` check context from GitHub Actions. The API payload
+must include the GitHub Actions app integration for the required check so an
+unexpected third-party status named `Lint` cannot satisfy the rule. GitHub's
+required-check troubleshooting guidance says required checks can be tied to a
+specific GitHub App source and warns that workflow-level path filters leave
+required checks pending when skipped.
+
+The intended protected refs are the default branch and production branch:
 
 - `~DEFAULT_BRANCH`
 - `refs/heads/production`
 
-Remove the `paths` filter from the actionlint workflow trigger in both the
-source template and mirrored root workflow. The workflow should continue to run
-on the same pull request activity types:
+Issue #68 intentionally kept the required status-check name `Lint`; this design
+does not rename the lint jobs. Instead, `Finisher` must verify the active PR's
+merge box and check runs after publication. If a failing, pending, or absent
+GitHub Actions lint job can bypass the `Lint` requirement, the run must halt and
+route a follow-up design change rather than claiming AC-72-1.
+
+Remove the `paths` filter from the actionlint workflow trigger in the source
+template, then realign the root workflow from that template. The workflow should
+continue to run on the same pull request activity types:
 
 - `opened`
 - `edited`
@@ -68,7 +85,11 @@ on the same pull request activity types:
 
 Do not rename workflow jobs or status contexts as part of this change. The
 required status-check context is `Lint`, matching the current job names across
-the repository's CI workflows.
+the repository's CI workflows and the guidance added by issue #68.
+
+If the local bootstrap realignment flow cannot be run safely, document that
+blocker explicitly. Do not describe a hand-copied root workflow as satisfying
+the realignment loop without that evidence.
 
 ## Workflow-Contract Pressure Tests
 
@@ -83,7 +104,8 @@ following dimensions before publish:
 - Rationalization resistance: reject arguments that a path-filtered workflow is
   acceptable for a required check because it saves runner time.
 - Red flags: ensure `Lint` is not renamed, ensure ruleset enforcement is active,
-  and ensure root/template workflow copies stay aligned.
+  ensure duplicate `Lint` contexts are verified on the live PR, and ensure
+  root/template workflow copies stay aligned through the realignment loop.
 - Token efficiency: keep new guidance minimal; do not add broad CI doctrine when
   the concrete invariant is enough.
 - Role ownership: `Finisher` owns live ruleset verification and PR publish-state
@@ -103,8 +125,12 @@ following dimensions before publish:
 
 - Inspect the active ruleset and confirm a `required_status_checks` rule for
   `Lint` with the GitHub Actions integration.
+- On the published PR, inspect the latest head's GitHub Actions check runs and
+  merge-readiness state to confirm the required `Lint` gate corresponds to the
+  intended lint jobs; halt if duplicate `Lint` contexts behave ambiguously.
 - Run `rg -n "paths:" .github/workflows/actions.yml skills/bootstrap/templates/core/.github/workflows/actions.yml`
   and expect no matches.
 - Run `actionlint` against root and template workflows, or document that
   `actionlint` is unavailable and rely on CI.
-- Review `git diff` to confirm root/template workflow parity.
+- Review `git diff` and realignment evidence to confirm root/template workflow
+  parity.

--- a/skills/bootstrap/templates/core/.github/workflows/actions.yml
+++ b/skills/bootstrap/templates/core/.github/workflows/actions.yml
@@ -3,9 +3,6 @@ name: Actions
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
-    paths:
-      - ".github/workflows/**"
-      - ".github/actionlint.yaml"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Linked issue

Closes #72

## What changed

- Added Superteam design and implementation-plan artifacts for the ruleset change.
- Added the active repository ruleset `Required Lint checks`, requiring GitHub Actions `Lint` for `~DEFAULT_BRANCH` and `refs/heads/production`.
- Removed the pull request `paths` filter from the actionlint workflow in the core template and mirrored root workflow.

## Do before merging

No work-specific operator steps required.

## Test coverage

| AC | Title | Unit | GitHub |
| --- | --- | --- | --- |
| AC-72-1 | Require Lint in rulesets | ➖ | ✅ tested |
| AC-72-2 | Actionlint workflow always reports | ✅ tested | ✅ tested |
| AC-72-3 | Template/root workflow parity | ✅ tested | ➖ |

## Acceptance criteria

### AC-72-1

Repository ruleset enforcement now requires the GitHub Actions `Lint` context for protected branch patterns, and the latest PR head reports all GitHub Actions `Lint` checks.

- GitHub test – Codex | gh api | `gh api repos/{owner}/{repo}/rulesets/15758344 --jq '{id,name,source_type,enforcement,conditions,rules}'` | 2026-04-30T04:05:07Z
- GitHub test – Codex | gh pr | `gh pr view 74 --json headRefOid,mergeStateStatus,reviewDecision,statusCheckRollup` showed head `15e1958b3c94edad5bb7f39262b94b1e94766b88`, merge state `CLEAN`, and successful GitHub Actions `Lint` checks for Actions, Markdown, and Pull Request | 2026-04-30T04:07:09Z
- Manual test: 1. Created repository ruleset `Required Lint checks`; 2. Confirmed it is active; 3. Confirmed it applies to `~DEFAULT_BRANCH` and `refs/heads/production`; 4. Confirmed it requires `Lint` with GitHub Actions integration ID `15368`.

### AC-72-2

The actionlint workflow no longer has a pull request `paths` filter, so it is not skipped by file path changes.

- Unit test – Codex | local | `rg -n "paths:" .github/workflows/actions.yml skills/bootstrap/templates/core/.github/workflows/actions.yml` exited 1 with no matches | 2026-04-30T04:05:07Z
- Unit test – Codex | local | `actionlint .github/workflows/*.yml skills/bootstrap/templates/core/.github/workflows/*.yml` passed | 2026-04-30T04:06:30Z
- Unit test – Codex | local | `pnpm lint:md` passed with 0 errors | 2026-04-30T04:06:30Z
- GitHub test – Codex | gh pr | latest-head GitHub Actions `Lint` check for workflow `Actions` completed successfully | 2026-04-30T04:07:09Z

### AC-72-3

The source template and mirrored root workflow are aligned for the actionlint workflow change.

- Unit test – Codex | local | `diff -u skills/bootstrap/templates/core/.github/workflows/actions.yml .github/workflows/actions.yml` exited 0 | 2026-04-30T04:05:07Z
- Manual test: 1. Edited the core template workflow; 2. Mirrored the accepted root workflow update; 3. Confirmed no diff remains between the two files.
