### PR TITLE
fix: #86 restore honest PR validation gaps

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -106,6 +106,10 @@ including unresolved blockers or pending validation when present.
   validation concern, not to restate a code-review finding, duplicate an
   operator action, or explain tests that should exist but are missing. Test gaps
   must be about observable behavior or validation that cannot yet be trusted.
+  Test-gap checkboxes are intentionally unchecked while unresolved. Do not
+  convert a real gap to prose or mark it optional to satisfy PR validation; the
+  readiness check reports unresolved validation gaps separately from operator
+  action checkboxes.
   Treat CI that must rerun after a fix as a test gap unless the operator must
   manually trigger or inspect a specific job. Delete unused placeholder checkbox
   rows.
@@ -127,10 +131,12 @@ including unresolved blockers or pending validation when present.
   the operator can validate. Keep manual product or workflow validation as an
   operator check when a human must exercise observable behavior after a gap is
   fixed. Do not add CI-rerun operator checks unless the operator must manually
-  trigger or inspect a specific job. When updating an existing PR body,
-  preserve every existing manual-review or manual-test instruction under its AC
-  in this checkbox form. Phrase checkbox text in imperative style. Delete
-  unused placeholder checkbox rows.
+  trigger or inspect a specific job. Operator-check checkboxes are completion
+  tasks. Unchecked operator checks remain readiness blockers unless explicitly
+  optional. When updating an existing PR body, preserve every existing
+  manual-review or manual-test instruction under its AC in this checkbox form.
+  Phrase checkbox text in imperative style. Delete unused placeholder checkbox
+  rows.
 -->
 - [ ] Operator check: <imperative operator action and expected decision or result>
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -84,7 +84,7 @@ jobs:
         # actions/checkout@v4.3.1
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
-      - name: Validate required template checkboxes
+      - name: Validate PR readiness gaps
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: node scripts/check-pr-template-checkboxes.mjs

--- a/docs/superpowers/plans/2026-05-03-86-revert-pr-checkbox-validation-behavior-that-hides-blocking-test-gaps-plan.md
+++ b/docs/superpowers/plans/2026-05-03-86-revert-pr-checkbox-validation-behavior-that-hides-blocking-test-gaps-plan.md
@@ -23,6 +23,7 @@
 ## Task 1: RED Fixtures For The Current Conflict
 
 **Files:**
+
 - Add: `skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/test-gap-unchecked.md`
 - Add: `scripts/fixtures/pr-template-checkboxes/test-gap-unchecked.md`
 - Add: `skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/test-gap-prose-workaround.md`
@@ -118,6 +119,7 @@ Expected: FAIL for the same reasons as the root tests.
 ## Task 2: Semantic Validator Implementation
 
 **Files:**
+
 - Modify: `skills/bootstrap/templates/core/scripts/check-pr-template-checkboxes.mjs`
 - Modify: `scripts/check-pr-template-checkboxes.mjs`
 - Modify: `skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/e2e-gap-unchecked.md`
@@ -206,6 +208,7 @@ Expected: PASS.
 ## Task 3: PR Template Wording
 
 **Files:**
+
 - Modify: `skills/bootstrap/templates/core/.github/pull_request_template.md`
 - Modify: `.github/pull_request_template.md`
 
@@ -242,6 +245,7 @@ Expected: `ok`.
 ## Task 4: Guidance And Search Verification
 
 **Files:**
+
 - Modify only if needed: `docs/ac-traceability.md`
 - Modify only if needed: `AGENTS.md`
 - Modify only if needed: `skills/bootstrap/templates/core/AGENTS.md.tmpl`
@@ -275,6 +279,7 @@ Expected: no output, or only intentional repository-local differences already do
 ## Task 5: Final Verification And Commit
 
 **Files:**
+
 - All changed files from Tasks 1-4.
 
 - [ ] **Step 1: Run root validator tests**

--- a/docs/superpowers/plans/2026-05-03-86-revert-pr-checkbox-validation-behavior-that-hides-blocking-test-gaps-plan.md
+++ b/docs/superpowers/plans/2026-05-03-86-revert-pr-checkbox-validation-behavior-that-hides-blocking-test-gaps-plan.md
@@ -1,0 +1,331 @@
+# Revert PR Checkbox Validation Behavior That Hides Blocking Test Gaps Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace broad PR checkbox failure messages with semantic readiness validation so canonical `⚠️ Test gap:` rows remain honest blockers and prose workarounds do not pass.
+
+**Architecture:** Keep the existing local Node validator and workflow step, but make `validatePrBody()` classify AC sections, matrix warning cells, test-gap rows, operator checks, explicit checkbox markers, and choice groups. Template copies remain source-of-truth first, then mirrored root files are updated to match.
+
+**Tech Stack:** Node.js ESM, `node:test`, Markdown PR-body parsing with local regexes, bootstrap template mirroring by direct parity.
+
+---
+
+## File Structure
+
+- Modify `skills/bootstrap/templates/core/scripts/check-pr-template-checkboxes.mjs`: add semantic classification for `⚠️ Test gap:` rows and matrix `⚠️` cells.
+- Modify `skills/bootstrap/templates/core/scripts/check-pr-template-checkboxes.test.mjs`: add RED/GREEN fixtures and expectations.
+- Add `skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/test-gap-unchecked.md`: canonical unresolved gap fixture.
+- Add `skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/test-gap-prose-workaround.md`: prose bypass fixture.
+- Modify `skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/e2e-gap-unchecked.md`: update legacy `E2E gap:` wording to canonical `⚠️ Test gap:`.
+- Modify `skills/bootstrap/templates/core/.github/pull_request_template.md`: clarify that test-gap checkboxes remain unchecked while unresolved and are readiness gaps, not generic required checkbox tasks.
+- Mirror every changed template file to its root counterpart under `scripts/`, `.github/`, and `package.json` only if package scripts change.
+
+## Task 1: RED Fixtures For The Current Conflict
+
+**Files:**
+- Add: `skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/test-gap-unchecked.md`
+- Add: `scripts/fixtures/pr-template-checkboxes/test-gap-unchecked.md`
+- Add: `skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/test-gap-prose-workaround.md`
+- Add: `scripts/fixtures/pr-template-checkboxes/test-gap-prose-workaround.md`
+- Modify: `skills/bootstrap/templates/core/scripts/check-pr-template-checkboxes.test.mjs`
+- Modify: `scripts/check-pr-template-checkboxes.test.mjs`
+
+- [ ] **Step 1: Add canonical unresolved test-gap fixture**
+
+Create the same fixture at both template and root paths:
+
+```md
+## Test coverage
+
+| AC | Title | Unit | Linux |
+| --- | --- | --- | --- |
+| AC-86-1 | Canonical unresolved gap | ➖ | ⚠️ |
+
+## Acceptance criteria
+
+### AC-86-1
+
+Canonical unresolved test gap should fail with a gap-specific readiness message.
+
+- [ ] ⚠️ Test gap: Linux validation has not rerun after the validator fix.
+
+## Docs updated
+
+<!-- pr-checkbox-choice: docs-updated exactly-one -->
+- [x] Not needed
+<!-- pr-checkbox-choice: docs-updated exactly-one -->
+- [ ] Updated in this PR
+```
+
+- [ ] **Step 2: Add prose-workaround fixture**
+
+Create the same fixture at both template and root paths:
+
+```md
+## Test coverage
+
+| AC | Title | Unit | Linux |
+| --- | --- | --- | --- |
+| AC-86-1 | Prose workaround | ➖ | ⚠️ |
+
+## Acceptance criteria
+
+### AC-86-1
+
+Blocking validation gap: Linux validation has not rerun after the validator fix.
+
+## Docs updated
+
+<!-- pr-checkbox-choice: docs-updated exactly-one -->
+- [x] Not needed
+<!-- pr-checkbox-choice: docs-updated exactly-one -->
+- [ ] Updated in this PR
+```
+
+- [ ] **Step 3: Add failing RED expectations**
+
+Add these tests to both template and root test files:
+
+```js
+test('fails canonical unresolved test gaps with gap-specific text', () => {
+  const result = validatePrBody(fixture('test-gap-unchecked.md'));
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join('\n'), /unresolved validation gap/i);
+  assert.match(result.errors.join('\n'), /Linux validation has not rerun/);
+  assert.doesNotMatch(result.errors.join('\n'), /required checklist item is unchecked/i);
+});
+
+test('fails prose workaround when matrix warning lacks canonical test gap', () => {
+  const result = validatePrBody(fixture('test-gap-prose-workaround.md'));
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join('\n'), /missing .*Test gap/i);
+  assert.match(result.errors.join('\n'), /AC-86-1/);
+});
+```
+
+- [ ] **Step 4: Run root RED tests**
+
+Run: `node --test scripts/check-pr-template-checkboxes.test.mjs`
+
+Expected: FAIL. The canonical test-gap fixture still reports `required checklist item is unchecked`, and the prose-workaround fixture currently passes.
+
+- [ ] **Step 5: Run template RED tests**
+
+Run: `node --test skills/bootstrap/templates/core/scripts/check-pr-template-checkboxes.test.mjs`
+
+Expected: FAIL for the same reasons as the root tests.
+
+## Task 2: Semantic Validator Implementation
+
+**Files:**
+- Modify: `skills/bootstrap/templates/core/scripts/check-pr-template-checkboxes.mjs`
+- Modify: `scripts/check-pr-template-checkboxes.mjs`
+- Modify: `skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/e2e-gap-unchecked.md`
+- Modify: `scripts/fixtures/pr-template-checkboxes/e2e-gap-unchecked.md`
+- Modify: `skills/bootstrap/templates/core/scripts/check-pr-template-checkboxes.test.mjs`
+- Modify: `scripts/check-pr-template-checkboxes.test.mjs`
+
+- [ ] **Step 1: Replace validator logic in template script**
+
+Replace `validatePrBody()` in `skills/bootstrap/templates/core/scripts/check-pr-template-checkboxes.mjs` with logic equivalent to this shape:
+
+```js
+const AC_HEADING = /^AC-\d+-\d+\b/;
+const TEST_GAP = /^⚠️\s*Test gap:/i;
+const OPERATOR_CHECK = /^Operator check:/i;
+const WARNING_CELL = /(^|\|)\s*⚠️\s*(\||$)/;
+
+function ensureAc(acMap, acId, section) {
+  const entry = acMap.get(acId) ?? {
+    section,
+    hasWarning: false,
+    testGaps: [],
+  };
+  if (section) entry.section = section;
+  acMap.set(acId, entry);
+  return entry;
+}
+
+function readMatrixAc(line) {
+  if (!line.trim().startsWith('|')) return null;
+  const cells = line
+    .split('|')
+    .slice(1, -1)
+    .map((cell) => cell.trim());
+  const acId = cells[0];
+  if (!AC_HEADING.test(acId)) return null;
+  return { acId, hasWarning: cells.slice(2).some((cell) => cell === '⚠️') || WARNING_CELL.test(line) };
+}
+```
+
+Keep the existing marker, choice-group, comment, checkbox, CLI, and GitHub error plumbing. When an unchecked checkbox text starts with `⚠️ Test gap:`, push `line N: AC-X-Y: unresolved validation gap: <text after prefix>` instead of the generic required-checkbox message. Record that gap under the active AC. When a checked or unchecked operator check is seen, keep required checkbox semantics unless explicitly optional. At the end, fail every AC with a matrix warning and no recorded canonical test gap with `line N: AC-X-Y: missing ⚠️ Test gap for warning matrix cell`.
+
+- [ ] **Step 2: Mirror validator logic to root script**
+
+Copy the completed template script to `scripts/check-pr-template-checkboxes.mjs`.
+
+- [ ] **Step 3: Update legacy E2E fixture wording**
+
+In both E2E fixtures, change:
+
+```md
+- [ ] E2E gap: browser behavior not covered by automation
+```
+
+to:
+
+```md
+- [ ] ⚠️ Test gap: browser behavior not covered by automation
+```
+
+- [ ] **Step 4: Update legacy E2E test expectation**
+
+In both test files, change the E2E test name and assertion to:
+
+```js
+test('fails included test gap while unchecked with gap-specific text', () => {
+  const result = validatePrBody(fixture('e2e-gap-unchecked.md'));
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join('\n'), /unresolved validation gap/i);
+  assert.match(result.errors.join('\n'), /browser behavior not covered/);
+});
+```
+
+- [ ] **Step 5: Run GREEN validator tests**
+
+Run: `node --test scripts/check-pr-template-checkboxes.test.mjs`
+
+Expected: PASS.
+
+- [ ] **Step 6: Run template validator tests**
+
+Run: `node --test skills/bootstrap/templates/core/scripts/check-pr-template-checkboxes.test.mjs`
+
+Expected: PASS.
+
+## Task 3: PR Template Wording
+
+**Files:**
+- Modify: `skills/bootstrap/templates/core/.github/pull_request_template.md`
+- Modify: `.github/pull_request_template.md`
+
+- [ ] **Step 1: Clarify test-gap semantics in template source**
+
+In the `⚠️ Test gap:` comment of `skills/bootstrap/templates/core/.github/pull_request_template.md`, add this compact wording:
+
+```md
+  Test-gap checkboxes are intentionally unchecked while unresolved. Do not
+  convert a real gap to prose or mark it optional to satisfy PR validation; the
+  readiness check reports unresolved validation gaps separately from operator
+  action checkboxes.
+```
+
+- [ ] **Step 2: Clarify operator-check semantics in template source**
+
+In the `Operator check:` comment, add this compact wording:
+
+```md
+  Operator-check checkboxes are completion tasks. Unchecked operator checks
+  remain readiness blockers unless explicitly optional.
+```
+
+- [ ] **Step 3: Mirror template to root**
+
+Copy the changed template PR template to `.github/pull_request_template.md`.
+
+- [ ] **Step 4: Verify template parity**
+
+Run: `cmp -s skills/bootstrap/templates/core/.github/pull_request_template.md .github/pull_request_template.md && echo ok`
+
+Expected: `ok`.
+
+## Task 4: Guidance And Search Verification
+
+**Files:**
+- Modify only if needed: `docs/ac-traceability.md`
+- Modify only if needed: `AGENTS.md`
+- Modify only if needed: `skills/bootstrap/templates/core/AGENTS.md.tmpl`
+
+- [ ] **Step 1: Search for stale broad-checkbox claims**
+
+Run: `rg -n 'every visible unchecked checkbox|unchecked visible checkbox|required template checkbox|Required template checkboxes|pr-checkbox|Test gap' AGENTS.md docs/ac-traceability.md .github/pull_request_template.md skills/bootstrap/templates/core/AGENTS.md.tmpl skills/bootstrap/templates/core/.github/pull_request_template.md scripts skills/bootstrap/templates/core/scripts`
+
+Expected: Any remaining broad checkbox wording is either removed or narrowed to semantic readiness, operator checks, explicit required markers, or test-gap readiness messages.
+
+- [ ] **Step 2: Patch stale guidance only where the search shows contradictions**
+
+If `docs/ac-traceability.md`, `AGENTS.md`, or `skills/bootstrap/templates/core/AGENTS.md.tmpl` still says unchecked test-gap checkboxes are ordinary required checkboxes, replace that wording with:
+
+```md
+Canonical `⚠️ Test gap:` rows stay unchecked while unresolved and are treated
+as validation-gap readiness blockers. `Operator check:` rows are completion
+checkboxes and remain unchecked until the named operator action is done.
+```
+
+- [ ] **Step 3: Verify mirrored AGENTS guidance if edited**
+
+If `AGENTS.md` or `skills/bootstrap/templates/core/AGENTS.md.tmpl` changed, run:
+
+```bash
+diff -u skills/bootstrap/templates/core/AGENTS.md.tmpl AGENTS.md
+```
+
+Expected: no output, or only intentional repository-local differences already documented by this repo.
+
+## Task 5: Final Verification And Commit
+
+**Files:**
+- All changed files from Tasks 1-4.
+
+- [ ] **Step 1: Run root validator tests**
+
+Run: `node --test scripts/check-pr-template-checkboxes.test.mjs`
+
+Expected: PASS.
+
+- [ ] **Step 2: Run template validator tests**
+
+Run: `node --test skills/bootstrap/templates/core/scripts/check-pr-template-checkboxes.test.mjs`
+
+Expected: PASS.
+
+- [ ] **Step 3: Verify script parity**
+
+Run:
+
+```bash
+cmp -s skills/bootstrap/templates/core/scripts/check-pr-template-checkboxes.mjs scripts/check-pr-template-checkboxes.mjs && echo script-ok
+cmp -s skills/bootstrap/templates/core/scripts/check-pr-template-checkboxes.test.mjs scripts/check-pr-template-checkboxes.test.mjs && echo test-ok
+diff -ru skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes scripts/fixtures/pr-template-checkboxes
+```
+
+Expected: `script-ok`, `test-ok`, and no fixture diff.
+
+- [ ] **Step 4: Run Markdown lint**
+
+Run: `pnpm lint:md`
+
+Expected: PASS. If dependencies are missing, run `pnpm install` once and rerun.
+
+- [ ] **Step 5: Run workflow lint if available**
+
+Run: `pnpm exec actionlint .github/workflows/*.yml`
+
+Expected: PASS or report that `actionlint` is unavailable from installed project tooling.
+
+- [ ] **Step 6: Commit implementation**
+
+Run:
+
+```bash
+git add .github/pull_request_template.md scripts/check-pr-template-checkboxes.mjs scripts/check-pr-template-checkboxes.test.mjs scripts/fixtures/pr-template-checkboxes skills/bootstrap/templates/core/.github/pull_request_template.md skills/bootstrap/templates/core/scripts/check-pr-template-checkboxes.mjs skills/bootstrap/templates/core/scripts/check-pr-template-checkboxes.test.mjs skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes docs/superpowers/plans/2026-05-03-86-revert-pr-checkbox-validation-behavior-that-hides-blocking-test-gaps-plan.md
+git commit -m "fix: #86 restore honest PR validation gaps"
+```
+
+Expected: Commit succeeds. Include `docs/ac-traceability.md`, `AGENTS.md`, or `skills/bootstrap/templates/core/AGENTS.md.tmpl` in `git add` if Task 4 changed them.
+
+## Self-Review
+
+- Spec coverage: R1-R11 map to Tasks 1-4; AC-86-1 and AC-86-2 map to test-gap fixtures and semantic messages; AC-86-3 maps to retained operator-check behavior; AC-86-4 maps to parity checks.
+- Placeholder scan: no placeholder tasks remain; every code-changing step includes concrete snippets or exact commands.
+- Type consistency: the plan uses the existing `validatePrBody(body)` API and keeps the current CLI contract.

--- a/docs/superpowers/specs/2026-05-03-86-revert-pr-checkbox-validation-behavior-that-hides-blocking-test-gaps-design.md
+++ b/docs/superpowers/specs/2026-05-03-86-revert-pr-checkbox-validation-behavior-that-hides-blocking-test-gaps-design.md
@@ -22,7 +22,8 @@ blocking validation visible to reviewers and publish-state checks.
   Operator actions can still require explicit completion before merge.
 - R5: The broad required-checkbox validator must no longer fail canonical
   unchecked `⚠️ Test gap:` rows as though they were ordinary required operator
-  tasks.
+  tasks; unresolved gaps must be handled by a semantic readiness-gap contract
+  with gap-specific failure messages.
 - R6: If implementation keeps a checkbox validator, it must validate only
   checkboxes whose semantics are genuinely "must be checked before merge,"
   such as `Operator check:` rows or explicitly marked required operator rows.
@@ -38,16 +39,21 @@ blocking validation visible to reviewers and publish-state checks.
 - R10: The implementation must include GREEN verification that canonical test
   gaps no longer need prose workarounds, while any retained required
   operator-action checkbox behavior is covered by fixtures.
+- R11: A prose workaround such as `Blocking validation gap:` must not satisfy
+  readiness when the PR body otherwise indicates a warning, unresolved
+  validation concern, or pending/failing check.
 
 ## Acceptance Criteria
 
 - AC-86-1: Given a PR body contains a canonical unchecked `⚠️ Test gap:` row,
   when repository PR validation runs, then the row is preserved as the
-  canonical way to report the unresolved validation gap and is not converted
-  to prose to satisfy the checkbox gate.
+  canonical way to report the unresolved validation gap and any failure names
+  the unresolved validation gap instead of treating it as a generic required
+  checkbox.
 - AC-86-2: Given a PR body contains a real unresolved blocking validation gap,
-  when reviewers inspect PR readiness, then the PR remains visibly not ready
-  until the gap is resolved or explicitly deferred.
+  when reviewers inspect PR readiness or required PR-body validation runs, then
+  the PR remains visibly not ready until the gap is resolved or explicitly
+  deferred.
 - AC-86-3: Given a PR body contains an unchecked operator-action checkbox,
   when any retained checkbox validation runs, then that operator action still
   fails readiness unless it is explicitly optional.
@@ -58,21 +64,31 @@ blocking validation visible to reviewers and publish-state checks.
 ## Recommended Approach
 
 Replace broad "all visible unchecked checkboxes are required" validation with
-semantic validation:
+semantic readiness validation:
 
 1. Treat `⚠️ Test gap:` rows as readiness blockers that must stay visible in
-   the PR body while unresolved, not as checkbox tasks that agents should make
-   green by checking or rewriting.
-2. Retain checkbox enforcement only for operator-action checkboxes whose text
+   the PR body while unresolved. They may fail readiness, but the failure must
+   say the unresolved validation gap is blocking instead of saying a generic
+   required checkbox is unchecked.
+2. Reject prose workarounds when a PR body shows a warning state, pending or
+   failing validation, or a missing test-gap row where the template requires a
+   canonical `⚠️ Test gap:` checkbox.
+3. Retain checkbox enforcement only for operator-action checkboxes whose text
    starts with `Operator check:` or rows explicitly marked with a required
    operator checkbox marker.
-3. Update the PR template comments to state that test-gap checkboxes are
+4. Update the PR template comments to state that test-gap checkboxes are
    intentionally unchecked while unresolved and must not be rewritten as prose.
-4. Update `scripts/check-pr-template-checkboxes.mjs` and its template copy so
-   canonical `⚠️ Test gap:` rows are not reported by that gate.
-5. Add or update fixtures for:
+5. Replace or rename `check-pr-template-checkboxes` if needed so the check name
+   reflects semantic readiness rather than generic checkbox completion.
+6. Update `scripts/check-pr-template-checkboxes.mjs` and its template copy so
+   canonical `⚠️ Test gap:` rows are reported as unresolved validation gaps,
+   not as ordinary required checklist items.
+7. Add or update fixtures for:
    - current failing baseline: unchecked `⚠️ Test gap:` fails the old validator;
-   - green target: unchecked `⚠️ Test gap:` is accepted by the checkbox gate;
+   - green target: unchecked `⚠️ Test gap:` fails, when appropriate, with a
+     gap-specific readiness message rather than a generic checkbox message;
+   - prose workaround: `Blocking validation gap:` does not satisfy canonical
+     test-gap requirements when the matrix or AC summary indicates a warning;
    - retained failure: unchecked `Operator check:` remains a readiness failure;
    - optional checkbox and docs-choice behavior remains covered if retained.
 
@@ -85,15 +101,18 @@ introduced by #64.
 ### Recommended: Narrow the checkbox validator to operator-action semantics
 
 This removes the prose workaround incentive while preserving enforcement for
-the rows that are truly "must be checked before merge." It is the smallest
-behavioral change that addresses the conflict.
+the rows that are truly "must be checked before merge." It is acceptable only
+if a separate semantic readiness-gap rule blocks unresolved test gaps and
+rejects prose substitutes.
 
 ### Simpler: Remove the checkbox validator and workflow step entirely
 
 This fully reverts the misleading gate and is acceptable if implementation
 finds that the validator's remaining operator-action coverage is too coupled
 to the broken assumption. The cost is losing automated enforcement for real
-operator-action checkboxes unless another gate already covers them.
+operator-action checkboxes unless another gate already covers them. It also
+requires a replacement readiness-gap gate; otherwise this approach leaves the
+core issue unsolved.
 
 ### Rejected: Mark every test gap as optional
 
@@ -129,7 +148,10 @@ the same incentive in place.
 ## Verification
 
 - RED baseline: run the current validator against a fixture containing an
-  unchecked canonical `⚠️ Test gap:` and record that it fails.
+  unchecked canonical `⚠️ Test gap:` and record that it fails with the generic
+  required-checkbox message.
+- RED bypass baseline: run or inspect a fixture that rewrites the same gap as
+  prose and record that the current gate lets the prose workaround pass.
 - GREEN fixture tests: run `node --test scripts/check-pr-template-checkboxes.test.mjs`
   after the semantic change.
 - Template parity: compare each edited root file with its corresponding
@@ -164,8 +186,37 @@ misleading incentive.
 ### GREEN Obligation
 
 The green behavior is not "unchecked boxes never fail." The green behavior is
-that test gaps keep their honest unresolved representation while genuine
-operator-action checkboxes keep their completion semantics.
+that test gaps keep their honest unresolved representation, unresolved gaps
+still block readiness through a gap-specific contract, prose substitutes do
+not satisfy the PR body, and genuine operator-action checkboxes keep their
+completion semantics.
+
+### Role Ownership
+
+- Planner owns splitting implementation into separate tasks for readiness-gap
+  semantics, operator-action checkbox semantics, template wording, and
+  template/root parity.
+- Executor owns RED/GREEN fixtures for both the current conflict and the prose
+  workaround bypass before changing validation behavior.
+- Reviewer owns pressure-testing the changed PR-body contract for loopholes,
+  including matrix warning without test-gap detail, prose-only gap reporting,
+  and stale generic checkbox wording.
+- Finisher owns PR-body rendering and publish-state follow-through: an
+  unresolved `⚠️ Test gap:` is a blocker until resolved, explicitly deferred,
+  or represented by an intentionally still-red required check.
+
+### Stage-Gate Bypass Cases
+
+- A PR body with `⚠️` in the matrix but no matching `⚠️ Test gap:` row must not
+  pass readiness.
+- A prose-only `Blocking validation gap:` row must not replace the canonical
+  test-gap checkbox.
+- A checked or deleted test-gap row without replacement evidence must not be
+  treated as resolved.
+- A generic "required checkbox is unchecked" failure for a test-gap row is not
+  enough; the failure must teach that unresolved validation is the blocker.
+- Removing the checkbox validator without adding or preserving semantic gap
+  readiness is a failed implementation.
 
 ### Rationalization Resistance
 

--- a/docs/superpowers/specs/2026-05-03-86-revert-pr-checkbox-validation-behavior-that-hides-blocking-test-gaps-design.md
+++ b/docs/superpowers/specs/2026-05-03-86-revert-pr-checkbox-validation-behavior-that-hides-blocking-test-gaps-design.md
@@ -1,0 +1,206 @@
+# Design: Revert PR checkbox validation behavior that hides blocking test gaps [#86](https://github.com/patinaproject/bootstrap/issues/86)
+
+## Intent
+
+Restore honest PR readiness reporting for unresolved validation gaps. The
+current `check-pr-template-checkboxes` gate treats every unchecked visible
+checkbox as a required template checkbox unless the row is explicitly optional.
+That collides with the PR template's canonical `⚠️ Test gap:` rows, which are
+intentionally unchecked while validation is still unresolved. The fix should
+remove the incentive to rewrite real gaps as prose while keeping unresolved
+blocking validation visible to reviewers and publish-state checks.
+
+## Requirements
+
+- R1: PR authors must keep real unresolved validation gaps in the canonical
+  unchecked `⚠️ Test gap:` checkbox format under the relevant AC.
+- R2: A PR with unresolved blocking validation gaps must remain visibly not
+  ready until those gaps are resolved or deliberately deferred.
+- R3: The repository must not reward converting unresolved test gaps to prose
+  solely to satisfy a checkbox validator.
+- R4: Operator-action checkboxes remain distinct from test-gap checkboxes.
+  Operator actions can still require explicit completion before merge.
+- R5: The broad required-checkbox validator must no longer fail canonical
+  unchecked `⚠️ Test gap:` rows as though they were ordinary required operator
+  tasks.
+- R6: If implementation keeps a checkbox validator, it must validate only
+  checkboxes whose semantics are genuinely "must be checked before merge,"
+  such as `Operator check:` rows or explicitly marked required operator rows.
+- R7: If implementation removes the checkbox validator entirely, it must also
+  remove or update its workflow step, package script, fixtures, and template
+  marker guidance so stale enforcement claims do not remain.
+- R8: Root baseline files must stay mirrored from
+  `skills/bootstrap/templates/**`; template edits happen first, then root files
+  are realigned.
+- R9: The implementation must include a RED baseline showing the current
+  conflict: a canonical unchecked `⚠️ Test gap:` row fails
+  `check-pr-template-checkboxes`.
+- R10: The implementation must include GREEN verification that canonical test
+  gaps no longer need prose workarounds, while any retained required
+  operator-action checkbox behavior is covered by fixtures.
+
+## Acceptance Criteria
+
+- AC-86-1: Given a PR body contains a canonical unchecked `⚠️ Test gap:` row,
+  when repository PR validation runs, then the row is preserved as the
+  canonical way to report the unresolved validation gap and is not converted
+  to prose to satisfy the checkbox gate.
+- AC-86-2: Given a PR body contains a real unresolved blocking validation gap,
+  when reviewers inspect PR readiness, then the PR remains visibly not ready
+  until the gap is resolved or explicitly deferred.
+- AC-86-3: Given a PR body contains an unchecked operator-action checkbox,
+  when any retained checkbox validation runs, then that operator action still
+  fails readiness unless it is explicitly optional.
+- AC-86-4: Given bootstrap ships repository baseline files from templates,
+  when the validation behavior changes, then template source files and mirrored
+  root files remain in sync.
+
+## Recommended Approach
+
+Replace broad "all visible unchecked checkboxes are required" validation with
+semantic validation:
+
+1. Treat `⚠️ Test gap:` rows as readiness blockers that must stay visible in
+   the PR body while unresolved, not as checkbox tasks that agents should make
+   green by checking or rewriting.
+2. Retain checkbox enforcement only for operator-action checkboxes whose text
+   starts with `Operator check:` or rows explicitly marked with a required
+   operator checkbox marker.
+3. Update the PR template comments to state that test-gap checkboxes are
+   intentionally unchecked while unresolved and must not be rewritten as prose.
+4. Update `scripts/check-pr-template-checkboxes.mjs` and its template copy so
+   canonical `⚠️ Test gap:` rows are not reported by that gate.
+5. Add or update fixtures for:
+   - current failing baseline: unchecked `⚠️ Test gap:` fails the old validator;
+   - green target: unchecked `⚠️ Test gap:` is accepted by the checkbox gate;
+   - retained failure: unchecked `Operator check:` remains a readiness failure;
+   - optional checkbox and docs-choice behavior remains covered if retained.
+
+This is a targeted correction rather than a full PR-template redesign. It keeps
+the useful distinction introduced by #83 while undoing the over-broad behavior
+introduced by #64.
+
+## Considered Approaches
+
+### Recommended: Narrow the checkbox validator to operator-action semantics
+
+This removes the prose workaround incentive while preserving enforcement for
+the rows that are truly "must be checked before merge." It is the smallest
+behavioral change that addresses the conflict.
+
+### Simpler: Remove the checkbox validator and workflow step entirely
+
+This fully reverts the misleading gate and is acceptable if implementation
+finds that the validator's remaining operator-action coverage is too coupled
+to the broken assumption. The cost is losing automated enforcement for real
+operator-action checkboxes unless another gate already covers them.
+
+### Rejected: Mark every test gap as optional
+
+Optional markers would make the checkbox gate pass, but they teach the wrong
+readiness model. A real blocking test gap is not optional; it is unresolved
+validation that must stay visible and prevent readiness until addressed or
+explicitly deferred.
+
+### Rejected: Keep the current validator and rely on agent discipline
+
+The reported failure mode is that agents already rationalize around the red
+check by converting canonical rows to prose. Leaving the gate unchanged keeps
+the same incentive in place.
+
+## Affected Surfaces
+
+- `skills/bootstrap/templates/core/.github/pull_request_template.md`
+- `.github/pull_request_template.md`
+- `skills/bootstrap/templates/core/scripts/check-pr-template-checkboxes.mjs`
+- `scripts/check-pr-template-checkboxes.mjs`
+- `skills/bootstrap/templates/core/scripts/check-pr-template-checkboxes.test.mjs`
+- `scripts/check-pr-template-checkboxes.test.mjs`
+- `skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/*`
+- `scripts/fixtures/pr-template-checkboxes/*`
+- `skills/bootstrap/templates/core/.github/workflows/pull-request.yml`
+- `.github/workflows/pull-request.yml`
+- `skills/bootstrap/templates/core/package.json.tmpl`
+- `package.json`
+- Related guidance if it names the checkbox gate or required PR-template
+  checkbox behavior, including `AGENTS.md`, template copies, and
+  `docs/ac-traceability.md`.
+
+## Verification
+
+- RED baseline: run the current validator against a fixture containing an
+  unchecked canonical `⚠️ Test gap:` and record that it fails.
+- GREEN fixture tests: run `node --test scripts/check-pr-template-checkboxes.test.mjs`
+  after the semantic change.
+- Template parity: compare each edited root file with its corresponding
+  `skills/bootstrap/templates/core/**` source.
+- Search check: run `rg 'Required template checkboxes|pr-checkbox|Test gap'`
+  across root and template files to confirm stale claims were removed or
+  narrowed.
+- Markdown lint: run `pnpm lint:md`.
+- Workflow lint: if `.github/workflows/pull-request.yml` changes, run
+  `pnpm exec actionlint .github/workflows/*.yml` or report if actionlint is
+  unavailable.
+
+## Non-Goals
+
+- Do not redesign the PR body top-level sections.
+- Do not remove canonical `⚠️ Test gap:` rows.
+- Do not make agents check unresolved test-gap boxes just to satisfy CI.
+- Do not introduce hidden state, labels, or sidecar files to track readiness.
+- Do not change GitHub issue or commit-message conventions.
+- Do not configure branch protection in this repository.
+
+## Writing-Skills Pressure-Test Considerations
+
+### RED Baseline Obligation
+
+The first executable evidence must show the present conflict: the existing
+checkbox validator fails a PR body that uses the template's canonical unchecked
+`⚠️ Test gap:` row for an unresolved validation gap. Without that failing
+baseline, the implementation has not proven it is fixing the reported
+misleading incentive.
+
+### GREEN Obligation
+
+The green behavior is not "unchecked boxes never fail." The green behavior is
+that test gaps keep their honest unresolved representation while genuine
+operator-action checkboxes keep their completion semantics.
+
+### Rationalization Resistance
+
+| Rationalization | Reality |
+| --- | --- |
+| "Just write `Blocking validation gap:` as prose." | R1 and R3 require canonical unchecked `⚠️ Test gap:` rows for real unresolved validation gaps. |
+| "Mark test gaps optional so the gate passes." | Test gaps are unresolved validation, not optional tasks. Optional markers hide the readiness problem. |
+| "Keep failing every unchecked checkbox because red CI is safer." | The broad rule caused the dishonest workaround; validation must follow row semantics. |
+| "Root script edits are enough." | R8 requires template-first edits and mirrored root files. |
+| "A passing checkbox test means readiness." | Readiness also depends on visible unresolved gaps, AC evidence, PR metadata, and publish-state checks. |
+
+### Red Flags
+
+- A canonical `⚠️ Test gap:` row still fails only because it is unchecked.
+- A real unresolved test gap is converted to prose, hidden in a summary, or
+  marked optional.
+- An unchecked `Operator check:` row passes without an explicit optional marker
+  or documented deferral.
+- Root files and bootstrap templates diverge.
+- Stale documentation still says every visible unchecked checkbox is forbidden.
+
+### Token-Efficiency Target
+
+Keep the template instructions short: one comment should explain that test-gap
+checkboxes are intentionally unchecked while unresolved, and one comment should
+explain which operator-action checkboxes remain enforced. Detailed parser
+behavior belongs in tests, not in the PR template.
+
+## Brainstormer Self-Review
+
+- Placeholder scan: no placeholders remain.
+- Internal consistency: test gaps stay visible and unresolved; operator
+  checkboxes retain completion semantics.
+- Scope check: the design is limited to PR checkbox validation behavior,
+  shipped templates, mirrored root files, and directly related guidance.
+- Ambiguity check: if the executor chooses full validator removal, R7 requires
+  stale workflow, script, fixture, package, and guidance cleanup so the result
+  is not half-reverted.

--- a/scripts/check-pr-template-checkboxes.mjs
+++ b/scripts/check-pr-template-checkboxes.mjs
@@ -103,6 +103,13 @@ export function validatePrBody(body) {
     const marker = pending ?? { kind: 'required', lineNumber };
     pending = null;
 
+    if (PROSE_GAP.test(text)) {
+      errors.push(
+        `line ${lineNumber}: ${section}: use canonical ⚠️ Test gap checkbox instead of prose: ${text}`,
+      );
+      continue;
+    }
+
     const testGap = text.match(TEST_GAP);
     if (testGap) {
       const acId = activeAc ?? section;

--- a/scripts/check-pr-template-checkboxes.mjs
+++ b/scripts/check-pr-template-checkboxes.mjs
@@ -13,6 +13,7 @@ const COMMENT_END = /-->\s*$/;
 const AC_HEADING = /^AC-\d+-\d+\b/;
 const TEST_GAP = /^⚠️\s*Test gap:\s*(.+)$/i;
 const OPERATOR_CHECK = /^Operator check:/i;
+const PROSE_GAP = /^\s*(?:[-*]\s*)?Blocking validation gap:/i;
 
 function ensureAc(acMap, acId, section, lineNumber) {
   const entry = acMap.get(acId) ?? {
@@ -87,6 +88,13 @@ export function validatePrBody(body) {
       continue;
     }
 
+    if (PROSE_GAP.test(line)) {
+      errors.push(
+        `line ${lineNumber}: ${section}: use canonical ⚠️ Test gap checkbox instead of prose: ${line.trim()}`,
+      );
+      continue;
+    }
+
     const checkbox = line.match(CHECKBOX);
     if (!checkbox) continue;
 
@@ -100,11 +108,10 @@ export function validatePrBody(body) {
       const acId = activeAc ?? section;
       const ac = ensureAc(acs, acId, section, lineNumber);
       ac.testGaps.push({ checked, lineNumber, text });
-      if (!checked) {
-        errors.push(
-          `line ${lineNumber}: ${section}: unresolved validation gap: ${testGap[1]}`,
-        );
-      }
+      const message = checked
+        ? `test gap checkbox must remain unchecked while unresolved: ${testGap[1]}`
+        : `unresolved validation gap: ${testGap[1]}`;
+      errors.push(`line ${lineNumber}: ${section}: ${message}`);
       continue;
     }
 
@@ -167,7 +174,7 @@ function readBodyFromArgs() {
 
 function emitGithubError(message) {
   const escaped = message.replaceAll('%', '%25').replaceAll('\n', '%0A');
-  console.error(`::error title=Required template checkbox::${escaped}`);
+  console.error(`::error title=PR readiness validation::${escaped}`);
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
@@ -176,5 +183,5 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
     for (const error of result.errors) emitGithubError(error);
     process.exit(1);
   }
-  console.log('Required template checkboxes are satisfied.');
+  console.log('PR readiness validation passed.');
 }

--- a/scripts/check-pr-template-checkboxes.mjs
+++ b/scripts/check-pr-template-checkboxes.mjs
@@ -10,19 +10,63 @@ const CHECKBOX = /^\s*-\s+\[( |x|X)\]\s+(.+)$/;
 const HEADING = /^\s{0,3}(#{2,6})\s+(.+?)\s*$/;
 const COMMENT_START = /^\s*<!--/;
 const COMMENT_END = /-->\s*$/;
+const AC_HEADING = /^AC-\d+-\d+\b/;
+const TEST_GAP = /^⚠️\s*Test gap:\s*(.+)$/i;
+const OPERATOR_CHECK = /^Operator check:/i;
+
+function ensureAc(acMap, acId, section, lineNumber) {
+  const entry = acMap.get(acId) ?? {
+    section,
+    lineNumber,
+    hasWarning: false,
+    testGaps: [],
+  };
+  if (section) entry.section = section;
+  if (lineNumber && !entry.lineNumber) entry.lineNumber = lineNumber;
+  acMap.set(acId, entry);
+  return entry;
+}
+
+function readMatrixAc(line) {
+  const trimmed = line.trim();
+  if (!trimmed.startsWith('|')) return null;
+
+  const cells = trimmed
+    .split('|')
+    .slice(1, -1)
+    .map((cell) => cell.trim());
+  const acId = cells[0];
+  if (!AC_HEADING.test(acId)) return null;
+
+  return {
+    acId,
+    hasWarning: cells.slice(2).some((cell) => cell === '⚠️'),
+  };
+}
 
 export function validatePrBody(body) {
   const errors = [];
   const choices = new Map();
+  const acs = new Map();
   const lines = String(body ?? '').split(/\r?\n/);
   let pending = null;
   let section = 'PR body';
+  let activeAc = null;
   let inComment = false;
 
   for (const [index, line] of lines.entries()) {
     const lineNumber = index + 1;
     const heading = line.match(HEADING);
-    if (heading) section = heading[2];
+    if (heading) {
+      section = heading[2];
+      activeAc = AC_HEADING.test(section) ? section.split(/\s+/)[0] : null;
+      if (activeAc) ensureAc(acs, activeAc, section, lineNumber);
+    }
+
+    const matrixAc = readMatrixAc(line);
+    if (matrixAc?.hasWarning) {
+      ensureAc(acs, matrixAc.acId, matrixAc.acId, lineNumber).hasWarning = true;
+    }
 
     const choiceMarker = line.match(CHOICE_MARKER);
     if (choiceMarker) {
@@ -51,13 +95,29 @@ export function validatePrBody(body) {
     const marker = pending ?? { kind: 'required', lineNumber };
     pending = null;
 
+    const testGap = text.match(TEST_GAP);
+    if (testGap) {
+      const acId = activeAc ?? section;
+      const ac = ensureAc(acs, acId, section, lineNumber);
+      ac.testGaps.push({ checked, lineNumber, text });
+      if (!checked) {
+        errors.push(
+          `line ${lineNumber}: ${section}: unresolved validation gap: ${testGap[1]}`,
+        );
+      }
+      continue;
+    }
+
     if (!marker) continue;
     if (marker.kind === 'optional') continue;
 
     if (marker.kind === 'required') {
       if (!checked) {
+        const label = OPERATOR_CHECK.test(text)
+          ? 'operator check is unchecked'
+          : 'required checklist item is unchecked';
         errors.push(
-          `line ${lineNumber}: ${section}: required checklist item is unchecked: ${text}`,
+          `line ${lineNumber}: ${section}: ${label}: ${text}`,
         );
       }
       continue;
@@ -78,6 +138,14 @@ export function validatePrBody(body) {
       const rows = group.rows.map((row) => row.text).join('; ');
       errors.push(
         `line ${group.firstLine}: ${groupName}: choice group must have exactly one checked item; ${group.checked} checked among: ${rows}`,
+      );
+    }
+  }
+
+  for (const [acId, ac] of acs.entries()) {
+    if (ac.hasWarning && ac.testGaps.length === 0) {
+      errors.push(
+        `line ${ac.lineNumber}: ${acId}: missing ⚠️ Test gap for warning matrix cell`,
       );
     }
   }

--- a/scripts/check-pr-template-checkboxes.test.mjs
+++ b/scripts/check-pr-template-checkboxes.test.mjs
@@ -70,6 +70,20 @@ test('fails prose workaround when matrix warning lacks canonical test gap', () =
   assert.match(result.errors.join('\n'), /AC-86-1/);
 });
 
+test('fails checked test gaps because gaps are not completion tasks', () => {
+  const result = validatePrBody(fixture('test-gap-checked.md'));
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join('\n'), /test gap checkbox must remain unchecked/i);
+  assert.match(result.errors.join('\n'), /Linux validation has not rerun/);
+});
+
+test('fails prose workaround even without a matrix warning cell', () => {
+  const result = validatePrBody(fixture('test-gap-prose-no-warning.md'));
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join('\n'), /use canonical ⚠️ Test gap/i);
+  assert.match(result.errors.join('\n'), /Blocking validation gap/);
+});
+
 test('fails manual test row while unchecked', () => {
   const result = validatePrBody(fixture('manual-unchecked.md'));
   assert.equal(result.ok, false);

--- a/scripts/check-pr-template-checkboxes.test.mjs
+++ b/scripts/check-pr-template-checkboxes.test.mjs
@@ -84,6 +84,24 @@ test('fails prose workaround even without a matrix warning cell', () => {
   assert.match(result.errors.join('\n'), /Blocking validation gap/);
 });
 
+test('fails checked checkbox-wrapped prose workaround', () => {
+  const result = validatePrBody(
+    '## Acceptance criteria\n\n### AC-86-1\n\n- [x] Blocking validation gap: Linux validation has not rerun.\n',
+  );
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join('\n'), /use canonical ⚠️ Test gap/i);
+  assert.match(result.errors.join('\n'), /Blocking validation gap/);
+});
+
+test('fails optional checkbox-wrapped prose workaround', () => {
+  const result = validatePrBody(
+    '## Acceptance criteria\n\n### AC-86-1\n\n<!-- pr-checkbox: optional -->\n- [ ] Blocking validation gap: Linux validation has not rerun.\n',
+  );
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join('\n'), /use canonical ⚠️ Test gap/i);
+  assert.match(result.errors.join('\n'), /Blocking validation gap/);
+});
+
 test('fails manual test row while unchecked', () => {
   const result = validatePrBody(fixture('manual-unchecked.md'));
   assert.equal(result.ok, false);

--- a/scripts/check-pr-template-checkboxes.test.mjs
+++ b/scripts/check-pr-template-checkboxes.test.mjs
@@ -45,10 +45,29 @@ test('fails docs choice group when more than one option is checked', () => {
   assert.match(result.errors.join('\n'), /2 checked/);
 });
 
-test('fails included E2E gap acknowledgement while unchecked', () => {
+test('fails included test gap while unchecked with gap-specific text', () => {
   const result = validatePrBody(fixture('e2e-gap-unchecked.md'));
   assert.equal(result.ok, false);
-  assert.match(result.errors.join('\n'), /E2E gap/);
+  assert.match(result.errors.join('\n'), /unresolved validation gap/i);
+  assert.match(result.errors.join('\n'), /browser behavior not covered/);
+});
+
+test('fails canonical unresolved test gaps with gap-specific text', () => {
+  const result = validatePrBody(fixture('test-gap-unchecked.md'));
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join('\n'), /unresolved validation gap/i);
+  assert.match(result.errors.join('\n'), /Linux validation has not rerun/);
+  assert.doesNotMatch(
+    result.errors.join('\n'),
+    /required checklist item is unchecked/i,
+  );
+});
+
+test('fails prose workaround when matrix warning lacks canonical test gap', () => {
+  const result = validatePrBody(fixture('test-gap-prose-workaround.md'));
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join('\n'), /missing .*Test gap/i);
+  assert.match(result.errors.join('\n'), /AC-86-1/);
 });
 
 test('fails manual test row while unchecked', () => {

--- a/scripts/fixtures/pr-template-checkboxes/e2e-gap-unchecked.md
+++ b/scripts/fixtures/pr-template-checkboxes/e2e-gap-unchecked.md
@@ -7,7 +7,7 @@ Included E2E gap acknowledgement should fail while unchecked.
 <!-- pr-checkbox: required -->
 - [x] Linux evidence -- runner | env | verifier | 2026-04-29T00:00:00Z
 <!-- pr-checkbox: required -->
-- [ ] E2E gap: browser behavior not covered by automation
+- [ ] ⚠️ Test gap: browser behavior not covered by automation
 <!-- pr-checkbox: required -->
 - [x] Manual test: 1. Open the PR; 2. Confirm the gate fails.
 

--- a/scripts/fixtures/pr-template-checkboxes/test-gap-checked.md
+++ b/scripts/fixtures/pr-template-checkboxes/test-gap-checked.md
@@ -1,0 +1,20 @@
+## Test coverage
+
+| AC | Title | Unit | Linux |
+| --- | --- | --- | --- |
+| AC-86-1 | Checked unresolved gap | ➖ | ⚠️ |
+
+## Acceptance criteria
+
+### AC-86-1
+
+Checked test gap should fail because unresolved gaps are not completion tasks.
+
+- [x] ⚠️ Test gap: Linux validation has not rerun after the validator fix.
+
+## Docs updated
+
+<!-- pr-checkbox-choice: docs-updated exactly-one -->
+- [x] Not needed
+<!-- pr-checkbox-choice: docs-updated exactly-one -->
+- [ ] Updated in this PR

--- a/scripts/fixtures/pr-template-checkboxes/test-gap-prose-no-warning.md
+++ b/scripts/fixtures/pr-template-checkboxes/test-gap-prose-no-warning.md
@@ -1,0 +1,18 @@
+## Test coverage
+
+| AC | Title | Unit | Linux |
+| --- | --- | --- | --- |
+| AC-86-1 | Prose without warning | ➖ | ➖ |
+
+## Acceptance criteria
+
+### AC-86-1
+
+Blocking validation gap: Linux validation has not rerun after the validator fix.
+
+## Docs updated
+
+<!-- pr-checkbox-choice: docs-updated exactly-one -->
+- [x] Not needed
+<!-- pr-checkbox-choice: docs-updated exactly-one -->
+- [ ] Updated in this PR

--- a/scripts/fixtures/pr-template-checkboxes/test-gap-prose-workaround.md
+++ b/scripts/fixtures/pr-template-checkboxes/test-gap-prose-workaround.md
@@ -1,0 +1,18 @@
+## Test coverage
+
+| AC | Title | Unit | Linux |
+| --- | --- | --- | --- |
+| AC-86-1 | Prose workaround | ➖ | ⚠️ |
+
+## Acceptance criteria
+
+### AC-86-1
+
+Blocking validation gap: Linux validation has not rerun after the validator fix.
+
+## Docs updated
+
+<!-- pr-checkbox-choice: docs-updated exactly-one -->
+- [x] Not needed
+<!-- pr-checkbox-choice: docs-updated exactly-one -->
+- [ ] Updated in this PR

--- a/scripts/fixtures/pr-template-checkboxes/test-gap-unchecked.md
+++ b/scripts/fixtures/pr-template-checkboxes/test-gap-unchecked.md
@@ -1,0 +1,20 @@
+## Test coverage
+
+| AC | Title | Unit | Linux |
+| --- | --- | --- | --- |
+| AC-86-1 | Canonical unresolved gap | ➖ | ⚠️ |
+
+## Acceptance criteria
+
+### AC-86-1
+
+Canonical unresolved test gap should fail with a gap-specific readiness message.
+
+- [ ] ⚠️ Test gap: Linux validation has not rerun after the validator fix.
+
+## Docs updated
+
+<!-- pr-checkbox-choice: docs-updated exactly-one -->
+- [x] Not needed
+<!-- pr-checkbox-choice: docs-updated exactly-one -->
+- [ ] Updated in this PR

--- a/skills/bootstrap/templates/core/.github/pull_request_template.md
+++ b/skills/bootstrap/templates/core/.github/pull_request_template.md
@@ -106,6 +106,10 @@ including unresolved blockers or pending validation when present.
   validation concern, not to restate a code-review finding, duplicate an
   operator action, or explain tests that should exist but are missing. Test gaps
   must be about observable behavior or validation that cannot yet be trusted.
+  Test-gap checkboxes are intentionally unchecked while unresolved. Do not
+  convert a real gap to prose or mark it optional to satisfy PR validation; the
+  readiness check reports unresolved validation gaps separately from operator
+  action checkboxes.
   Treat CI that must rerun after a fix as a test gap unless the operator must
   manually trigger or inspect a specific job. Delete unused placeholder checkbox
   rows.
@@ -127,10 +131,12 @@ including unresolved blockers or pending validation when present.
   the operator can validate. Keep manual product or workflow validation as an
   operator check when a human must exercise observable behavior after a gap is
   fixed. Do not add CI-rerun operator checks unless the operator must manually
-  trigger or inspect a specific job. When updating an existing PR body,
-  preserve every existing manual-review or manual-test instruction under its AC
-  in this checkbox form. Phrase checkbox text in imperative style. Delete
-  unused placeholder checkbox rows.
+  trigger or inspect a specific job. Operator-check checkboxes are completion
+  tasks. Unchecked operator checks remain readiness blockers unless explicitly
+  optional. When updating an existing PR body, preserve every existing
+  manual-review or manual-test instruction under its AC in this checkbox form.
+  Phrase checkbox text in imperative style. Delete unused placeholder checkbox
+  rows.
 -->
 - [ ] Operator check: <imperative operator action and expected decision or result>
 

--- a/skills/bootstrap/templates/core/.github/workflows/pull-request.yml
+++ b/skills/bootstrap/templates/core/.github/workflows/pull-request.yml
@@ -84,7 +84,7 @@ jobs:
         # actions/checkout@v4.3.1
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
-      - name: Validate required template checkboxes
+      - name: Validate PR readiness gaps
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: node scripts/check-pr-template-checkboxes.mjs

--- a/skills/bootstrap/templates/core/scripts/check-pr-template-checkboxes.mjs
+++ b/skills/bootstrap/templates/core/scripts/check-pr-template-checkboxes.mjs
@@ -103,6 +103,13 @@ export function validatePrBody(body) {
     const marker = pending ?? { kind: 'required', lineNumber };
     pending = null;
 
+    if (PROSE_GAP.test(text)) {
+      errors.push(
+        `line ${lineNumber}: ${section}: use canonical ⚠️ Test gap checkbox instead of prose: ${text}`,
+      );
+      continue;
+    }
+
     const testGap = text.match(TEST_GAP);
     if (testGap) {
       const acId = activeAc ?? section;

--- a/skills/bootstrap/templates/core/scripts/check-pr-template-checkboxes.mjs
+++ b/skills/bootstrap/templates/core/scripts/check-pr-template-checkboxes.mjs
@@ -13,6 +13,7 @@ const COMMENT_END = /-->\s*$/;
 const AC_HEADING = /^AC-\d+-\d+\b/;
 const TEST_GAP = /^⚠️\s*Test gap:\s*(.+)$/i;
 const OPERATOR_CHECK = /^Operator check:/i;
+const PROSE_GAP = /^\s*(?:[-*]\s*)?Blocking validation gap:/i;
 
 function ensureAc(acMap, acId, section, lineNumber) {
   const entry = acMap.get(acId) ?? {
@@ -87,6 +88,13 @@ export function validatePrBody(body) {
       continue;
     }
 
+    if (PROSE_GAP.test(line)) {
+      errors.push(
+        `line ${lineNumber}: ${section}: use canonical ⚠️ Test gap checkbox instead of prose: ${line.trim()}`,
+      );
+      continue;
+    }
+
     const checkbox = line.match(CHECKBOX);
     if (!checkbox) continue;
 
@@ -100,11 +108,10 @@ export function validatePrBody(body) {
       const acId = activeAc ?? section;
       const ac = ensureAc(acs, acId, section, lineNumber);
       ac.testGaps.push({ checked, lineNumber, text });
-      if (!checked) {
-        errors.push(
-          `line ${lineNumber}: ${section}: unresolved validation gap: ${testGap[1]}`,
-        );
-      }
+      const message = checked
+        ? `test gap checkbox must remain unchecked while unresolved: ${testGap[1]}`
+        : `unresolved validation gap: ${testGap[1]}`;
+      errors.push(`line ${lineNumber}: ${section}: ${message}`);
       continue;
     }
 
@@ -167,7 +174,7 @@ function readBodyFromArgs() {
 
 function emitGithubError(message) {
   const escaped = message.replaceAll('%', '%25').replaceAll('\n', '%0A');
-  console.error(`::error title=Required template checkbox::${escaped}`);
+  console.error(`::error title=PR readiness validation::${escaped}`);
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
@@ -176,5 +183,5 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
     for (const error of result.errors) emitGithubError(error);
     process.exit(1);
   }
-  console.log('Required template checkboxes are satisfied.');
+  console.log('PR readiness validation passed.');
 }

--- a/skills/bootstrap/templates/core/scripts/check-pr-template-checkboxes.mjs
+++ b/skills/bootstrap/templates/core/scripts/check-pr-template-checkboxes.mjs
@@ -10,19 +10,63 @@ const CHECKBOX = /^\s*-\s+\[( |x|X)\]\s+(.+)$/;
 const HEADING = /^\s{0,3}(#{2,6})\s+(.+?)\s*$/;
 const COMMENT_START = /^\s*<!--/;
 const COMMENT_END = /-->\s*$/;
+const AC_HEADING = /^AC-\d+-\d+\b/;
+const TEST_GAP = /^⚠️\s*Test gap:\s*(.+)$/i;
+const OPERATOR_CHECK = /^Operator check:/i;
+
+function ensureAc(acMap, acId, section, lineNumber) {
+  const entry = acMap.get(acId) ?? {
+    section,
+    lineNumber,
+    hasWarning: false,
+    testGaps: [],
+  };
+  if (section) entry.section = section;
+  if (lineNumber && !entry.lineNumber) entry.lineNumber = lineNumber;
+  acMap.set(acId, entry);
+  return entry;
+}
+
+function readMatrixAc(line) {
+  const trimmed = line.trim();
+  if (!trimmed.startsWith('|')) return null;
+
+  const cells = trimmed
+    .split('|')
+    .slice(1, -1)
+    .map((cell) => cell.trim());
+  const acId = cells[0];
+  if (!AC_HEADING.test(acId)) return null;
+
+  return {
+    acId,
+    hasWarning: cells.slice(2).some((cell) => cell === '⚠️'),
+  };
+}
 
 export function validatePrBody(body) {
   const errors = [];
   const choices = new Map();
+  const acs = new Map();
   const lines = String(body ?? '').split(/\r?\n/);
   let pending = null;
   let section = 'PR body';
+  let activeAc = null;
   let inComment = false;
 
   for (const [index, line] of lines.entries()) {
     const lineNumber = index + 1;
     const heading = line.match(HEADING);
-    if (heading) section = heading[2];
+    if (heading) {
+      section = heading[2];
+      activeAc = AC_HEADING.test(section) ? section.split(/\s+/)[0] : null;
+      if (activeAc) ensureAc(acs, activeAc, section, lineNumber);
+    }
+
+    const matrixAc = readMatrixAc(line);
+    if (matrixAc?.hasWarning) {
+      ensureAc(acs, matrixAc.acId, matrixAc.acId, lineNumber).hasWarning = true;
+    }
 
     const choiceMarker = line.match(CHOICE_MARKER);
     if (choiceMarker) {
@@ -51,13 +95,29 @@ export function validatePrBody(body) {
     const marker = pending ?? { kind: 'required', lineNumber };
     pending = null;
 
+    const testGap = text.match(TEST_GAP);
+    if (testGap) {
+      const acId = activeAc ?? section;
+      const ac = ensureAc(acs, acId, section, lineNumber);
+      ac.testGaps.push({ checked, lineNumber, text });
+      if (!checked) {
+        errors.push(
+          `line ${lineNumber}: ${section}: unresolved validation gap: ${testGap[1]}`,
+        );
+      }
+      continue;
+    }
+
     if (!marker) continue;
     if (marker.kind === 'optional') continue;
 
     if (marker.kind === 'required') {
       if (!checked) {
+        const label = OPERATOR_CHECK.test(text)
+          ? 'operator check is unchecked'
+          : 'required checklist item is unchecked';
         errors.push(
-          `line ${lineNumber}: ${section}: required checklist item is unchecked: ${text}`,
+          `line ${lineNumber}: ${section}: ${label}: ${text}`,
         );
       }
       continue;
@@ -78,6 +138,14 @@ export function validatePrBody(body) {
       const rows = group.rows.map((row) => row.text).join('; ');
       errors.push(
         `line ${group.firstLine}: ${groupName}: choice group must have exactly one checked item; ${group.checked} checked among: ${rows}`,
+      );
+    }
+  }
+
+  for (const [acId, ac] of acs.entries()) {
+    if (ac.hasWarning && ac.testGaps.length === 0) {
+      errors.push(
+        `line ${ac.lineNumber}: ${acId}: missing ⚠️ Test gap for warning matrix cell`,
       );
     }
   }

--- a/skills/bootstrap/templates/core/scripts/check-pr-template-checkboxes.test.mjs
+++ b/skills/bootstrap/templates/core/scripts/check-pr-template-checkboxes.test.mjs
@@ -70,6 +70,20 @@ test('fails prose workaround when matrix warning lacks canonical test gap', () =
   assert.match(result.errors.join('\n'), /AC-86-1/);
 });
 
+test('fails checked test gaps because gaps are not completion tasks', () => {
+  const result = validatePrBody(fixture('test-gap-checked.md'));
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join('\n'), /test gap checkbox must remain unchecked/i);
+  assert.match(result.errors.join('\n'), /Linux validation has not rerun/);
+});
+
+test('fails prose workaround even without a matrix warning cell', () => {
+  const result = validatePrBody(fixture('test-gap-prose-no-warning.md'));
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join('\n'), /use canonical ⚠️ Test gap/i);
+  assert.match(result.errors.join('\n'), /Blocking validation gap/);
+});
+
 test('fails manual test row while unchecked', () => {
   const result = validatePrBody(fixture('manual-unchecked.md'));
   assert.equal(result.ok, false);

--- a/skills/bootstrap/templates/core/scripts/check-pr-template-checkboxes.test.mjs
+++ b/skills/bootstrap/templates/core/scripts/check-pr-template-checkboxes.test.mjs
@@ -84,6 +84,24 @@ test('fails prose workaround even without a matrix warning cell', () => {
   assert.match(result.errors.join('\n'), /Blocking validation gap/);
 });
 
+test('fails checked checkbox-wrapped prose workaround', () => {
+  const result = validatePrBody(
+    '## Acceptance criteria\n\n### AC-86-1\n\n- [x] Blocking validation gap: Linux validation has not rerun.\n',
+  );
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join('\n'), /use canonical ⚠️ Test gap/i);
+  assert.match(result.errors.join('\n'), /Blocking validation gap/);
+});
+
+test('fails optional checkbox-wrapped prose workaround', () => {
+  const result = validatePrBody(
+    '## Acceptance criteria\n\n### AC-86-1\n\n<!-- pr-checkbox: optional -->\n- [ ] Blocking validation gap: Linux validation has not rerun.\n',
+  );
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join('\n'), /use canonical ⚠️ Test gap/i);
+  assert.match(result.errors.join('\n'), /Blocking validation gap/);
+});
+
 test('fails manual test row while unchecked', () => {
   const result = validatePrBody(fixture('manual-unchecked.md'));
   assert.equal(result.ok, false);

--- a/skills/bootstrap/templates/core/scripts/check-pr-template-checkboxes.test.mjs
+++ b/skills/bootstrap/templates/core/scripts/check-pr-template-checkboxes.test.mjs
@@ -45,10 +45,29 @@ test('fails docs choice group when more than one option is checked', () => {
   assert.match(result.errors.join('\n'), /2 checked/);
 });
 
-test('fails included E2E gap acknowledgement while unchecked', () => {
+test('fails included test gap while unchecked with gap-specific text', () => {
   const result = validatePrBody(fixture('e2e-gap-unchecked.md'));
   assert.equal(result.ok, false);
-  assert.match(result.errors.join('\n'), /E2E gap/);
+  assert.match(result.errors.join('\n'), /unresolved validation gap/i);
+  assert.match(result.errors.join('\n'), /browser behavior not covered/);
+});
+
+test('fails canonical unresolved test gaps with gap-specific text', () => {
+  const result = validatePrBody(fixture('test-gap-unchecked.md'));
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join('\n'), /unresolved validation gap/i);
+  assert.match(result.errors.join('\n'), /Linux validation has not rerun/);
+  assert.doesNotMatch(
+    result.errors.join('\n'),
+    /required checklist item is unchecked/i,
+  );
+});
+
+test('fails prose workaround when matrix warning lacks canonical test gap', () => {
+  const result = validatePrBody(fixture('test-gap-prose-workaround.md'));
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join('\n'), /missing .*Test gap/i);
+  assert.match(result.errors.join('\n'), /AC-86-1/);
 });
 
 test('fails manual test row while unchecked', () => {

--- a/skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/e2e-gap-unchecked.md
+++ b/skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/e2e-gap-unchecked.md
@@ -7,7 +7,7 @@ Included E2E gap acknowledgement should fail while unchecked.
 <!-- pr-checkbox: required -->
 - [x] Linux evidence -- runner | env | verifier | 2026-04-29T00:00:00Z
 <!-- pr-checkbox: required -->
-- [ ] E2E gap: browser behavior not covered by automation
+- [ ] ⚠️ Test gap: browser behavior not covered by automation
 <!-- pr-checkbox: required -->
 - [x] Manual test: 1. Open the PR; 2. Confirm the gate fails.
 

--- a/skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/test-gap-checked.md
+++ b/skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/test-gap-checked.md
@@ -1,0 +1,20 @@
+## Test coverage
+
+| AC | Title | Unit | Linux |
+| --- | --- | --- | --- |
+| AC-86-1 | Checked unresolved gap | ➖ | ⚠️ |
+
+## Acceptance criteria
+
+### AC-86-1
+
+Checked test gap should fail because unresolved gaps are not completion tasks.
+
+- [x] ⚠️ Test gap: Linux validation has not rerun after the validator fix.
+
+## Docs updated
+
+<!-- pr-checkbox-choice: docs-updated exactly-one -->
+- [x] Not needed
+<!-- pr-checkbox-choice: docs-updated exactly-one -->
+- [ ] Updated in this PR

--- a/skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/test-gap-prose-no-warning.md
+++ b/skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/test-gap-prose-no-warning.md
@@ -1,0 +1,18 @@
+## Test coverage
+
+| AC | Title | Unit | Linux |
+| --- | --- | --- | --- |
+| AC-86-1 | Prose without warning | ➖ | ➖ |
+
+## Acceptance criteria
+
+### AC-86-1
+
+Blocking validation gap: Linux validation has not rerun after the validator fix.
+
+## Docs updated
+
+<!-- pr-checkbox-choice: docs-updated exactly-one -->
+- [x] Not needed
+<!-- pr-checkbox-choice: docs-updated exactly-one -->
+- [ ] Updated in this PR

--- a/skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/test-gap-prose-workaround.md
+++ b/skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/test-gap-prose-workaround.md
@@ -1,0 +1,18 @@
+## Test coverage
+
+| AC | Title | Unit | Linux |
+| --- | --- | --- | --- |
+| AC-86-1 | Prose workaround | ➖ | ⚠️ |
+
+## Acceptance criteria
+
+### AC-86-1
+
+Blocking validation gap: Linux validation has not rerun after the validator fix.
+
+## Docs updated
+
+<!-- pr-checkbox-choice: docs-updated exactly-one -->
+- [x] Not needed
+<!-- pr-checkbox-choice: docs-updated exactly-one -->
+- [ ] Updated in this PR

--- a/skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/test-gap-unchecked.md
+++ b/skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/test-gap-unchecked.md
@@ -1,0 +1,20 @@
+## Test coverage
+
+| AC | Title | Unit | Linux |
+| --- | --- | --- | --- |
+| AC-86-1 | Canonical unresolved gap | ➖ | ⚠️ |
+
+## Acceptance criteria
+
+### AC-86-1
+
+Canonical unresolved test gap should fail with a gap-specific readiness message.
+
+- [ ] ⚠️ Test gap: Linux validation has not rerun after the validator fix.
+
+## Docs updated
+
+<!-- pr-checkbox-choice: docs-updated exactly-one -->
+- [x] Not needed
+<!-- pr-checkbox-choice: docs-updated exactly-one -->
+- [ ] Updated in this PR


### PR DESCRIPTION
## Linked issue

- Closes #86

## What changed

- Reworked PR readiness validation so canonical `⚠️ Test gap:` rows fail with validation-gap messages instead of generic required-checkbox errors.
- Added bypass coverage for prose-only gaps, checked test-gap rows, checkbox-wrapped prose gaps, and matrix `⚠️` cells without canonical gap detail.
- Updated PR template and workflow wording in both bootstrap templates and mirrored root files.

## Test coverage

| AC | Title | Unit | Workflow |
| --- | --- | --- | --- |
| AC-86-1 | Canonical gap format | ✅ | ✅ |
| AC-86-2 | Blocking gap readiness | ✅ | ✅ |
| AC-86-3 | Operator checkbox behavior | ✅ | ✅ |
| AC-86-4 | Template/root parity | ✅ | ✅ |

## Acceptance criteria

### AC-86-1

Canonical unchecked `⚠️ Test gap:` rows remain the required representation and now fail with gap-specific readiness text instead of generic checkbox wording.

- Unit test: `node --test scripts/check-pr-template-checkboxes.test.mjs`, local, Finisher, 2026-05-03
- Workflow test: `node --test skills/bootstrap/templates/core/scripts/check-pr-template-checkboxes.test.mjs`, local, Finisher, 2026-05-03

### AC-86-2

Unresolved blocking validation gaps remain not ready: unchecked and checked `⚠️ Test gap:` rows fail, matrix warnings without canonical gap rows fail, and prose workaround variants fail.

- Unit test: `node --test scripts/check-pr-template-checkboxes.test.mjs`, local, Finisher, 2026-05-03
- Workflow test: `pnpm exec actionlint .github/workflows/*.yml`, local, Finisher, 2026-05-03

### AC-86-3

Operator-action checkbox behavior is retained: required unchecked operator checks still fail, while explicitly optional checkboxes are still allowed.

- Unit test: `node --test scripts/check-pr-template-checkboxes.test.mjs`, local, Finisher, 2026-05-03

### AC-86-4

Template source files and mirrored root files are in sync for the PR template, workflow, validator, tests, and fixtures.

- Workflow test: `cmp -s skills/bootstrap/templates/core/.github/pull_request_template.md .github/pull_request_template.md`, local, Finisher, 2026-05-03
- Workflow test: `cmp -s skills/bootstrap/templates/core/.github/workflows/pull-request.yml .github/workflows/pull-request.yml`, local, Finisher, 2026-05-03
- Workflow test: `cmp -s skills/bootstrap/templates/core/scripts/check-pr-template-checkboxes.mjs scripts/check-pr-template-checkboxes.mjs`, local, Finisher, 2026-05-03
- Workflow test: `cmp -s skills/bootstrap/templates/core/scripts/check-pr-template-checkboxes.test.mjs scripts/check-pr-template-checkboxes.test.mjs`, local, Finisher, 2026-05-03
- Workflow test: `diff -ru skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes scripts/fixtures/pr-template-checkboxes`, local, Finisher, 2026-05-03

## Test coverage notes

- `pnpm lint:md`, local, Finisher, 2026-05-03
- Local pre-publish review found no remaining findings after review-fix iterations.
