### PR TITLE
feat: #83 clarify PR template test coverage symbols

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -55,13 +55,18 @@
   still needs an AC heading. Each cell summarizes the required-validation state
   for that AC and column. Use only these symbols in status cells:
   ✅ = required validation passed, with no blocking gap for this column
-  ❌ = required validation missing, failing, or blocked by an unresolved gap
+  ❌ = tests that should exist are missing
+  ⚠️ = required validation has an acknowledged gap, warning, unresolved
+       concern, or failing/pending state that needs reviewer attention
   ➖ = not relevant to this AC
 
   Use `➖` only when that verification type is not relevant to the AC. If an AC
   includes evidence, a test gap, or an operator check that clearly maps to a
-  matrix column, that cell must not be `➖`. If required validation is still
-  pending, use `❌` and add a test-gap checkbox until that validation passes.
+  matrix column, that cell must not be `➖`. Every `⚠️` matrix cell must have
+  one or more corresponding `⚠️ Test gap:` checkboxes under that AC. If required
+  validation is failing, pending, blocked by an unresolved concern, or otherwise
+  cannot yet be trusted, use `⚠️` and add a test-gap checkbox until that
+  validation passes.
 -->
 | AC | Title | Unit | <Platform> |
 | --- | --- | --- | --- |
@@ -82,8 +87,9 @@ including unresolved blockers or pending validation when present.
 
 <!--
   For each supported platform that is relevant to this AC, include one evidence
-  row or report the missing validation as a test-gap checkbox. Keep evidence
-  rows compact and use a colon after the evidence label:
+  row, summarize missing tests in the outcome, or report an acknowledged
+  validation gap as a test-gap checkbox. Keep evidence rows compact and use a
+  colon after the evidence label:
   `<Platform> test: <command, workflow job, tool, or harness>, <environment>[, <link, verifier, or ISO>]`.
   Name the concrete command, workflow job, tool, or harness when known. Use a
   neutral verifier value, such as a person, role, or run identifier. Add a unit
@@ -96,12 +102,15 @@ including unresolved blockers or pending validation when present.
 - <Platform> test: <command, workflow job, tool, or harness>, <environment>[, <link, verifier, or ISO>]
 <!--
   Include every known Test gap that the operator must consciously review. Use
-  `Test gap:` to describe missing coverage or an unresolved validation concern,
-  not to restate a code-review finding or duplicate an operator action. Test
-  gaps must be about observable behavior, missing coverage, or validation that
-  cannot yet be trusted. Treat CI that must rerun after a fix as a test gap
-  unless the operator must manually trigger or inspect a specific job. Delete
-  unused placeholder checkbox rows.
+  `Test gap:` to describe an acknowledged coverage gap or an unresolved
+  validation concern, not to restate a code-review finding, duplicate an
+  operator action, or explain tests that should exist but are missing. Test gaps
+  must be about observable behavior or validation that cannot yet be trusted.
+  Treat CI that must rerun after a fix as a test gap unless the operator must
+  manually trigger or inspect a specific job. Delete unused placeholder checkbox
+  rows.
+  Every `⚠️ Test gap:` that maps to a matrix column must have a corresponding
+  `⚠️` cell in that AC's matrix row.
   Example: - [ ] ⚠️ Test gap: <observable behavior or validation not verified>
 -->
 - [ ] ⚠️ Test gap: <observable behavior, missing coverage, or unresolved validation concern>

--- a/docs/superpowers/plans/2026-05-03-83-clarify-pr-template-emoji-semantics-for-test-coverage-plan.md
+++ b/docs/superpowers/plans/2026-05-03-83-clarify-pr-template-emoji-semantics-for-test-coverage-plan.md
@@ -1,0 +1,268 @@
+# Clarify PR Template Emoji Semantics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Clarify PR template test coverage symbols so `❌` means missing tests, `⚠️` means acknowledged gap or warning, and every matrix `⚠️` has matching per-AC `⚠️ Test gap:` detail.
+
+**Architecture:** Update the bootstrap template source first, mirror it to the root PR template, and keep `docs/ac-traceability.md` as a pointer to the template grammar. Verification is text-based because this is a workflow-contract wording change.
+
+**Tech Stack:** Markdown, `rg`, `cmp`, `pnpm exec markdownlint-cli2`.
+
+---
+
+## Task 1: RED Baseline
+
+**Files:**
+
+- Read: `skills/bootstrap/templates/core/.github/pull_request_template.md`
+- Read: `.github/pull_request_template.md`
+
+- [ ] **Step 1: Capture the current stale symbol semantics**
+
+Run:
+
+```bash
+rg -n "❌ = required validation missing, failing, or blocked by an unresolved gap|If required validation is still pending, use `❌`" \
+  skills/bootstrap/templates/core/.github/pull_request_template.md \
+  .github/pull_request_template.md
+```
+
+Expected: four matches total, proving the current template uses `❌` for
+unresolved gaps or pending validation.
+
+- [ ] **Step 2: Capture the missing matrix-warning linkage**
+
+Run:
+
+```bash
+rg -n "every `⚠️`|matrix.*⚠️|⚠️.*matrix|corresponding.*Test gap" \
+  skills/bootstrap/templates/core/.github/pull_request_template.md \
+  .github/pull_request_template.md || true
+```
+
+Expected: no output, proving the current template does not explicitly require
+every matrix warning to have corresponding per-AC `⚠️ Test gap:` detail.
+
+## Task 2: Template Source Update
+
+**Files:**
+
+- Modify: `skills/bootstrap/templates/core/.github/pull_request_template.md`
+
+- [ ] **Step 1: Update the symbol legend in the template source**
+
+In `skills/bootstrap/templates/core/.github/pull_request_template.md`, replace:
+
+```markdown
+  ✅ = required validation passed, with no blocking gap for this column
+  ❌ = required validation missing, failing, or blocked by an unresolved gap
+  ➖ = not relevant to this AC
+```
+
+with:
+
+```markdown
+  ✅ = required validation passed, with no blocking gap for this column
+  ❌ = tests that should exist are missing
+  ⚠️ = required validation has an acknowledged gap, warning, unresolved
+       concern, or failing/pending state that needs reviewer attention
+  ➖ = not relevant to this AC
+```
+
+- [ ] **Step 2: Update the follow-on matrix instruction**
+
+In the same file, replace:
+
+```markdown
+  Use `➖` only when that verification type is not relevant to the AC. If an AC
+  includes evidence, a test gap, or an operator check that clearly maps to a
+  matrix column, that cell must not be `➖`. If required validation is still
+  pending, use `❌` and add a test-gap checkbox until that validation passes.
+```
+
+with:
+
+```markdown
+  Use `➖` only when that verification type is not relevant to the AC. If an AC
+  includes evidence, a test gap, or an operator check that clearly maps to a
+  matrix column, that cell must not be `➖`. Every `⚠️` matrix cell must have
+  one or more corresponding `⚠️ Test gap:` checkboxes under that AC. If required
+  validation is failing, pending, blocked by an unresolved concern, or otherwise
+  cannot yet be trusted, use `⚠️` and add a test-gap checkbox until that
+  validation passes.
+```
+
+- [ ] **Step 3: Tighten the test-gap checkbox guidance**
+
+In the same file, replace:
+
+```markdown
+  Example: - [ ] ⚠️ Test gap: <observable behavior or validation not verified>
+```
+
+with:
+
+```markdown
+  Every `⚠️ Test gap:` that maps to a matrix column must have a corresponding
+  `⚠️` cell in that AC's matrix row.
+  Example: - [ ] ⚠️ Test gap: <observable behavior or validation not verified>
+```
+
+## Task 3: Mirror and Traceability Check
+
+**Files:**
+
+- Modify: `.github/pull_request_template.md`
+- Read or modify: `docs/ac-traceability.md`
+
+- [ ] **Step 1: Mirror the template source to the root PR template**
+
+Run:
+
+```bash
+cp skills/bootstrap/templates/core/.github/pull_request_template.md .github/pull_request_template.md
+```
+
+Expected: no output.
+
+- [ ] **Step 2: Verify template parity**
+
+Run:
+
+```bash
+cmp -s .github/pull_request_template.md skills/bootstrap/templates/core/.github/pull_request_template.md
+```
+
+Expected: exit 0.
+
+- [ ] **Step 3: Check `docs/ac-traceability.md` for contradictions**
+
+Run:
+
+```bash
+rg -n "❌|⚠️|required validation missing|unresolved gap|pending" docs/ac-traceability.md
+```
+
+Expected: no stale `❌` semantics. If the file only delegates grammar to the PR
+template without defining symbol meanings, do not edit it.
+
+## Task 4: GREEN Verification
+
+**Files:**
+
+- Read: `skills/bootstrap/templates/core/.github/pull_request_template.md`
+- Read: `.github/pull_request_template.md`
+- Read: `docs/ac-traceability.md`
+- Read: `docs/superpowers/specs/2026-05-03-83-clarify-pr-template-emoji-semantics-for-test-coverage-design.md`
+- Read: `docs/superpowers/plans/2026-05-03-83-clarify-pr-template-emoji-semantics-for-test-coverage-plan.md`
+
+- [ ] **Step 1: Verify clarified symbol meanings exist in both templates**
+
+Run:
+
+```bash
+rg -n "❌ = tests that should exist are missing|⚠️ = required validation has an acknowledged gap|Every `⚠️` matrix cell must have" \
+  skills/bootstrap/templates/core/.github/pull_request_template.md \
+  .github/pull_request_template.md
+```
+
+Expected: each pattern appears in both files.
+
+- [ ] **Step 2: Verify stale `❌` gap semantics are gone**
+
+Run:
+
+```bash
+rg -n "❌ = required validation missing|use `❌` and add a test-gap|blocked by an unresolved gap" \
+  skills/bootstrap/templates/core/.github/pull_request_template.md \
+  .github/pull_request_template.md
+```
+
+Expected: no output and exit 1.
+
+- [ ] **Step 3: Pressure-test a sample PR excerpt**
+
+Inspect this sample against the updated template instructions:
+
+```markdown
+| AC | Title | Unit |
+| --- | --- | --- |
+| AC-83-1 | Missing expected unit tests | ❌ |
+| AC-83-2 | Acknowledged coverage warning | ⚠️ |
+
+### AC-83-1
+
+Tests that should exist are missing.
+
+### AC-83-2
+
+Required validation has an acknowledged warning.
+
+- [ ] ⚠️ Test gap: Unit test does not exercise the warning path yet.
+```
+
+Expected: `AC-83-1` uses `❌` with no `⚠️ Test gap:` requirement because tests
+that should exist are missing. `AC-83-2` uses `⚠️` and includes matching
+per-AC `⚠️ Test gap:` detail.
+
+- [ ] **Step 4: Run Markdown lint**
+
+Run:
+
+```bash
+pnpm exec markdownlint-cli2 \
+  docs/superpowers/specs/2026-05-03-83-clarify-pr-template-emoji-semantics-for-test-coverage-design.md \
+  docs/superpowers/plans/2026-05-03-83-clarify-pr-template-emoji-semantics-for-test-coverage-plan.md \
+  skills/bootstrap/templates/core/.github/pull_request_template.md \
+  .github/pull_request_template.md \
+  docs/ac-traceability.md
+```
+
+Expected: zero errors.
+
+## Task 5: Implementation Commit
+
+**Files:**
+
+- Modify: `skills/bootstrap/templates/core/.github/pull_request_template.md`
+- Modify: `.github/pull_request_template.md`
+- Modify: `docs/ac-traceability.md` only if Task 3 finds stale contradictory wording
+- Create: `docs/superpowers/plans/2026-05-03-83-clarify-pr-template-emoji-semantics-for-test-coverage-plan.md`
+
+- [ ] **Step 1: Review the final diff**
+
+Run:
+
+```bash
+git diff --stat && git diff -- \
+  skills/bootstrap/templates/core/.github/pull_request_template.md \
+  .github/pull_request_template.md \
+  docs/ac-traceability.md \
+  docs/superpowers/plans/2026-05-03-83-clarify-pr-template-emoji-semantics-for-test-coverage-plan.md
+```
+
+Expected: diff is limited to the planned files.
+
+- [ ] **Step 2: Commit the plan and implementation**
+
+Run:
+
+```bash
+git add \
+  docs/superpowers/plans/2026-05-03-83-clarify-pr-template-emoji-semantics-for-test-coverage-plan.md \
+  skills/bootstrap/templates/core/.github/pull_request_template.md \
+  .github/pull_request_template.md \
+  docs/ac-traceability.md
+git commit -m "feat: #83 clarify PR template test coverage symbols"
+```
+
+Expected: commit succeeds.
+
+## Planner Self-Review
+
+- Spec coverage: Task 2 covers R1-R6 and R9-R11, Task 3 covers R7-R8, Task 4
+  covers all ACs plus RED/GREEN pressure-test verification.
+- Placeholder scan: no `TBD`, `TODO`, or deferred implementation placeholders
+  remain.
+- Scope check: no plan task introduces automated PR-body linting or template
+  section redesign.

--- a/docs/superpowers/specs/2026-05-03-83-clarify-pr-template-emoji-semantics-for-test-coverage-design.md
+++ b/docs/superpowers/specs/2026-05-03-83-clarify-pr-template-emoji-semantics-for-test-coverage-design.md
@@ -1,0 +1,117 @@
+# Design: Clarify PR template emoji semantics for test coverage [#83](https://github.com/patinaproject/bootstrap/issues/83)
+
+## Intent
+
+Clarify the pull request template's test coverage matrix so authors can tell
+the difference between missing tests and acknowledged test gaps. The change
+keeps the existing PR body shape while tightening the symbol legend and the
+relationship between matrix warnings and per-AC `Test gap` rows.
+
+## Requirements
+
+- R1: The test coverage matrix legend defines `✅` as required validation
+  passed with no blocking gap for that column.
+- R2: The legend defines `❌` as tests that should exist but are missing.
+- R3: The legend defines `⚠️` as required validation that has an acknowledged
+  gap, warning, unresolved concern, or failing/pending state that requires
+  reviewer attention.
+- R4: The legend defines `➖` as not relevant to this AC.
+- R5: The template instructions state that every `⚠️` matrix cell must have
+  one or more corresponding `⚠️ Test gap:` checkboxes under the relevant AC.
+- R6: The existing `⚠️ Test gap:` row semantics stay focused on observable
+  behavior, missing coverage, or unresolved validation concerns; the change
+  does not turn test gaps into generic review comments or operator actions.
+- R7: Root `.github/pull_request_template.md` remains byte-identical to the
+  bootstrap template source at
+  `skills/bootstrap/templates/core/.github/pull_request_template.md`.
+- R8: `docs/ac-traceability.md` continues to delegate the detailed PR-body
+  grammar to the canonical PR template, with wording updated only if needed to
+  avoid contradicting the clarified symbol semantics.
+- R9: The new template wording remains concise: update the symbol legend and
+  the `⚠️ Test gap:` instruction without duplicating the full grammar from
+  `docs/ac-traceability.md`.
+- R10: PR authors and Superteam `Finisher` own rendering the matrix-to-gap
+  relationship correctly in PR bodies; `Reviewer` and `Finisher` own flagging
+  mismatches before publish-state readiness.
+- R11: A matrix `⚠️` without corresponding per-AC `⚠️ Test gap:` detail, or a
+  per-AC `⚠️ Test gap:` without a matching matrix warning when the gap maps to
+  a matrix column, blocks readiness until reconciled.
+
+## Non-Goals
+
+- Do not redesign the pull request template or change its top-level sections.
+- Do not add or remove test coverage matrix columns.
+- Do not change the requirement that known test gaps are unchecked checkboxes.
+- Do not introduce automated PR-body linting for the new relationship rule in
+  this issue.
+
+## Acceptance Criteria
+
+- AC-83-1: Given an author reads the pull request template's `## Test coverage`
+  legend, when tests that should exist are missing, then the legend tells the
+  author to use `❌`.
+- AC-83-2: Given an author reads the pull request template's `## Test coverage`
+  legend, when required coverage has an acknowledged gap or warning, then the
+  legend tells the author to use `⚠️`.
+- AC-83-3: Given an author reads the acceptance-criteria guidance, when a real
+  automated coverage gap must be called out, then the existing `⚠️ Test gap:`
+  guidance remains unchanged.
+- AC-83-4: Given an author marks any test coverage table cell with `⚠️`, when
+  the author fills in the corresponding acceptance-criteria section, then that
+  section contains one or more `⚠️ Test gap:` rows explaining the warning.
+
+## Implementation Shape
+
+1. Update `skills/bootstrap/templates/core/.github/pull_request_template.md`
+   first.
+2. Mirror the template to `.github/pull_request_template.md` according to the
+   repository's round-trip discipline.
+3. Review `docs/ac-traceability.md` for stale references to the old symbol
+   semantics and adjust only if a direct contradiction remains.
+
+## Verification
+
+- Compare the mirrored PR template files with `cmp -s`.
+- Search both PR template copies for the clarified symbol meanings.
+- Search for stale wording that still says `❌` covers unresolved gaps.
+- RED baseline: inspect the current template and record that it permits the
+  target failure mode by defining `❌` as covering unresolved gaps and not
+  requiring every matrix warning to map to per-AC `⚠️ Test gap:` rows.
+- GREEN pressure test: render or inspect a sample PR-body excerpt with one
+  missing-test cell and one acknowledged-gap cell, then verify the clarified
+  template tells authors to use `❌` only for the missing-test cell and `⚠️`
+  plus one or more `⚠️ Test gap:` rows for the acknowledged-gap cell.
+- Run Markdown lint after the design, plan, and implementation docs are in
+  place.
+
+## Rationalization Resistance
+
+| Rationalization | Reality |
+| --- | --- |
+| "`❌` already covers gaps, so no template change is needed." | Issue #83 explicitly separates missing tests from acknowledged gaps; the legend must teach that split. |
+| "A table `⚠️` is self-explanatory." | The template must require corresponding `⚠️ Test gap:` rows so reviewers can inspect the reason. |
+| "I'll use `❌` or `✅` to avoid creating an unchecked gap row." | Symbol choice must describe the validation state honestly; acknowledged gaps use `⚠️` and require per-AC detail. |
+| "Only the root PR template matters." | The bootstrap template source is authoritative; root changes must be mirrored from it. |
+| "This is only wording, so no verification is needed." | PR-template wording is workflow behavior; verification must prove the shipped template and root mirror agree. |
+
+## Red Flags
+
+- A remaining `❌` definition that includes unresolved gaps, failing validation,
+  or pending validation.
+- A `⚠️` definition that does not require corresponding `⚠️ Test gap:` detail.
+- A matrix `⚠️` with no matching per-AC `⚠️ Test gap:` detail.
+- A per-AC `⚠️ Test gap:` that maps to a matrix column but leaves that column
+  marked `✅`, `❌`, or `➖`.
+- Root and template-source PR templates differ after implementation.
+- `docs/ac-traceability.md` contradicts the clarified symbol split.
+
+## Brainstormer Self-Review
+
+- Placeholder scan: no placeholders remain.
+- Internal consistency: `❌` is reserved for missing tests, while `⚠️` carries
+  acknowledged gap and warning states with required per-AC detail.
+- Scope check: the change is limited to PR-template semantics and any directly
+  contradictory traceability pointer.
+- Ambiguity check: failing or pending validation is intentionally treated as a
+  warning/gap state unless the concrete problem is missing tests that should
+  exist.

--- a/skills/bootstrap/templates/core/.github/pull_request_template.md
+++ b/skills/bootstrap/templates/core/.github/pull_request_template.md
@@ -55,13 +55,18 @@
   still needs an AC heading. Each cell summarizes the required-validation state
   for that AC and column. Use only these symbols in status cells:
   ✅ = required validation passed, with no blocking gap for this column
-  ❌ = required validation missing, failing, or blocked by an unresolved gap
+  ❌ = tests that should exist are missing
+  ⚠️ = required validation has an acknowledged gap, warning, unresolved
+       concern, or failing/pending state that needs reviewer attention
   ➖ = not relevant to this AC
 
   Use `➖` only when that verification type is not relevant to the AC. If an AC
   includes evidence, a test gap, or an operator check that clearly maps to a
-  matrix column, that cell must not be `➖`. If required validation is still
-  pending, use `❌` and add a test-gap checkbox until that validation passes.
+  matrix column, that cell must not be `➖`. Every `⚠️` matrix cell must have
+  one or more corresponding `⚠️ Test gap:` checkboxes under that AC. If required
+  validation is failing, pending, blocked by an unresolved concern, or otherwise
+  cannot yet be trusted, use `⚠️` and add a test-gap checkbox until that
+  validation passes.
 -->
 | AC | Title | Unit | <Platform> |
 | --- | --- | --- | --- |
@@ -82,8 +87,9 @@ including unresolved blockers or pending validation when present.
 
 <!--
   For each supported platform that is relevant to this AC, include one evidence
-  row or report the missing validation as a test-gap checkbox. Keep evidence
-  rows compact and use a colon after the evidence label:
+  row, summarize missing tests in the outcome, or report an acknowledged
+  validation gap as a test-gap checkbox. Keep evidence rows compact and use a
+  colon after the evidence label:
   `<Platform> test: <command, workflow job, tool, or harness>, <environment>[, <link, verifier, or ISO>]`.
   Name the concrete command, workflow job, tool, or harness when known. Use a
   neutral verifier value, such as a person, role, or run identifier. Add a unit
@@ -96,12 +102,15 @@ including unresolved blockers or pending validation when present.
 - <Platform> test: <command, workflow job, tool, or harness>, <environment>[, <link, verifier, or ISO>]
 <!--
   Include every known Test gap that the operator must consciously review. Use
-  `Test gap:` to describe missing coverage or an unresolved validation concern,
-  not to restate a code-review finding or duplicate an operator action. Test
-  gaps must be about observable behavior, missing coverage, or validation that
-  cannot yet be trusted. Treat CI that must rerun after a fix as a test gap
-  unless the operator must manually trigger or inspect a specific job. Delete
-  unused placeholder checkbox rows.
+  `Test gap:` to describe an acknowledged coverage gap or an unresolved
+  validation concern, not to restate a code-review finding, duplicate an
+  operator action, or explain tests that should exist but are missing. Test gaps
+  must be about observable behavior or validation that cannot yet be trusted.
+  Treat CI that must rerun after a fix as a test gap unless the operator must
+  manually trigger or inspect a specific job. Delete unused placeholder checkbox
+  rows.
+  Every `⚠️ Test gap:` that maps to a matrix column must have a corresponding
+  `⚠️` cell in that AC's matrix row.
   Example: - [ ] ⚠️ Test gap: <observable behavior or validation not verified>
 -->
 - [ ] ⚠️ Test gap: <observable behavior, missing coverage, or unresolved validation concern>


### PR DESCRIPTION
## Linked issue

Closes #83

## What changed

- Clarified PR template status symbols so `❌` is reserved for tests that should exist but are missing.
- Added `⚠️` as the matrix symbol for acknowledged validation gaps, warnings, unresolved concerns, and failing or pending validation.
- Required every matrix `⚠️` to have matching per-AC `⚠️ Test gap:` detail, while keeping root and bootstrap template copies mirrored.

## Test coverage

| AC | Title | Unit |
| --- | --- | --- |
| AC-83-1 | Missing tests use ❌ | ✅ |
| AC-83-2 | Acknowledged gaps use ⚠️ | ✅ |
| AC-83-3 | Test gap guidance preserved | ✅ |
| AC-83-4 | Matrix warnings require gap detail | ✅ |

## Acceptance criteria

### AC-83-1

The PR template legend now tells authors to use `❌` when tests that should exist are missing.

- Unit test: clarified-symbol `rg` search across both PR templates, local shell, Codex, 2026-05-03.
- Unit test: RED baseline `rg` search before edits found stale `❌` semantics in both PR templates, local shell, Codex, 2026-05-03.

### AC-83-2

The PR template legend now tells authors to use `⚠️` for acknowledged gaps, warnings, unresolved concerns, and failing or pending validation.

- Unit test: clarified-symbol `rg` search across both PR templates, local shell, Codex, 2026-05-03.
- Unit test: stale `❌` gap-semantics `rg` search across both PR templates returned no matches with exit 1, local shell, Codex, 2026-05-03.

### AC-83-3

The existing `⚠️ Test gap:` row remains the mechanism for acknowledged coverage gaps and unresolved validation concerns, with wording tightened so it does not explain tests that should exist but are missing.

- Unit test: `docs/ac-traceability.md` contradiction `rg` search returned no matches with exit 1, local shell, Codex, 2026-05-03.
- Unit test: `pnpm exec markdownlint-cli2` on the design, plan, PR templates, and `docs/ac-traceability.md`, local shell, Codex, 2026-05-03.

### AC-83-4

Every matrix `⚠️` must now have one or more corresponding `⚠️ Test gap:` rows under the relevant AC, and mapped `⚠️ Test gap:` rows must have a corresponding matrix `⚠️`.

- Unit test: `cmp -s .github/pull_request_template.md skills/bootstrap/templates/core/.github/pull_request_template.md`, local shell, Codex, 2026-05-03.
- Unit test: GREEN pressure-test excerpt inspection, local review, Codex, 2026-05-03. The updated template classifies `AC-83-1` as `❌` without a gap because tests that should exist are missing, and `AC-83-2` as `⚠️` with matching per-AC `⚠️ Test gap:` detail.
