### PR TITLE
feat: #73 omit empty pre-merge sections

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,16 +21,20 @@
 
 -
 
-## Do before merging
-
 <!--
-  Add checklist items only for work-specific operator steps that must happen
-  after review and before merge. Omit this section's checklist when no
-  work-specific pre-merge steps are required.
+  Include this section only when work-specific operator steps must happen after
+  review and before merge:
+
+  ## Do before merging
+
+  - [ ] Rotate the production secret after deploy.
+
+  Keep checklist items concrete and actionable. Do not add this section for
+  placeholders such as `None`, `N/A`, or `No work-specific pre-merge operator
+  steps.`
   Visible unchecked checkboxes are enforced by the `Required template
-  checkboxes` status check. To include an intentionally optional checkbox, put
-  `<!-- pr-checkbox: optional -->` immediately above that checkbox.
-  Example: - [ ] Rotate the production secret after deploy.
+  checkboxes` status check. To include an intentionally optional checkbox, put a
+  `pr-checkbox: optional` HTML comment immediately above that checkbox.
 -->
 
 ## Test coverage

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,7 +112,7 @@ The `autorelease: pending` and `autorelease: tagged` labels are reserved for Rel
 
 This repo ships canonical templates for issues and pull requests. Agents must use them – do not invent parallel structure.
 
-- Pull requests: `.github/pull_request_template.md`. Read it before running `gh pr create`. The PR body must use the template's section headings (`Linked issue`, `What changed`, `Do before merging`, `Test coverage`, `Acceptance criteria`) in the order the template defines, even when the body is passed inline via `--body`.
+- Pull requests: `.github/pull_request_template.md`. Read it before running `gh pr create`. The PR body must use the template's section headings in the order the template defines, even when the body is passed inline via `--body`. Include `Do before merging` only when work-specific operator steps exist; when present, it belongs between `What changed` and `Test coverage`.
 - Issues: `.github/ISSUE_TEMPLATE/bug_report.md` and `.github/ISSUE_TEMPLATE/feature_request.md`. Pick the one that matches the report and reproduce its sections in order.
 
 Recommended `gh` patterns:
@@ -225,7 +225,7 @@ The verb "standardize" combined with a diff under `skills/**` and `.codex-plugin
 
 On this repo the canonical "Commit type selection" section is shipped through `skills/bootstrap/templates/core/AGENTS.md.tmpl` and round-tripped to root `AGENTS.md` via the `bootstrap` skill in realignment mode. Mistyped commits silently suppress releases – see [`RELEASING.md`](RELEASING.md) for the release-please semver mapping. The AC-54-7 parity grep (a one-liner that checks every per-tool surface for the verbatim glob list) is the verification artifact.
 
-Pull requests should include linked issue (`None` when no issue applies), what changed, a `Do before merging` section for work-specific operator pre-merge steps, test coverage matrix, and acceptance-criteria outcomes.
+Pull requests should include linked issue (`None` when no issue applies), what changed, test coverage matrix, and acceptance-criteria outcomes. Include a `Do before merging` section only when work-specific operator pre-merge steps exist.
 
 For squash-and-merge workflows, PR titles must exactly match the commitlint and commitizen commit format:
 

--- a/docs/superpowers/plans/2026-04-30-73-omit-empty-do-before-merging-sections-from-pr-bodies-plan.md
+++ b/docs/superpowers/plans/2026-04-30-73-omit-empty-do-before-merging-sections-from-pr-bodies-plan.md
@@ -1,0 +1,174 @@
+# Plan: Omit empty Do before merging sections from PR bodies [#73](https://github.com/patinaproject/bootstrap/issues/73)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Update the PR body contract so `Do before merging` appears only when work-specific operator steps exist.
+
+**Architecture:** This is a template-first documentation contract change. Edit the bootstrap source template first, mirror the root files, and verify root/template parity plus rendered PR body examples.
+
+**Tech Stack:** Markdown templates, repository guidance, shell checks, `pnpm lint:md`.
+
+---
+
+## Workstreams
+
+1. Template contract
+   - Update `skills/bootstrap/templates/core/.github/pull_request_template.md`.
+   - Mirror `.github/pull_request_template.md`.
+   - Add a lightweight rendered-body check for both absent and present `Do before merging` cases.
+
+2. Guidance alignment
+   - Update `skills/bootstrap/templates/core/AGENTS.md.tmpl`.
+   - Mirror `AGENTS.md`.
+   - Keep canonical section-order wording conditional: when present, `Do before merging` sits between `What changed` and `Test coverage`.
+
+3. Verification and PR handoff
+   - Compare root and template PR templates.
+   - Search for stale filler guidance.
+   - Run markdown lint.
+   - Render the PR body without `Do before merging` because this issue has no operator steps.
+
+## Task Mapping
+
+- T73-1 covers AC-73-1 and AC-73-2 by changing the PR template contract and rendered examples.
+- T73-2 covers AC-73-3 by aligning root guidance with template guidance.
+- T73-3 covers all ACs with parity, stale-text, and lint verification.
+
+## Tasks
+
+### Task T73-1: Template contract
+
+**Files:**
+
+- Modify: `skills/bootstrap/templates/core/.github/pull_request_template.md`
+- Modify: `.github/pull_request_template.md`
+
+- [ ] **Step 1: Capture the current failing baseline**
+
+Run:
+
+```bash
+rg -n "## Do before merging|Omit this section's checklist|No work-specific pre-merge operator steps" .github/pull_request_template.md skills/bootstrap/templates/core/.github/pull_request_template.md
+```
+
+Expected before implementation: both PR templates contain `## Do before merging`, and the comment only says to omit the checklist when no steps exist.
+
+- [ ] **Step 2: Update the bootstrap source template**
+
+In `skills/bootstrap/templates/core/.github/pull_request_template.md`, replace the visible `## Do before merging` heading plus comment with an HTML comment that instructs authors to add the whole section only when needed. Use this exact wording:
+
+```markdown
+<!--
+  Include this section only when work-specific operator steps must happen after
+  review and before merge:
+
+  ## Do before merging
+
+  - [ ] Rotate the production secret after deploy.
+
+  Keep checklist items concrete and actionable. Do not add this section for
+  placeholders such as `None`, `N/A`, or `No work-specific pre-merge operator
+  steps.`
+  Visible unchecked checkboxes are enforced by the `Required template
+  checkboxes` status check. To include an intentionally optional checkbox, put
+  `<!-- pr-checkbox: optional -->` immediately above that checkbox.
+-->
+```
+
+- [ ] **Step 3: Mirror the root PR template**
+
+Copy the same change into `.github/pull_request_template.md`.
+
+- [ ] **Step 4: Verify template parity**
+
+Run:
+
+```bash
+cmp -s .github/pull_request_template.md skills/bootstrap/templates/core/.github/pull_request_template.md
+```
+
+Expected: exit 0.
+
+### Task T73-2: Guidance alignment
+
+**Files:**
+
+- Modify: `skills/bootstrap/templates/core/AGENTS.md.tmpl`
+- Modify: `AGENTS.md`
+
+- [ ] **Step 1: Update template guidance**
+
+Change `skills/bootstrap/templates/core/AGENTS.md.tmpl` so:
+
+- The `.github/pull_request_template.md` guidance lists `Do before merging` as conditional.
+- The PR guideline says to include a `Do before merging` section only for work-specific operator pre-merge steps.
+
+- [ ] **Step 2: Mirror root guidance**
+
+Apply the same wording changes to `AGENTS.md`.
+
+- [ ] **Step 3: Verify stale wording is gone**
+
+Run:
+
+```bash
+rg -n "must use the template's section headings \\(`Linked issue`, `What changed`, `Do before merging`, `Test coverage`, `Acceptance criteria`\\)|what changed, a `Do before merging` section" AGENTS.md skills/bootstrap/templates/core/AGENTS.md.tmpl
+```
+
+Expected: no output.
+
+### Task T73-3: Verification
+
+**Files:** no additional modifications expected.
+
+- [ ] **Step 1: Verify rendered no-steps PR body omits the section**
+
+Run:
+
+```bash
+tmp=$(mktemp)
+printf '%s\n' \
+  '## Linked issue' '' 'Closes #73' '' \
+  '## What changed' '' '- Updated PR body guidance.' '' \
+  '## Test coverage' '' '| AC | Title | Unit |' '| --- | --- | --- |' '| AC-73-1 | Empty pre-merge section omitted | ✅ tested |' '' \
+  '## Acceptance criteria' '' '### AC-73-1' '' 'The section is omitted when no operator steps exist.' > "$tmp"
+! rg -n '^## Do before merging$|No work-specific pre-merge operator steps' "$tmp"
+```
+
+Expected: exit 0.
+
+- [ ] **Step 2: Verify rendered steps PR body keeps the section in order**
+
+Run:
+
+```bash
+tmp=$(mktemp)
+printf '%s\n' \
+  '## Linked issue' '' 'Closes #73' '' \
+  '## What changed' '' '- Updated PR body guidance.' '' \
+  '## Do before merging' '' '- [ ] Rotate the production secret after deploy.' '' \
+  '## Test coverage' '' '| AC | Title | Unit |' '| --- | --- | --- |' '| AC-73-2 | Actionable steps retained | ✅ tested |' > "$tmp"
+awk '/^## Linked issue$/{print "linked"} /^## What changed$/{print "changed"} /^## Do before merging$/{print "before"} /^## Test coverage$/{print "coverage"}' "$tmp" | paste -sd ' ' -
+```
+
+Expected output:
+
+```text
+linked changed before coverage
+```
+
+- [ ] **Step 3: Run repository checks**
+
+Run:
+
+```bash
+cmp -s .github/pull_request_template.md skills/bootstrap/templates/core/.github/pull_request_template.md
+git diff --check
+pnpm lint:md
+```
+
+Expected: all commands pass.
+
+## Blockers
+
+None known.

--- a/docs/superpowers/specs/2026-04-30-73-omit-empty-do-before-merging-sections-from-pr-bodies-design.md
+++ b/docs/superpowers/specs/2026-04-30-73-omit-empty-do-before-merging-sections-from-pr-bodies-design.md
@@ -1,0 +1,42 @@
+# Design: Omit empty Do before merging sections from PR bodies [#73](https://github.com/patinaproject/bootstrap/issues/73)
+
+## Intent
+
+Make the PR body contract omit `Do before merging` entirely when a PR has no work-specific operator action before merge. Keep the section available for real pre-merge work so reviewers see actionable checkboxes only when an operator must do something.
+
+## Requirements
+
+- R1: A rendered PR body with no work-specific pre-merge operator steps must omit the `Do before merging` heading and its placeholder text entirely.
+- R2: A rendered PR body with one or more work-specific pre-merge operator steps must include `Do before merging` in the canonical position between `What changed` and `Test coverage`.
+- R3: The `Do before merging` section, when present, must contain only concrete operator actions and must not be used for filler such as `No work-specific pre-merge operator steps.`
+- R4: Root guidance and bootstrap template guidance must describe the conditional section rule consistently.
+- R5: Template source changes must round-trip into mirrored root files according to this repository's baseline-config workflow.
+- R6: The change must preserve the existing rule that unchecked visible checkboxes are reserved for required operator actions and are enforced by the required-template-checkboxes check.
+
+## Acceptance Criteria
+
+- AC-73-1: Given a PR has no work-specific pre-merge operator steps, when its PR body is rendered, then the `Do before merging` section is omitted entirely.
+- AC-73-2: Given a PR has one or more work-specific pre-merge operator steps, when its PR body is rendered, then the `Do before merging` section is present and contains only those actionable steps.
+- AC-73-3: Given the bootstrap repository mirrors baseline config from templates, when the PR body guidance changes, then the source template and root PR guidance remain aligned.
+
+## Approach
+
+Use a conditional-template convention rather than inventing a new section or replacing the heading with a visible "none" statement. Update the bootstrap template source first, then mirror the root PR template and root guidance. The template comment should tell authors to include the whole section only when needed, which prevents agents from preserving a visible empty section during PR creation.
+
+`AGENTS.md` and its core template should change from "include a `Do before merging` section" to "include it only when work-specific operator steps exist." The working-with-templates guidance should still identify the canonical section order for cases where the section is present, while explicitly allowing the section to be absent when there are no steps.
+
+## Workflow-Contract Pressure Tests
+
+- RED baseline: Current generated PR bodies can include a visible empty/filler `Do before merging` section; an agent may rationalize that every template heading must appear even when it has no content.
+- GREEN expectation: With the updated contract, an agent rendering a no-operator-step PR body omits the section and does not replace it with `None`, `N/A`, or "No work-specific pre-merge operator steps."
+- Rationalization resistance: The guidance must close the loophole that "canonical section order" means "always include every possible heading." It means preserve order among sections that apply.
+- Red flags: Any visible empty `Do before merging` heading, visible no-op filler, or unchecked checkbox that is not a real operator action is a failure.
+- Token efficiency: Prefer one compact template comment and one compact AGENTS guidance change over duplicating detailed examples in multiple docs.
+- Role ownership: Authors decide whether pre-merge operator steps exist; reviewers inspect that any visible checklist is actionable; operators only receive checklist items when actual work is required.
+- Stage-gate bypass prevention: The PR-body rules remain in the template and root guidance, so Finisher-owned PR publication follows the same condition instead of relying on memory.
+
+## Non-Goals
+
+- Do not change the required-template-checkboxes enforcement behavior.
+- Do not add a new PR-body section or rename existing sections.
+- Do not change acceptance-criteria test reporting.

--- a/skills/bootstrap/templates/core/.github/pull_request_template.md
+++ b/skills/bootstrap/templates/core/.github/pull_request_template.md
@@ -21,16 +21,20 @@
 
 -
 
-## Do before merging
-
 <!--
-  Add checklist items only for work-specific operator steps that must happen
-  after review and before merge. Omit this section's checklist when no
-  work-specific pre-merge steps are required.
+  Include this section only when work-specific operator steps must happen after
+  review and before merge:
+
+  ## Do before merging
+
+  - [ ] Rotate the production secret after deploy.
+
+  Keep checklist items concrete and actionable. Do not add this section for
+  placeholders such as `None`, `N/A`, or `No work-specific pre-merge operator
+  steps.`
   Visible unchecked checkboxes are enforced by the `Required template
-  checkboxes` status check. To include an intentionally optional checkbox, put
-  `<!-- pr-checkbox: optional -->` immediately above that checkbox.
-  Example: - [ ] Rotate the production secret after deploy.
+  checkboxes` status check. To include an intentionally optional checkbox, put a
+  `pr-checkbox: optional` HTML comment immediately above that checkbox.
 -->
 
 ## Test coverage

--- a/skills/bootstrap/templates/core/AGENTS.md.tmpl
+++ b/skills/bootstrap/templates/core/AGENTS.md.tmpl
@@ -70,7 +70,7 @@ The `autorelease: pending` and `autorelease: tagged` labels are reserved for Rel
 
 This repo ships canonical templates for issues and pull requests. Agents must use them – do not invent parallel structure.
 
-- Pull requests: `.github/pull_request_template.md`. Read it before running `gh pr create`. The PR body must use the template's section headings (`Linked issue`, `What changed`, `Do before merging`, `Test coverage`, `Acceptance criteria`) in the order the template defines, even when the body is passed inline via `--body`.
+- Pull requests: `.github/pull_request_template.md`. Read it before running `gh pr create`. The PR body must use the template's section headings in the order the template defines, even when the body is passed inline via `--body`. Include `Do before merging` only when work-specific operator steps exist; when present, it belongs between `What changed` and `Test coverage`.
 - Issues: `.github/ISSUE_TEMPLATE/bug_report.md` and `.github/ISSUE_TEMPLATE/feature_request.md`. Pick the one that matches the report and reproduce its sections in order.
 
 Recommended `gh` patterns:
@@ -178,7 +178,7 @@ The verb "standardize" combined with a diff under `skills/**` and `.codex-plugin
 
 On this repo the canonical "Commit type selection" section is shipped through `skills/bootstrap/templates/core/AGENTS.md.tmpl` and round-tripped to root `AGENTS.md` via the `bootstrap` skill in realignment mode. Mistyped commits silently suppress releases – see [`RELEASING.md`](RELEASING.md) for the release-please semver mapping. The AC-54-7 parity grep (a one-liner that checks every per-tool surface for the verbatim glob list) is the verification artifact.
 
-Pull requests should include linked issue (`None` when no issue applies), what changed, a `Do before merging` section for work-specific operator pre-merge steps, test coverage matrix, and acceptance-criteria outcomes.
+Pull requests should include linked issue (`None` when no issue applies), what changed, test coverage matrix, and acceptance-criteria outcomes. Include a `Do before merging` section only when work-specific operator pre-merge steps exist.
 
 For squash-and-merge workflows, PR titles must exactly match the commit format. Use the final intended squash commit title as the PR title.
 


### PR DESCRIPTION
## Linked issue

Closes #73

## What changed

- Updated the PR template source and mirrored root template so `Do before merging` is hidden by default and included only for concrete operator steps.
- Updated root and bootstrap-template AGENTS guidance to make the section conditional while preserving canonical order when present.
- Added Superteam design and plan artifacts for the workflow-contract change.

## Test coverage

| AC | Title | Unit |
| --- | --- | --- |
| AC-73-1 | Empty pre-merge section omitted | ✅ tested |
| AC-73-2 | Actionable steps retained | ✅ tested |
| AC-73-3 | Root/template alignment | ✅ tested |

## Acceptance criteria

### AC-73-1

No-step PR bodies omit `Do before merging` entirely instead of showing a visible filler section.

- Unit test – rendered no-step PR body grep | local shell | Codex | 2026-04-30T04:12:53Z
- Manual test: 1. Rendered a sample PR body without operator steps. 2. Confirmed no `Do before merging` heading or stale filler text appeared.

### AC-73-2

PR bodies with real operator steps can still include `Do before merging` between `What changed` and `Test coverage`.

- Unit test – rendered operator-step PR body order check | local shell | Codex | 2026-04-30T04:12:53Z
- Manual test: 1. Rendered a sample PR body with a concrete checklist item. 2. Confirmed the heading order was `Linked issue`, `What changed`, `Do before merging`, `Test coverage`.

### AC-73-3

Bootstrap source templates and mirrored root guidance are aligned.

- Unit test – `cmp -s .github/pull_request_template.md skills/bootstrap/templates/core/.github/pull_request_template.md` | local shell | Codex | 2026-04-30T04:12:53Z
- Unit test – `pnpm lint:md` | local shell | Codex | 2026-04-30T04:12:53Z
- Unit test – `pnpm test:pr-template-checkboxes` | local shell | Codex | 2026-04-30T04:12:53Z
- Manual test: 1. Reviewed `AGENTS.md` and `skills/bootstrap/templates/core/AGENTS.md.tmpl`. 2. Confirmed both describe `Do before merging` as conditional.
