### PR TITLE
feat: #87 clarify non-blocking coverage warnings

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -54,19 +54,21 @@
   summarized in the AC section without a matrix row, but every relevant AC
   still needs an AC heading. Each cell summarizes the required-validation state
   for that AC and column. Use only these symbols in status cells:
-  ✅ = required validation passed, with no blocking gap for this column
-  ❌ = tests that should exist are missing
-  ⚠️ = required validation has an acknowledged gap, warning, unresolved
-       concern, or failing/pending state that needs reviewer attention
+  ✅ = required validation passed, with no known relevant gap for this column
+  ⚠️ = validation exists and is sufficient to merge, with a known non-blocking
+       gap documented under this AC
+  ❌ = required validation is missing, failing, pending, or blocked by a
+       merge-blocking gap
   ➖ = not relevant to this AC
 
   Use `➖` only when that verification type is not relevant to the AC. If an AC
-  includes evidence, a test gap, or an operator check that clearly maps to a
-  matrix column, that cell must not be `➖`. Every `⚠️` matrix cell must have
-  one or more corresponding `⚠️ Test gap:` checkboxes under that AC. If required
-  validation is failing, pending, blocked by an unresolved concern, or otherwise
-  cannot yet be trusted, use `⚠️` and add a test-gap checkbox until that
-  validation passes.
+  includes evidence, a gap, or an operator check that clearly maps to a matrix
+  column, that cell must not be `➖`. If a known non-blocking gap remains after
+  sufficient validation, use `⚠️` and document the gap under the AC in prose or
+  with an explicitly optional checkbox. If required validation is missing,
+  failing, pending, blocked by an unresolved concern, or otherwise cannot yet
+  be trusted for merge, use `❌` and add a required gap or operator-check
+  checkbox when pre-merge action is needed.
 -->
 | AC | Title | Unit | <Platform> |
 | --- | --- | --- | --- |
@@ -87,33 +89,37 @@ including unresolved blockers or pending validation when present.
 
 <!--
   For each supported platform that is relevant to this AC, include one evidence
-  row, summarize missing tests in the outcome, or report an acknowledged
-  validation gap as a test-gap checkbox. Keep evidence rows compact and use a
-  colon after the evidence label:
+  row, summarize missing tests in the outcome, or document a known gap below.
+  Keep evidence rows compact and use a colon after the evidence label:
   `<Platform> test: <command, workflow job, tool, or harness>, <environment>[, <link, verifier, or ISO>]`.
   Name the concrete command, workflow job, tool, or harness when known. Use a
   neutral verifier value, such as a person, role, or run identifier. Add a unit
   evidence row only when unit evidence is the meaningful validation for this AC;
   otherwise keep unit details in the matrix or CI summary.
   If an unresolved critical or major review finding affects validation for this
-  AC, describe the missing observable behavior or validation as a test-gap
+  AC, describe the missing observable behavior or validation as a required gap
   checkbox unless it belongs in Do before merging.
 -->
 - <Platform> test: <command, workflow job, tool, or harness>, <environment>[, <link, verifier, or ISO>]
 <!--
-  Include every known Test gap that the operator must consciously review. Use
-  `Test gap:` to describe an acknowledged coverage gap or an unresolved
-  validation concern, not to restate a code-review finding, duplicate an
-  operator action, or explain tests that should exist but are missing. Test gaps
-  must be about observable behavior or validation that cannot yet be trusted.
-  Treat CI that must rerun after a fix as a test gap unless the operator must
-  manually trigger or inspect a specific job. Delete unused placeholder checkbox
-  rows.
-  Every `⚠️ Test gap:` that maps to a matrix column must have a corresponding
-  `⚠️` cell in that AC's matrix row.
-  Example: - [ ] ⚠️ Test gap: <observable behavior or validation not verified>
+  Include every known blocking gap that the operator must consciously review
+  or resolve before merge. Use `Test gap:` to describe missing coverage or an
+  unresolved validation concern that keeps the matrix cell at `❌`. Do not use
+  required unchecked `Test gap:` rows for non-blocking caveats. Treat CI that
+  must rerun after a fix as a required test gap unless the operator must
+  manually trigger or inspect a specific job. Delete unused placeholder
+  checkbox rows.
+  Example: - [ ] ⚠️ Test gap: <blocking observable behavior or validation not verified>
 -->
-- [ ] ⚠️ Test gap: <observable behavior, missing coverage, or unresolved validation concern>
+- [ ] ⚠️ Test gap: <blocking observable behavior, missing coverage, or unresolved validation concern>
+<!--
+  For a non-blocking gap represented by a `⚠️` matrix cell, use prose or an
+  explicitly optional checkbox. Optional checkboxes must include
+  `pr-checkbox: optional` immediately above the row. For example, write prose
+  like `Non-blocking gap: <known caveat accepted for this PR>.` Or, when a
+  visible acknowledgement row is useful, put `pr-checkbox: optional` in an
+  HTML comment immediately above an unchecked `⚠️ Non-blocking gap:` checkbox.
+-->
 <!--
   Include every known operator action below any test-gap checkboxes for this
   AC. Use the literal prefix `Operator check:` for product testing, diff

--- a/docs/ac-traceability.md
+++ b/docs/ac-traceability.md
@@ -22,4 +22,17 @@ ACs describe observable behavior, not implementation steps. Prefer "the template
 
 The PR body mirrors the issue's ACs using the `### AC-<issue>-<n>` heading-per-AC format specified in [`AGENTS.md`](../AGENTS.md). One heading per relevant AC, a short outcome summary, and checkboxes only for operator actions that must happen before merge. Do not restate those rules here – extend `AGENTS.md` if they need to change.
 
-Test coverage and per-AC verification rows – a `## Test coverage` matrix with `Unit` plus the affected supported-platform columns, symbol-only status cells, compact colon-style platform test rows (`- <Platform> test: <command, workflow job, tool, or harness>, <environment>[, <link, verifier, or ISO>]`) or explicit gap checkboxes for missing relevant platform validation, every known test gap as an unchecked descriptive checkbox for the operator, every known operator action below gaps as an unchecked imperative `Operator check:` checkbox with an expected decision or result, and every existing manual-review or manual-test instruction preserved under its AC as an operator check – are defined by the canonical PR template at [`.github/pull_request_template.md`](../.github/pull_request_template.md). The template comments are the source of truth for the coverage matrix, slim-test grammar, per-AC unit-test detail rule, per-AC content order, operator-check rule, checkbox imperative-style rule, status-symbol rule, matrix consistency rule, platform-evidence-or-gap rule, observable test-gap rule, placeholder deletion rule, and gap-acknowledgement rule; do not duplicate that grammar here.
+Test coverage and per-AC verification rows – a `## Test coverage` matrix with
+`Unit` plus the affected supported-platform columns, symbol-only status cells,
+compact colon-style platform test rows (`- <Platform> test: <command, workflow
+job, tool, or harness>, <environment>[, <link, verifier, or ISO>]`), required
+gap checkboxes for merge-blocking missing/failing/pending validation, and prose
+or explicitly optional checkbox explanations for known non-blocking gaps – are
+defined by the canonical PR template at
+[`.github/pull_request_template.md`](../.github/pull_request_template.md).
+The template comments are the source of truth for the coverage matrix,
+slim-test grammar, per-AC unit-test detail rule, per-AC content order,
+operator-check rule, checkbox imperative-style rule, status-symbol rule, matrix
+consistency rule, platform-evidence-or-gap rule, observable test-gap rule,
+optional non-blocking gap rule, placeholder deletion rule, and
+gap-acknowledgement rule; do not duplicate that grammar here.

--- a/docs/superpowers/plans/2026-05-03-87-clarify-non-blocking-warning-semantics-in-pr-coverage-matrix-plan.md
+++ b/docs/superpowers/plans/2026-05-03-87-clarify-non-blocking-warning-semantics-in-pr-coverage-matrix-plan.md
@@ -1,0 +1,360 @@
+# Clarify Non-Blocking Warning Semantics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Update the PR-template coverage grammar so `⚠️` means validated enough to merge with a known non-blocking gap, while blocking or pending validation uses `❌`.
+
+**Architecture:** The canonical source is `skills/bootstrap/templates/core/.github/pull_request_template.md`; the root `.github/pull_request_template.md` must mirror it exactly. `docs/ac-traceability.md` remains a compact pointer to the template grammar, and the checkbox checker keeps its existing syntax-only responsibility.
+
+**Tech Stack:** Markdown templates, `markdownlint-cli2`, Node.js built-in test runner for the existing checkbox checker.
+
+---
+
+## File Structure
+
+- Modify: `skills/bootstrap/templates/core/.github/pull_request_template.md`
+  - Owns the canonical PR-template grammar shipped by bootstrap.
+- Modify: `.github/pull_request_template.md`
+  - Mirrors the canonical template for this repository.
+- Modify: `docs/ac-traceability.md`
+  - Summarizes that non-blocking gap explanations may be prose or explicitly optional checkboxes, without duplicating the full grammar.
+- Optional test-only change: `scripts/fixtures/pr-template-checkboxes/non-blocking-gap-optional.md`
+  - Demonstrates that an explicitly optional non-blocking gap checkbox does not fail the required checkbox gate.
+- Optional test-only change: `scripts/check-pr-template-checkboxes.test.mjs`
+  - Adds one regression assertion only if the executor chooses to add the fixture above.
+
+## Task 1: Update Canonical PR Template
+
+**Files:**
+
+- Modify: `skills/bootstrap/templates/core/.github/pull_request_template.md`
+
+- [ ] **Step 1: Confirm RED baseline strings exist**
+
+Run:
+
+```bash
+rg -n "failing/pending state|Every `⚠️` matrix cell|Every `⚠️ Test gap:`|tests that should exist are missing" \
+  skills/bootstrap/templates/core/.github/pull_request_template.md
+```
+
+Expected: output includes the current issue-83 wording that conflates `⚠️`
+with failing/pending states and reverse maps `⚠️ Test gap:` rows to matrix
+`⚠️` cells.
+
+- [ ] **Step 2: Edit the matrix legend and matrix-cell guidance**
+
+In `skills/bootstrap/templates/core/.github/pull_request_template.md`, replace
+the status-cell legend and the paragraph after it with:
+
+```markdown
+  ✅ = required validation passed, with no known relevant gap for this column
+  ⚠️ = validation exists and is sufficient to merge, with a known non-blocking
+       gap documented under this AC
+  ❌ = required validation is missing, failing, pending, or blocked by a
+       merge-blocking gap
+  ➖ = not relevant to this AC
+
+  Use `➖` only when that verification type is not relevant to the AC. If an AC
+  includes evidence, a gap, or an operator check that clearly maps to a matrix
+  column, that cell must not be `➖`. If a known non-blocking gap remains after
+  sufficient validation, use `⚠️` and document the gap under the AC in prose or
+  with an explicitly optional checkbox. If required validation is missing,
+  failing, pending, blocked by an unresolved concern, or otherwise cannot yet
+  be trusted for merge, use `❌` and add a required gap or operator-check
+  checkbox when pre-merge action is needed.
+```
+
+- [ ] **Step 3: Edit the per-AC evidence and gap guidance**
+
+In the same file, replace the evidence/gap comments and placeholder gap row
+around the `- <Platform> test:` line with:
+
+```markdown
+  For each supported platform that is relevant to this AC, include one evidence
+  row, summarize missing tests in the outcome, or document a known gap below.
+  Keep evidence rows compact and use a colon after the evidence label:
+  `<Platform> test: <command, workflow job, tool, or harness>, <environment>[, <link, verifier, or ISO>]`.
+  Name the concrete command, workflow job, tool, or harness when known. Use a
+  neutral verifier value, such as a person, role, or run identifier. Add a unit
+  evidence row only when unit evidence is the meaningful validation for this AC;
+  otherwise keep unit details in the matrix or CI summary.
+  If an unresolved critical or major review finding affects validation for this
+  AC, describe the missing observable behavior or validation as a required gap
+  checkbox unless it belongs in Do before merging.
+-->
+- <Platform> test: <command, workflow job, tool, or harness>, <environment>[, <link, verifier, or ISO>]
+<!--
+  Include every known blocking gap that the operator must consciously review
+  or resolve before merge. Use `Test gap:` to describe missing coverage or an
+  unresolved validation concern that keeps the matrix cell at `❌`. Do not use
+  required unchecked `Test gap:` rows for non-blocking caveats. Treat CI that
+  must rerun after a fix as a required test gap unless the operator must
+  manually trigger or inspect a specific job. Delete unused placeholder
+  checkbox rows.
+  Example: - [ ] ⚠️ Test gap: <blocking observable behavior or validation not verified>
+-->
+- [ ] ⚠️ Test gap: <blocking observable behavior, missing coverage, or unresolved validation concern>
+<!--
+  For a non-blocking gap represented by a `⚠️` matrix cell, use prose or an
+  explicitly optional checkbox. Optional checkboxes must include
+  `pr-checkbox: optional` immediately above the row.
+  Example prose: Non-blocking gap: <known caveat accepted for this PR>.
+  Example optional checkbox:
+  <!-- pr-checkbox: optional -->
+  - [ ] ⚠️ Non-blocking gap: <known caveat accepted for this PR>
+-->
+```
+
+Important: if the nested HTML comment example would make the template comment
+hard to read, use prose instead of embedding the literal optional-marker block
+inside another HTML comment. The final template must still plainly say that
+optional checkbox rows require `pr-checkbox: optional` immediately above them.
+
+- [ ] **Step 4: Verify stale canonical wording is gone**
+
+Run:
+
+```bash
+rg -n "failing/pending state|Every `⚠️` matrix cell|Every `⚠️ Test gap:`|corresponding.*⚠️.*matrix|tests that should exist are missing" \
+  skills/bootstrap/templates/core/.github/pull_request_template.md
+```
+
+Expected: no output.
+
+## Task 2: Mirror Root PR Template
+
+**Files:**
+
+- Modify: `.github/pull_request_template.md`
+
+- [ ] **Step 1: Copy the canonical template to the root template**
+
+Run:
+
+```bash
+cp skills/bootstrap/templates/core/.github/pull_request_template.md .github/pull_request_template.md
+```
+
+- [ ] **Step 2: Confirm exact parity**
+
+Run:
+
+```bash
+diff -u skills/bootstrap/templates/core/.github/pull_request_template.md .github/pull_request_template.md
+```
+
+Expected: no output.
+
+- [ ] **Step 3: Confirm root stale wording is gone**
+
+Run:
+
+```bash
+rg -n "failing/pending state|Every `⚠️` matrix cell|Every `⚠️ Test gap:`|corresponding.*⚠️.*matrix|tests that should exist are missing" \
+  .github/pull_request_template.md
+```
+
+Expected: no output.
+
+## Task 3: Align AC Traceability Summary
+
+**Files:**
+
+- Modify: `docs/ac-traceability.md`
+
+- [ ] **Step 1: Replace the compact PR grammar sentence**
+
+In `docs/ac-traceability.md`, update the paragraph beginning `Test coverage
+and per-AC verification rows` so it mentions:
+
+```markdown
+Test coverage and per-AC verification rows – a `## Test coverage` matrix with
+`Unit` plus the affected supported-platform columns, symbol-only status cells,
+compact colon-style platform test rows (`- <Platform> test: <command, workflow
+job, tool, or harness>, <environment>[, <link, verifier, or ISO>]`), required
+gap checkboxes for merge-blocking missing/failing/pending validation, and prose
+or explicitly optional checkbox explanations for known non-blocking gaps – are
+defined by the canonical PR template at [`.github/pull_request_template.md`](../.github/pull_request_template.md).
+The template comments are the source of truth for the coverage matrix,
+slim-test grammar, per-AC unit-test detail rule, per-AC content order,
+operator-check rule, checkbox imperative-style rule, status-symbol rule, matrix
+consistency rule, platform-evidence-or-gap rule, observable test-gap rule,
+optional non-blocking gap rule, placeholder deletion rule, and
+gap-acknowledgement rule; do not duplicate that grammar here.
+```
+
+- [ ] **Step 2: Verify the summary mentions non-blocking optional detail**
+
+Run:
+
+```bash
+rg -n "non-blocking gap|explicitly optional|merge-blocking" docs/ac-traceability.md
+```
+
+Expected: output includes the updated paragraph.
+
+## Task 4: Optional Checkbox Regression Test
+
+**Files:**
+
+- Create: `scripts/fixtures/pr-template-checkboxes/non-blocking-gap-optional.md`
+- Modify: `scripts/check-pr-template-checkboxes.test.mjs`
+
+- [ ] **Step 1: Add fixture for optional non-blocking gap**
+
+Create `scripts/fixtures/pr-template-checkboxes/non-blocking-gap-optional.md`
+with:
+
+```markdown
+## Acceptance criteria
+
+### AC-87-4
+
+Chrome validation is enough to merge; Safari is a known non-blocking gap.
+
+<!-- pr-checkbox: optional -->
+- [ ] ⚠️ Non-blocking gap: Safari persistence was not verified.
+```
+
+- [ ] **Step 2: Add test assertion**
+
+In `scripts/check-pr-template-checkboxes.test.mjs`, add:
+
+```js
+test('passes optional non-blocking gap checkbox rows', () => {
+  assert.equal(validatePrBody(fixture('non-blocking-gap-optional.md')).ok, true);
+});
+```
+
+- [ ] **Step 3: Run checkbox tests**
+
+Run:
+
+```bash
+node --test scripts/check-pr-template-checkboxes.test.mjs
+```
+
+Expected: all tests pass.
+
+## Task 5: Full Verification
+
+**Files:**
+
+- Verify all changed files.
+
+- [ ] **Step 1: Run targeted stale-wording checks**
+
+Run:
+
+```bash
+rg -n "failing/pending state|Every `⚠️` matrix cell|Every `⚠️ Test gap:`|corresponding.*⚠️.*matrix|tests that should exist are missing" \
+  .github/pull_request_template.md \
+  skills/bootstrap/templates/core/.github/pull_request_template.md \
+  docs/ac-traceability.md
+```
+
+Expected: no output.
+
+- [ ] **Step 2: Run parity check**
+
+Run:
+
+```bash
+diff -u skills/bootstrap/templates/core/.github/pull_request_template.md .github/pull_request_template.md
+```
+
+Expected: no output.
+
+- [ ] **Step 3: Run checkbox tests**
+
+Run:
+
+```bash
+node --test scripts/check-pr-template-checkboxes.test.mjs
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Run markdown lint**
+
+If dependencies are not installed, first run:
+
+```bash
+pnpm install
+```
+
+Then run:
+
+```bash
+pnpm lint:md
+```
+
+Expected: lint passes.
+
+- [ ] **Step 5: Review final diff**
+
+Run:
+
+```bash
+git diff --check
+git diff --stat
+git diff -- .github/pull_request_template.md skills/bootstrap/templates/core/.github/pull_request_template.md docs/ac-traceability.md scripts/check-pr-template-checkboxes.test.mjs scripts/fixtures/pr-template-checkboxes/non-blocking-gap-optional.md
+```
+
+Expected: whitespace check passes; diff is limited to the planned files.
+
+## Task 6: Commit Implementation
+
+**Files:**
+
+- Stage implementation and verification files.
+
+- [ ] **Step 1: Stage changes**
+
+Run:
+
+```bash
+git add \
+  .github/pull_request_template.md \
+  skills/bootstrap/templates/core/.github/pull_request_template.md \
+  docs/ac-traceability.md \
+  scripts/check-pr-template-checkboxes.test.mjs \
+  scripts/fixtures/pr-template-checkboxes/non-blocking-gap-optional.md
+```
+
+If Task 4 was intentionally skipped because existing optional-checkbox tests
+are sufficient, omit the two `scripts/` paths and document that decision in the
+PR body.
+
+- [ ] **Step 2: Commit changes**
+
+Run:
+
+```bash
+git commit -m "feat: #87 clarify non-blocking coverage warnings"
+```
+
+Expected: commit succeeds. The type is `feat:` because the diff touches
+product-surface files including the PR template and bootstrap template source.
+
+## Spec Coverage
+
+- AC-87-1: Tasks 1, 2, 3, and 5 verify `⚠️` is the visible matrix state for
+  known non-blocking gaps.
+- AC-87-2: Tasks 1 and 5 verify `❌` covers missing, failing, pending, and
+  merge-blocking validation.
+- AC-87-3: Tasks 1, 3, and 5 verify non-blocking gap explanations do not use
+  required unchecked merge gates.
+- AC-87-4: Task 4 verifies optional non-blocking gap checkboxes do not fail the
+  required-template-checkbox gate; Task 5 reruns the checker.
+- R9: Task 2 enforces canonical-template and root-template parity.
+- R12: The design artifact records the observed RED pressure result; no
+  implementation task removes or rewrites that evidence.
+
+## Plan Self-Review
+
+- Spec coverage: every AC and requirement maps to at least one task above.
+- Placeholder scan: no unresolved placeholder text remains.
+- Type consistency: no new code API is introduced; existing `validatePrBody`
+  and fixture helper names are reused exactly.

--- a/docs/superpowers/specs/2026-05-03-87-clarify-non-blocking-warning-semantics-in-pr-coverage-matrix-design.md
+++ b/docs/superpowers/specs/2026-05-03-87-clarify-non-blocking-warning-semantics-in-pr-coverage-matrix-design.md
@@ -191,9 +191,11 @@ authoring guidance that keeps non-blocking gaps out of required checkbox form.
   already supports `pr-checkbox: optional`, so the main behavior change may be
   template-only.
 - Verify no stale issue-83 wording remains with targeted `rg` checks for
-  `Every \`⚠️\` matrix cell`, `failing/pending state`, and `one or more corresponding`.
+  the literal text `Every ⚠️ matrix cell`, `failing/pending state`, and
+  `one or more corresponding`.
 - Verify no stale reverse-mapping wording remains with a targeted `rg` check
-  for `Every \`⚠️ Test gap:\`` and `corresponding.*⚠️.*matrix`.
+  for the literal text `Every ⚠️ Test gap:` and
+  `corresponding.*⚠️.*matrix`.
 
 ## Self-Review
 

--- a/docs/superpowers/specs/2026-05-03-87-clarify-non-blocking-warning-semantics-in-pr-coverage-matrix-design.md
+++ b/docs/superpowers/specs/2026-05-03-87-clarify-non-blocking-warning-semantics-in-pr-coverage-matrix-design.md
@@ -1,0 +1,206 @@
+# Design: Clarify non-blocking warning semantics in PR coverage matrix [#87](https://github.com/patinaproject/bootstrap/issues/87)
+
+## Intent
+
+Clarify the PR template's coverage-matrix symbol contract so `⚠️` means
+"validation exists and the remaining gap is known, documented, and non-blocking"
+instead of "the PR is blocked until this unchecked gap row is resolved." This
+keeps reviewer attention visible without turning accepted coverage caveats into
+merge gates.
+
+## Requirements
+
+- R1: The `## Test coverage` legend defines `✅` as required validation passed
+  with no known relevant gap for the AC and column.
+- R2: The legend defines `⚠️` as validation that exists and is sufficient to
+  merge, while a known non-blocking coverage gap remains.
+- R3: The legend defines `❌` as required validation missing, failing, pending,
+  or blocked by a gap that must be resolved before merge.
+- R4: The legend keeps `➖` for verification types that are not relevant to the
+  AC.
+- R5: The template instructions state that a `⚠️` matrix cell must be explained
+  under the matching AC, but that explanation must not be a required unchecked
+  merge gate solely because the gap exists.
+- R6: The template gives authors an explicit non-blocking gap form: prose or an
+  explicitly optional checkbox using the existing `pr-checkbox: optional`
+  marker.
+- R7: Blocking gaps, failing validation, and pending required validation still
+  use required unchecked checklist rows when operator action or conscious
+  pre-merge resolution is required.
+- R8: `docs/ac-traceability.md` stays aligned with the canonical PR-template
+  grammar without duplicating the full template instructions.
+- R9: Because `.github/pull_request_template.md` is a bootstrapped baseline
+  file, edits are made in `skills/bootstrap/templates/core/.github/pull_request_template.md`
+  first and mirrored to the root template in the same change.
+- R10: The required-template-checkbox checker continues to treat unmarked
+  visible unchecked checkboxes as required and explicitly optional checkboxes as
+  non-blocking.
+- R11: The template removes the stale reverse mapping that says every
+  `⚠️ Test gap:` row must have a corresponding `⚠️` matrix cell. Required
+  unchecked gap rows for blocking, failing, or pending validation map to `❌`;
+  non-blocking `⚠️` cells map only to prose or explicitly optional gap notes.
+- R12: The plan must preserve the observed RED pressure result before
+  implementation: a fresh agent using the current template chose `✅` for a
+  known non-blocking Safari gap, hiding the warning in prose instead of using a
+  visible `⚠️` table state.
+
+## Acceptance Criteria
+
+- AC-87-1: Given an author reads the PR template coverage legend, when
+  validation exists but a known non-blocking gap remains, then the legend tells
+  the author to use `⚠️` rather than `✅` or `❌`.
+- AC-87-2: Given an author reads the PR template coverage legend, when required
+  validation is missing, failing, pending, or blocked by a merge-blocking gap,
+  then the legend tells the author to use `❌`.
+- AC-87-3: Given an author marks a coverage matrix cell with `⚠️`, when they
+  fill the corresponding acceptance-criteria section, then the template tells
+  them to document the non-blocking gap without creating a required unchecked
+  merge gate.
+- AC-87-4: Given a PR body includes an optional or prose non-blocking gap
+  explanation, when the required-template-checkbox check runs, then the
+  non-blocking gap does not block merge solely because it exists.
+
+## Proposed Shape
+
+Update the matrix legend from the current issue-83 wording:
+
+```markdown
+✅ = required validation passed, with no blocking gap for this column
+❌ = tests that should exist are missing
+⚠️ = required validation has an acknowledged gap, warning, unresolved
+     concern, or failing/pending state that needs reviewer attention
+➖ = not relevant to this AC
+```
+
+to wording that separates merge-blocking and non-blocking states:
+
+```markdown
+✅ = required validation passed, with no known relevant gap for this column
+⚠️ = validation exists and is sufficient to merge, with a known non-blocking
+     gap documented under this AC
+❌ = required validation is missing, failing, pending, or blocked by a
+     merge-blocking gap
+➖ = not relevant to this AC
+```
+
+Then update the AC guidance so a `⚠️` cell maps to either:
+
+- a short prose note such as `Non-blocking gap: Safari persistence was not
+  verified; accepted because this PR changes only Chrome-specific behavior.`
+- an explicitly optional checkbox when a maintainer wants visible review
+  acknowledgement:
+
+```markdown
+<!-- pr-checkbox: optional -->
+- [ ] ⚠️ Non-blocking gap: Safari persistence was not verified.
+```
+
+Required unchecked gap rows remain available for merge-blocking validation
+concerns, but those rows map to `❌`, not `⚠️`. The template must stop saying
+every matrix `⚠️` requires a required unchecked `⚠️ Test gap:` checkbox, and it
+must stop saying every `⚠️ Test gap:` row maps back to a `⚠️` matrix cell.
+
+## RED Baseline
+
+Current behavior after issue #83 makes `⚠️` carry too many meanings:
+acknowledged gap, warning, unresolved concern, failing state, and pending state.
+The template also says every matrix `⚠️` must have corresponding `⚠️ Test gap:`
+checkboxes. Because unmarked visible checkboxes are required by default, an
+author who honestly marks a non-blocking caveat with `⚠️` can accidentally make
+the PR look blocked.
+
+Observed pressure scenario:
+
+```markdown
+| AC | Title | Unit | Browser |
+| --- | --- | --- | --- |
+| AC-87-1 | Saves settings | ✅ | ⚠️ |
+
+### AC-87-1
+
+Settings save behavior is covered in Chrome. Safari was not verified and is
+accepted as non-blocking for this PR.
+
+- Browser test: Chrome smoke test, local
+- Non-blocking gap: Safari settings persistence was not verified.
+```
+
+Fresh-agent RED result, recorded before implementation:
+
+- Prompt: using the current template, choose the Browser matrix symbol and
+  per-AC detail when Chrome validation exists, Safari was not verified, and the
+  maintainer says the Safari gap is explicitly non-blocking.
+- Result: the agent chose `✅` and put the Safari caveat in prose because the
+  current legend says `✅` means required validation passed "with no blocking
+  gap" and `⚠️` requires matching `⚠️ Test gap:` checkboxes.
+- Failure: a known relevant non-blocking gap disappeared from the matrix, so
+  reviewers scanning the table would see a full pass instead of a visible
+  warning.
+
+## GREEN Target
+
+After the change, authors can express four distinct states:
+
+| Cell | Meaning | Per-AC detail |
+| --- | --- | --- |
+| `✅` | validation passed, no known relevant gap | optional evidence only |
+| `⚠️` | enough validation to merge, known non-blocking gap | prose or optional checkbox |
+| `❌` | missing, failing, pending, or merge-blocking validation | required gap/operator row when action is needed |
+| `➖` | not relevant | no mapped detail required |
+
+The required-template-checkbox checker remains simple: it does not infer
+semantic blocking state from emoji. It only enforces visible unchecked
+checkboxes unless they are explicitly marked optional. The PR template owns the
+authoring guidance that keeps non-blocking gaps out of required checkbox form.
+
+## Rationalization Resistance
+
+| Rationalization | Reality |
+| --- | --- |
+| "Any gap means `❌`." | `❌` is for missing, failing, pending, or merge-blocking validation. Non-blocking documented gaps use `⚠️`. |
+| "`⚠️` is still a warning, so it must be a required checkbox." | Warning visibility and merge blocking are separate. Use prose or an explicitly optional checkbox for non-blocking gaps. |
+| "A `✅` plus a prose caveat is good enough." | `✅` means no known relevant gap. If a relevant non-blocking gap exists, the matrix cell should be `⚠️`. |
+| "The checkbox checker should detect emoji semantics." | The checker enforces checkbox syntax only. The template tells authors which form to use. |
+| "Pending CI can be `⚠️` because it needs attention." | Pending required validation is not enough to merge; use `❌` until it passes or is explicitly accepted as non-blocking by the project. |
+| "A required `⚠️ Test gap:` row must map to `⚠️` because the label says warning." | Required unchecked gap rows are merge-blocking by form and must map to `❌`; `⚠️` is reserved for non-blocking documented gaps. |
+
+## Red Flags
+
+- `⚠️` still described as failing, pending, unresolved, or otherwise
+  merge-blocking.
+- Any instruction saying every `⚠️` cell must have a required unchecked
+  `⚠️ Test gap:` checkbox.
+- Any instruction saying every required `⚠️ Test gap:` checkbox maps back to a
+  `⚠️` cell.
+- `✅` allowed when a known relevant non-blocking gap remains.
+- `❌` narrowed only to missing tests while failing or pending required
+  validation loses a clear symbol.
+- Optional checkbox examples missing the `pr-checkbox: optional` marker.
+- Root `.github/pull_request_template.md` changed without the matching
+  template-source edit.
+- `docs/ac-traceability.md` left pointing only at required gap checkboxes.
+
+## Implementation Notes
+
+- Update `skills/bootstrap/templates/core/.github/pull_request_template.md`
+  first, then mirror `.github/pull_request_template.md`.
+- Update `docs/ac-traceability.md` only enough to mention non-blocking gap prose
+  or optional checkbox explanations as part of the canonical PR-template grammar.
+- Add or adjust checker tests only if the optional-checkbox behavior needs a
+  direct regression fixture for the new non-blocking gap example. The checker
+  already supports `pr-checkbox: optional`, so the main behavior change may be
+  template-only.
+- Verify no stale issue-83 wording remains with targeted `rg` checks for
+  `Every \`⚠️\` matrix cell`, `failing/pending state`, and `one or more corresponding`.
+- Verify no stale reverse-mapping wording remains with a targeted `rg` check
+  for `Every \`⚠️ Test gap:\`` and `corresponding.*⚠️.*matrix`.
+
+## Self-Review
+
+- Placeholder scan: no placeholders remain.
+- Internal consistency: `⚠️` is non-blocking, `❌` is blocking/missing/failing,
+  and `✅` excludes known relevant gaps.
+- Scope check: focused on PR-template grammar and its one summary doc.
+- Ambiguity check: optional checkbox versus required checkbox behavior is
+  explicit, reverse mapping is assigned to `❌` for blocking gaps, and checker
+  responsibility is separated from template guidance.

--- a/scripts/check-pr-template-checkboxes.mjs
+++ b/scripts/check-pr-template-checkboxes.mjs
@@ -12,8 +12,10 @@ const COMMENT_START = /^\s*<!--/;
 const COMMENT_END = /-->\s*$/;
 const AC_HEADING = /^AC-\d+-\d+\b/;
 const TEST_GAP = /^⚠️\s*Test gap:\s*(.+)$/i;
+const NON_BLOCKING_GAP = /^⚠️\s*Non-blocking gap:\s*(.+)$/i;
 const OPERATOR_CHECK = /^Operator check:/i;
 const PROSE_GAP = /^\s*(?:[-*]\s*)?Blocking validation gap:/i;
+const NON_BLOCKING_PROSE = /^\s*(?:[-*]\s*)?Non-blocking gap:/i;
 
 function ensureAc(acMap, acId, section, lineNumber) {
   const entry = acMap.get(acId) ?? {
@@ -21,6 +23,7 @@ function ensureAc(acMap, acId, section, lineNumber) {
     lineNumber,
     hasWarning: false,
     testGaps: [],
+    nonBlockingGaps: 0,
   };
   if (section) entry.section = section;
   if (lineNumber && !entry.lineNumber) entry.lineNumber = lineNumber;
@@ -95,6 +98,11 @@ export function validatePrBody(body) {
       continue;
     }
 
+    if (NON_BLOCKING_PROSE.test(line) && activeAc) {
+      ensureAc(acs, activeAc, section, lineNumber).nonBlockingGaps += 1;
+      continue;
+    }
+
     const checkbox = line.match(CHECKBOX);
     if (!checkbox) continue;
 
@@ -106,6 +114,18 @@ export function validatePrBody(body) {
     if (PROSE_GAP.test(text)) {
       errors.push(
         `line ${lineNumber}: ${section}: use canonical ⚠️ Test gap checkbox instead of prose: ${text}`,
+      );
+      continue;
+    }
+
+    const nonBlockingGap = text.match(NON_BLOCKING_GAP);
+    if (nonBlockingGap) {
+      const acId = activeAc ?? section;
+      const ac = ensureAc(acs, acId, section, lineNumber);
+      ac.nonBlockingGaps += 1;
+      if (marker.kind === 'optional') continue;
+      errors.push(
+        `line ${lineNumber}: ${section}: ⚠️ Non-blocking gap rows must be marked optional with \`<!-- pr-checkbox: optional -->\` immediately above: ${text}`,
       );
       continue;
     }
@@ -157,9 +177,9 @@ export function validatePrBody(body) {
   }
 
   for (const [acId, ac] of acs.entries()) {
-    if (ac.hasWarning && ac.testGaps.length === 0) {
+    if (ac.hasWarning && ac.testGaps.length === 0 && ac.nonBlockingGaps === 0) {
       errors.push(
-        `line ${ac.lineNumber}: ${acId}: missing ⚠️ Test gap for warning matrix cell`,
+        `line ${ac.lineNumber}: ${acId}: missing ⚠️ Test gap or Non-blocking gap explanation for warning matrix cell`,
       );
     }
   }

--- a/scripts/check-pr-template-checkboxes.test.mjs
+++ b/scripts/check-pr-template-checkboxes.test.mjs
@@ -27,6 +27,10 @@ test('passes explicitly optional unchecked checklist rows', () => {
   assert.equal(validatePrBody(fixture('optional-unchecked.md')).ok, true);
 });
 
+test('passes optional non-blocking gap checkbox rows', () => {
+  assert.equal(validatePrBody(fixture('non-blocking-gap-optional.md')).ok, true);
+});
+
 test('fails docs choice group when no option is checked', () => {
   const result = validatePrBody(fixture('docs-choice-none.md'));
   assert.equal(result.ok, false);

--- a/scripts/check-pr-template-checkboxes.test.mjs
+++ b/scripts/check-pr-template-checkboxes.test.mjs
@@ -31,6 +31,23 @@ test('passes optional non-blocking gap checkbox rows', () => {
   assert.equal(validatePrBody(fixture('non-blocking-gap-optional.md')).ok, true);
 });
 
+test('passes ⚠️ matrix cell satisfied by Non-blocking gap prose', () => {
+  assert.equal(validatePrBody(fixture('non-blocking-gap-prose.md')).ok, true);
+});
+
+test('passes ⚠️ matrix cell satisfied by optional Non-blocking gap checkbox', () => {
+  assert.equal(
+    validatePrBody(fixture('non-blocking-gap-optional-with-warning.md')).ok,
+    true,
+  );
+});
+
+test('fails Non-blocking gap checkbox missing the optional marker', () => {
+  const result = validatePrBody(fixture('non-blocking-gap-required.md'));
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join('\n'), /Non-blocking gap rows must be marked optional/i);
+});
+
 test('fails docs choice group when no option is checked', () => {
   const result = validatePrBody(fixture('docs-choice-none.md'));
   assert.equal(result.ok, false);

--- a/scripts/fixtures/pr-template-checkboxes/non-blocking-gap-optional-with-warning.md
+++ b/scripts/fixtures/pr-template-checkboxes/non-blocking-gap-optional-with-warning.md
@@ -1,0 +1,21 @@
+## Test coverage
+
+| AC | Title | Unit | Linux |
+| --- | --- | --- | --- |
+| AC-87-4 | Non-blocking gap | ➖ | ⚠️ |
+
+## Acceptance criteria
+
+### AC-87-4
+
+Chrome validation is enough to merge; Safari is a known non-blocking gap.
+
+<!-- pr-checkbox: optional -->
+- [ ] ⚠️ Non-blocking gap: Safari persistence was not verified.
+
+## Docs updated
+
+<!-- pr-checkbox-choice: docs-updated exactly-one -->
+- [x] Not needed
+<!-- pr-checkbox-choice: docs-updated exactly-one -->
+- [ ] Updated in this PR

--- a/scripts/fixtures/pr-template-checkboxes/non-blocking-gap-optional.md
+++ b/scripts/fixtures/pr-template-checkboxes/non-blocking-gap-optional.md
@@ -1,0 +1,8 @@
+## Acceptance criteria
+
+### AC-87-4
+
+Chrome validation is enough to merge; Safari is a known non-blocking gap.
+
+<!-- pr-checkbox: optional -->
+- [ ] ⚠️ Non-blocking gap: Safari persistence was not verified.

--- a/scripts/fixtures/pr-template-checkboxes/non-blocking-gap-prose.md
+++ b/scripts/fixtures/pr-template-checkboxes/non-blocking-gap-prose.md
@@ -1,0 +1,20 @@
+## Test coverage
+
+| AC | Title | Unit | Linux |
+| --- | --- | --- | --- |
+| AC-87-4 | Non-blocking gap | ➖ | ⚠️ |
+
+## Acceptance criteria
+
+### AC-87-4
+
+Chrome validation is enough to merge; Safari is a known non-blocking gap.
+
+Non-blocking gap: Safari persistence was not verified.
+
+## Docs updated
+
+<!-- pr-checkbox-choice: docs-updated exactly-one -->
+- [x] Not needed
+<!-- pr-checkbox-choice: docs-updated exactly-one -->
+- [ ] Updated in this PR

--- a/scripts/fixtures/pr-template-checkboxes/non-blocking-gap-required.md
+++ b/scripts/fixtures/pr-template-checkboxes/non-blocking-gap-required.md
@@ -1,0 +1,20 @@
+## Test coverage
+
+| AC | Title | Unit | Linux |
+| --- | --- | --- | --- |
+| AC-87-4 | Non-blocking gap missing optional marker | ➖ | ⚠️ |
+
+## Acceptance criteria
+
+### AC-87-4
+
+Author forgot the optional marker so the row is treated as required.
+
+- [ ] ⚠️ Non-blocking gap: Safari persistence was not verified.
+
+## Docs updated
+
+<!-- pr-checkbox-choice: docs-updated exactly-one -->
+- [x] Not needed
+<!-- pr-checkbox-choice: docs-updated exactly-one -->
+- [ ] Updated in this PR

--- a/skills/bootstrap/templates/core/.github/pull_request_template.md
+++ b/skills/bootstrap/templates/core/.github/pull_request_template.md
@@ -54,19 +54,21 @@
   summarized in the AC section without a matrix row, but every relevant AC
   still needs an AC heading. Each cell summarizes the required-validation state
   for that AC and column. Use only these symbols in status cells:
-  ✅ = required validation passed, with no blocking gap for this column
-  ❌ = tests that should exist are missing
-  ⚠️ = required validation has an acknowledged gap, warning, unresolved
-       concern, or failing/pending state that needs reviewer attention
+  ✅ = required validation passed, with no known relevant gap for this column
+  ⚠️ = validation exists and is sufficient to merge, with a known non-blocking
+       gap documented under this AC
+  ❌ = required validation is missing, failing, pending, or blocked by a
+       merge-blocking gap
   ➖ = not relevant to this AC
 
   Use `➖` only when that verification type is not relevant to the AC. If an AC
-  includes evidence, a test gap, or an operator check that clearly maps to a
-  matrix column, that cell must not be `➖`. Every `⚠️` matrix cell must have
-  one or more corresponding `⚠️ Test gap:` checkboxes under that AC. If required
-  validation is failing, pending, blocked by an unresolved concern, or otherwise
-  cannot yet be trusted, use `⚠️` and add a test-gap checkbox until that
-  validation passes.
+  includes evidence, a gap, or an operator check that clearly maps to a matrix
+  column, that cell must not be `➖`. If a known non-blocking gap remains after
+  sufficient validation, use `⚠️` and document the gap under the AC in prose or
+  with an explicitly optional checkbox. If required validation is missing,
+  failing, pending, blocked by an unresolved concern, or otherwise cannot yet
+  be trusted for merge, use `❌` and add a required gap or operator-check
+  checkbox when pre-merge action is needed.
 -->
 | AC | Title | Unit | <Platform> |
 | --- | --- | --- | --- |
@@ -87,33 +89,37 @@ including unresolved blockers or pending validation when present.
 
 <!--
   For each supported platform that is relevant to this AC, include one evidence
-  row, summarize missing tests in the outcome, or report an acknowledged
-  validation gap as a test-gap checkbox. Keep evidence rows compact and use a
-  colon after the evidence label:
+  row, summarize missing tests in the outcome, or document a known gap below.
+  Keep evidence rows compact and use a colon after the evidence label:
   `<Platform> test: <command, workflow job, tool, or harness>, <environment>[, <link, verifier, or ISO>]`.
   Name the concrete command, workflow job, tool, or harness when known. Use a
   neutral verifier value, such as a person, role, or run identifier. Add a unit
   evidence row only when unit evidence is the meaningful validation for this AC;
   otherwise keep unit details in the matrix or CI summary.
   If an unresolved critical or major review finding affects validation for this
-  AC, describe the missing observable behavior or validation as a test-gap
+  AC, describe the missing observable behavior or validation as a required gap
   checkbox unless it belongs in Do before merging.
 -->
 - <Platform> test: <command, workflow job, tool, or harness>, <environment>[, <link, verifier, or ISO>]
 <!--
-  Include every known Test gap that the operator must consciously review. Use
-  `Test gap:` to describe an acknowledged coverage gap or an unresolved
-  validation concern, not to restate a code-review finding, duplicate an
-  operator action, or explain tests that should exist but are missing. Test gaps
-  must be about observable behavior or validation that cannot yet be trusted.
-  Treat CI that must rerun after a fix as a test gap unless the operator must
-  manually trigger or inspect a specific job. Delete unused placeholder checkbox
-  rows.
-  Every `⚠️ Test gap:` that maps to a matrix column must have a corresponding
-  `⚠️` cell in that AC's matrix row.
-  Example: - [ ] ⚠️ Test gap: <observable behavior or validation not verified>
+  Include every known blocking gap that the operator must consciously review
+  or resolve before merge. Use `Test gap:` to describe missing coverage or an
+  unresolved validation concern that keeps the matrix cell at `❌`. Do not use
+  required unchecked `Test gap:` rows for non-blocking caveats. Treat CI that
+  must rerun after a fix as a required test gap unless the operator must
+  manually trigger or inspect a specific job. Delete unused placeholder
+  checkbox rows.
+  Example: - [ ] ⚠️ Test gap: <blocking observable behavior or validation not verified>
 -->
-- [ ] ⚠️ Test gap: <observable behavior, missing coverage, or unresolved validation concern>
+- [ ] ⚠️ Test gap: <blocking observable behavior, missing coverage, or unresolved validation concern>
+<!--
+  For a non-blocking gap represented by a `⚠️` matrix cell, use prose or an
+  explicitly optional checkbox. Optional checkboxes must include
+  `pr-checkbox: optional` immediately above the row. For example, write prose
+  like `Non-blocking gap: <known caveat accepted for this PR>.` Or, when a
+  visible acknowledgement row is useful, put `pr-checkbox: optional` in an
+  HTML comment immediately above an unchecked `⚠️ Non-blocking gap:` checkbox.
+-->
 <!--
   Include every known operator action below any test-gap checkboxes for this
   AC. Use the literal prefix `Operator check:` for product testing, diff

--- a/skills/bootstrap/templates/core/scripts/check-pr-template-checkboxes.mjs
+++ b/skills/bootstrap/templates/core/scripts/check-pr-template-checkboxes.mjs
@@ -12,8 +12,10 @@ const COMMENT_START = /^\s*<!--/;
 const COMMENT_END = /-->\s*$/;
 const AC_HEADING = /^AC-\d+-\d+\b/;
 const TEST_GAP = /^⚠️\s*Test gap:\s*(.+)$/i;
+const NON_BLOCKING_GAP = /^⚠️\s*Non-blocking gap:\s*(.+)$/i;
 const OPERATOR_CHECK = /^Operator check:/i;
 const PROSE_GAP = /^\s*(?:[-*]\s*)?Blocking validation gap:/i;
+const NON_BLOCKING_PROSE = /^\s*(?:[-*]\s*)?Non-blocking gap:/i;
 
 function ensureAc(acMap, acId, section, lineNumber) {
   const entry = acMap.get(acId) ?? {
@@ -21,6 +23,7 @@ function ensureAc(acMap, acId, section, lineNumber) {
     lineNumber,
     hasWarning: false,
     testGaps: [],
+    nonBlockingGaps: 0,
   };
   if (section) entry.section = section;
   if (lineNumber && !entry.lineNumber) entry.lineNumber = lineNumber;
@@ -95,6 +98,11 @@ export function validatePrBody(body) {
       continue;
     }
 
+    if (NON_BLOCKING_PROSE.test(line) && activeAc) {
+      ensureAc(acs, activeAc, section, lineNumber).nonBlockingGaps += 1;
+      continue;
+    }
+
     const checkbox = line.match(CHECKBOX);
     if (!checkbox) continue;
 
@@ -106,6 +114,18 @@ export function validatePrBody(body) {
     if (PROSE_GAP.test(text)) {
       errors.push(
         `line ${lineNumber}: ${section}: use canonical ⚠️ Test gap checkbox instead of prose: ${text}`,
+      );
+      continue;
+    }
+
+    const nonBlockingGap = text.match(NON_BLOCKING_GAP);
+    if (nonBlockingGap) {
+      const acId = activeAc ?? section;
+      const ac = ensureAc(acs, acId, section, lineNumber);
+      ac.nonBlockingGaps += 1;
+      if (marker.kind === 'optional') continue;
+      errors.push(
+        `line ${lineNumber}: ${section}: ⚠️ Non-blocking gap rows must be marked optional with \`<!-- pr-checkbox: optional -->\` immediately above: ${text}`,
       );
       continue;
     }
@@ -157,9 +177,9 @@ export function validatePrBody(body) {
   }
 
   for (const [acId, ac] of acs.entries()) {
-    if (ac.hasWarning && ac.testGaps.length === 0) {
+    if (ac.hasWarning && ac.testGaps.length === 0 && ac.nonBlockingGaps === 0) {
       errors.push(
-        `line ${ac.lineNumber}: ${acId}: missing ⚠️ Test gap for warning matrix cell`,
+        `line ${ac.lineNumber}: ${acId}: missing ⚠️ Test gap or Non-blocking gap explanation for warning matrix cell`,
       );
     }
   }

--- a/skills/bootstrap/templates/core/scripts/check-pr-template-checkboxes.test.mjs
+++ b/skills/bootstrap/templates/core/scripts/check-pr-template-checkboxes.test.mjs
@@ -27,6 +27,27 @@ test('passes explicitly optional unchecked checklist rows', () => {
   assert.equal(validatePrBody(fixture('optional-unchecked.md')).ok, true);
 });
 
+test('passes optional non-blocking gap checkbox rows', () => {
+  assert.equal(validatePrBody(fixture('non-blocking-gap-optional.md')).ok, true);
+});
+
+test('passes ⚠️ matrix cell satisfied by Non-blocking gap prose', () => {
+  assert.equal(validatePrBody(fixture('non-blocking-gap-prose.md')).ok, true);
+});
+
+test('passes ⚠️ matrix cell satisfied by optional Non-blocking gap checkbox', () => {
+  assert.equal(
+    validatePrBody(fixture('non-blocking-gap-optional-with-warning.md')).ok,
+    true,
+  );
+});
+
+test('fails Non-blocking gap checkbox missing the optional marker', () => {
+  const result = validatePrBody(fixture('non-blocking-gap-required.md'));
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join('\n'), /Non-blocking gap rows must be marked optional/i);
+});
+
 test('fails docs choice group when no option is checked', () => {
   const result = validatePrBody(fixture('docs-choice-none.md'));
   assert.equal(result.ok, false);

--- a/skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/non-blocking-gap-optional-with-warning.md
+++ b/skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/non-blocking-gap-optional-with-warning.md
@@ -1,0 +1,21 @@
+## Test coverage
+
+| AC | Title | Unit | Linux |
+| --- | --- | --- | --- |
+| AC-87-4 | Non-blocking gap | ➖ | ⚠️ |
+
+## Acceptance criteria
+
+### AC-87-4
+
+Chrome validation is enough to merge; Safari is a known non-blocking gap.
+
+<!-- pr-checkbox: optional -->
+- [ ] ⚠️ Non-blocking gap: Safari persistence was not verified.
+
+## Docs updated
+
+<!-- pr-checkbox-choice: docs-updated exactly-one -->
+- [x] Not needed
+<!-- pr-checkbox-choice: docs-updated exactly-one -->
+- [ ] Updated in this PR

--- a/skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/non-blocking-gap-optional.md
+++ b/skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/non-blocking-gap-optional.md
@@ -1,0 +1,8 @@
+## Acceptance criteria
+
+### AC-87-4
+
+Chrome validation is enough to merge; Safari is a known non-blocking gap.
+
+<!-- pr-checkbox: optional -->
+- [ ] ⚠️ Non-blocking gap: Safari persistence was not verified.

--- a/skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/non-blocking-gap-prose.md
+++ b/skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/non-blocking-gap-prose.md
@@ -1,0 +1,20 @@
+## Test coverage
+
+| AC | Title | Unit | Linux |
+| --- | --- | --- | --- |
+| AC-87-4 | Non-blocking gap | ➖ | ⚠️ |
+
+## Acceptance criteria
+
+### AC-87-4
+
+Chrome validation is enough to merge; Safari is a known non-blocking gap.
+
+Non-blocking gap: Safari persistence was not verified.
+
+## Docs updated
+
+<!-- pr-checkbox-choice: docs-updated exactly-one -->
+- [x] Not needed
+<!-- pr-checkbox-choice: docs-updated exactly-one -->
+- [ ] Updated in this PR

--- a/skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/non-blocking-gap-required.md
+++ b/skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/non-blocking-gap-required.md
@@ -1,0 +1,20 @@
+## Test coverage
+
+| AC | Title | Unit | Linux |
+| --- | --- | --- | --- |
+| AC-87-4 | Non-blocking gap missing optional marker | ➖ | ⚠️ |
+
+## Acceptance criteria
+
+### AC-87-4
+
+Author forgot the optional marker so the row is treated as required.
+
+- [ ] ⚠️ Non-blocking gap: Safari persistence was not verified.
+
+## Docs updated
+
+<!-- pr-checkbox-choice: docs-updated exactly-one -->
+- [x] Not needed
+<!-- pr-checkbox-choice: docs-updated exactly-one -->
+- [ ] Updated in this PR


### PR DESCRIPTION
## Linked issue

Closes #87

## What changed

- Clarified PR coverage matrix symbols so `⚠️` means validated enough to merge with a known non-blocking gap, while missing/failing/pending/blocking validation uses `❌`.
- Updated per-AC guidance so non-blocking gaps are documented with prose or explicitly optional checkboxes instead of required unchecked merge gates.
- Mirrored the canonical bootstrap PR template to the root template and aligned AC traceability guidance.
- Reconciled the PR readiness checker (merged in from #89 via main) so it honors AC-87-4: `Non-blocking gap:` prose under an AC, and `⚠️ Non-blocking gap:` checkboxes wrapped in `pr-checkbox: optional`, both satisfy a `⚠️` matrix cell without blocking merge.
- A `⚠️ Non-blocking gap:` checkbox that omits the optional marker still fails so non-blocking acknowledgements cannot silently bypass the required-checkbox gate.

## Test coverage

| AC | Title | Unit |
| --- | --- | --- |
| AC-87-1 | Non-blocking gaps use warning state | ➖ |
| AC-87-2 | Blocking validation uses failure state | ➖ |
| AC-87-3 | Warning details avoid required gates | ➖ |
| AC-87-4 | Optional/prose gaps do not block | ✅ |

## Acceptance criteria

### AC-87-1

The PR template legend now tells authors to use `⚠️` when validation exists and is sufficient to merge, with a known non-blocking gap documented under the AC.

- Template check: `rg -n 'validation exists and is sufficient to merge|known non-blocking gap' .github/pull_request_template.md skills/bootstrap/templates/core/.github/pull_request_template.md`, local, passed
- Template parity: `diff -u skills/bootstrap/templates/core/.github/pull_request_template.md .github/pull_request_template.md`, local, no output

### AC-87-2

The PR template legend now tells authors to use `❌` when required validation is missing, failing, pending, or blocked by a merge-blocking gap.

- Template check: `rg -n 'required validation is missing, failing, pending|merge-blocking gap' .github/pull_request_template.md skills/bootstrap/templates/core/.github/pull_request_template.md`, local, passed
- Stale wording check: `rg -n 'failing/pending state|tests that should exist are missing' .github/pull_request_template.md skills/bootstrap/templates/core/.github/pull_request_template.md docs/ac-traceability.md`, local, no matches

### AC-87-3

The AC guidance now says a `⚠️` matrix cell should be documented in prose or with an explicitly optional checkbox, not a required unchecked merge gate.

- Template check: `rg -n 'prose or an explicitly optional checkbox|Do not use required unchecked .*non-blocking caveats' .github/pull_request_template.md skills/bootstrap/templates/core/.github/pull_request_template.md`, local, passed
- Reverse-mapping check: targeted `rg` scan for stale matrix/gap reverse-mapping wording, local, no matches

### AC-87-4

The checkbox checker still blocks unmarked visible unchecked checkboxes, while explicitly optional non-blocking gap checkboxes and `Non-blocking gap:` prose pass without blocking merge.

- Unit test: `node --test scripts/check-pr-template-checkboxes.test.mjs`, local, 20/20 passed (covers prose, optional checkbox, and missing-optional-marker failure)
- Mirror parity: `diff -ru scripts skills/bootstrap/templates/core/scripts`, local, no output
- Real-template smoke: `node scripts/check-pr-template-checkboxes.mjs .github/pull_request_template.md`, local, passed
- Markdown lint: `pnpm lint:md`, local, 140 files linted with 0 errors
