### PR TITLE
feat: #90 render PR template review context

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,9 +23,19 @@
 
 ## What changed
 
--
+Context: <prior PR, prior QA pass, or follow-up issue this PR builds on, or `standalone — <reason>` when there is none>
+
+- <change> — <why>
 
 <!--
+  The rendered `Context:` line and `- <change> — <why>` bullet shape are the
+  structural placeholders this section requires. Replace `<...>` with actual
+  values; do not delete the `Context:` line. When this PR has no prior
+  context, write `Context: standalone — <reason>` (e.g.
+  `Context: standalone — first pass on the new lint rule`). One bullet per
+  change; the `— <why>` half states the rationale (user-visible reason or
+  triggering observation), not a restatement of the change.
+
   Include this section only when PR-level operator steps that do not belong to
   a specific AC must happen after review and before merge:
 
@@ -42,6 +52,15 @@
 -->
 
 ## Test coverage
+
+Legend for status cells:
+
+- ✅ — required validation passed with no known relevant gap for this column.
+- ⚠️ — validation exists and is sufficient to merge with a known non-blocking gap documented under the AC.
+- ❌ — required validation is missing, failing, pending, or merge-blocked.
+- ➖ — not relevant to this AC.
+
+The `AC` column references the acceptance-criteria IDs from the linked issue, in `AC-<issue>-<n>` form.
 
 <!--
   When showing a partial example outside a PR body, label the whole example as
@@ -75,6 +94,10 @@
 | AC-<issue>-<n> | <short title> | ➖ | ➖ |
 
 ## Acceptance criteria
+
+Evidence rows take the form `<Platform> test: <command, workflow job, tool, or harness>, <environment>[, <link, verifier, or ISO>]` — the trailing field is who or what proves the test ran.
+
+Reviewers and QA exercising the change manually follow the `Operator check:` rows under each AC for evidence of manual exercise.
 
 <!--
   One heading per relevant AC. AC IDs follow the convention in

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -44,7 +44,7 @@ Context: <prior PR, prior QA pass, or follow-up issue this PR builds on, or `sta
   - [ ] Rotate the production secret after deploy.
 
   Keep checklist items concrete, actionable, and imperative. Do not duplicate
-  AC-specific test gaps, operator checks, or failing/pending PR checks here;
+  AC-specific coverage gaps, testing steps, or failing/pending PR checks here;
   PR check status is already reported by GitHub. Do not add this section for
   placeholders such as `None`, `N/A`, or `No work-specific pre-merge operator
   steps.` To include an intentionally optional checkbox, put a
@@ -67,12 +67,12 @@ The `AC` column references the acceptance-criteria IDs from the linked issue, in
   an excerpt before the first omitted section or table. Actual PR bodies must
   not omit relevant AC headings.
 
-  Include one row per AC with validation evidence, a required test gap, or an
-  operator check. Keep the `Unit` column, then add one column per supported
-  platform affected by this PR. Deferred or bookkeeping-only ACs may be
-  summarized in the AC section without a matrix row, but every relevant AC
-  still needs an AC heading. Each cell summarizes the required-validation state
-  for that AC and column. Use only these symbols in status cells:
+  Include one matrix row per relevant AC, then one subsection per AC with only
+  tester-useful coverage context: what was validated, where it ran, evidence,
+  known gaps or caveats, and whether manual testing is still needed. Keep the
+  `Unit` column, then add one column per supported platform affected by this
+  PR. Each cell summarizes the required-validation state for that AC and
+  column. Use only these symbols in status cells:
   ✅ = required validation passed, with no known relevant gap for this column
   ⚠️ = validation exists and is sufficient to merge, with a known non-blocking
        gap documented under this AC
@@ -81,88 +81,48 @@ The `AC` column references the acceptance-criteria IDs from the linked issue, in
   ➖ = not relevant to this AC
 
   Use `➖` only when that verification type is not relevant to the AC. If an AC
-  includes evidence, a gap, or an operator check that clearly maps to a matrix
-  column, that cell must not be `➖`. If a known non-blocking gap remains after
-  sufficient validation, use `⚠️` and document the gap under the AC in prose or
-  with an explicitly optional checkbox. If required validation is missing,
-  failing, pending, blocked by an unresolved concern, or otherwise cannot yet
-  be trusted for merge, use `❌` and add a required gap or operator-check
-  checkbox when pre-merge action is needed.
+  includes evidence or a gap that clearly maps to a matrix column, that cell
+  must not be `➖`. If a known non-blocking gap remains after sufficient
+  validation, use `⚠️` and document the gap under the AC in prose. If required
+  validation is missing, failing, pending, blocked by an unresolved concern, or
+  otherwise cannot yet be trusted for merge, use `❌` and document the gap under
+  the AC in prose. Do not use checkboxes in this section; tester actions belong
+  under `## Testing steps`.
 -->
 | AC | Title | Unit | <Platform> |
 | --- | --- | --- | --- |
 | AC-<issue>-<n> | <short title> | ➖ | ➖ |
 
-## Acceptance criteria
-
-Evidence rows take the form `<Platform> test: <command, workflow job, tool, or harness>, <environment>[, <link, verifier, or ISO>]` — the trailing field is who or what proves the test ran.
-
-Reviewers and QA exercising the change manually follow the `Operator check:` rows under each AC for evidence of manual exercise.
-
-<!--
-  One heading per relevant AC. AC IDs follow the convention in
-  docs/ac-traceability.md. Under each AC, use this order when present:
-  summary, evidence rows, test-gap checkboxes, operator-check checkboxes.
--->
-
 ### AC-<issue>-<n>
 
-Short outcome summary that states the current reviewer-relevant result,
-including unresolved blockers or pending validation when present.
+Coverage summary focused on what helps a human tester understand the state of this AC.
+
+- Evidence: `<Platform> test: <command, workflow job, tool, or harness>, <environment>[, <link, verifier, or ISO>]`.
+- Gap: <missing, pending, or non-blocking validation, or `None`>.
+- Manual testing needed: <yes/no and why>.
 
 <!--
-  For each supported platform that is relevant to this AC, include one evidence
-  row, summarize missing tests in the outcome, or document a known gap below.
-  Keep evidence rows compact and use a colon after the evidence label:
-  `<Platform> test: <command, workflow job, tool, or harness>, <environment>[, <link, verifier, or ISO>]`.
-  Name the concrete command, workflow job, tool, or harness when known. Use a
-  neutral verifier value, such as a person, role, or run identifier. Add a unit
-  evidence row only when unit evidence is the meaningful validation for this AC;
-  otherwise keep unit details in the matrix or CI summary.
-  If an unresolved critical or major review finding affects validation for this
-  AC, describe the missing observable behavior or validation as a required gap
-  checkbox unless it belongs in Do before merging.
+  Repeat one subsection per relevant AC. Keep this section evidence-only and
+  checkbox-free. Include only information that helps a reviewer or tester
+  understand coverage, gaps, and whether manual exercise is still needed.
 -->
-- <Platform> test: <command, workflow job, tool, or harness>, <environment>[, <link, verifier, or ISO>]
-<!--
-  Include every known blocking gap that the operator must consciously review
-  or resolve before merge. Use `Test gap:` to describe missing coverage or an
-  unresolved validation concern that keeps the matrix cell at `❌`. Do not use
-  required unchecked `Test gap:` rows for non-blocking caveats. Treat CI that
-  must rerun after a fix as a required test gap unless the operator must
-  manually trigger or inspect a specific job. Delete unused placeholder
-  checkbox rows.
-  Example: - [ ] ⚠️ Test gap: <blocking observable behavior or validation not verified>
--->
-- [ ] ⚠️ Test gap: <blocking observable behavior, missing coverage, or unresolved validation concern>
-<!--
-  For a non-blocking gap represented by a `⚠️` matrix cell, use prose or an
-  explicitly optional checkbox. Optional checkboxes must include
-  `pr-checkbox: optional` immediately above the row. For example, write prose
-  like `Non-blocking gap: <known caveat accepted for this PR>.` Or, when a
-  visible acknowledgement row is useful, put `pr-checkbox: optional` in an
-  HTML comment immediately above an unchecked `⚠️ Non-blocking gap:` checkbox.
--->
-<!--
-  Include every known operator action below any test-gap checkboxes for this
-  AC. Use the literal prefix `Operator check:` for product testing, diff
-  inspection, coverage-report review, review-finding review, deployment
-  evidence review, or other operator work. Include an expected decision or
-  result for each operator check. Do not add generic diff-review
-  checks unless the operator must inspect a specific risk, artifact, or
-  unresolved decision. Do not duplicate a test gap as an operator check unless
-  the operator action can close or validate the gap. Do not add product retest
-  checkboxes for maintainability-only findings unless there is a behavior risk
-  the operator can validate. Keep manual product or workflow validation as an
-  operator check when a human must exercise observable behavior after a gap is
-  fixed. Do not add CI-rerun operator checks unless the operator must manually
-  trigger or inspect a specific job. When updating an existing PR body,
-  preserve every existing manual-review or manual-test instruction under its AC
-  in this checkbox form. Phrase checkbox text in imperative style. Delete
-  unused placeholder checkbox rows.
--->
-- [ ] Operator check: <imperative operator action and expected decision or result>
 
-### AC-<issue>-<n>
+<!--
+  Deferred or out-of-scope ACs still get a subsection so reviewers can see why
+  no testing is reported for them:
 
-Deferred to `<repo-or-follow-up>`.
+  ### AC-<issue>-<n>
+
+  Deferred to `<repo-or-follow-up>`.
+-->
+
+## Testing steps
+
+<!--
+  Add concrete tester actions here. Use checkboxes only in this section or in
+  `## Do before merging`. Steps should cover any `❌` or `⚠️` gaps called out
+  in `## Test coverage` when a human can close or evaluate the gap. If no
+  manual testing is needed, include one checked row explaining why.
+-->
+
+- [ ] <imperative testing step and expected result>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,7 +120,7 @@ Recommended `gh` patterns:
 - PRs: `gh pr create --body-file <path-to-rendered-body>` is the safest path. The rendered body must already follow the template. If you pass `--body` inline, copy every template section name and order verbatim before filling them in.
 - Issues: `gh issue create --template bug_report.md` or `--template feature_request.md` lets `gh` start from the canonical file. If you pass `--body` inline, mirror the template's headings the same way.
 
-Do not invent alternative section names (e.g. `Out of scope`, `Verification`, `Notes`) when the template uses different ones – extend an existing section instead, or open a follow-up to update the template itself. The PR-body acceptance-criteria rules under [Commit & Pull Request Guidelines](#commit--pull-request-guidelines) are a refinement of the template's `Acceptance criteria` section, not a replacement for it.
+Do not invent alternative section names (e.g. `Out of scope`, `Verification`, `Notes`) when the template uses different ones – extend an existing section instead, or open a follow-up to update the template itself. The PR-body acceptance-criteria rules under [Commit & Pull Request Guidelines](#commit--pull-request-guidelines) are a refinement of the template's `Test coverage` and `Testing steps` sections, not a replacement for them.
 
 ## GitHub Actions pinning
 
@@ -225,10 +225,11 @@ Use the final intended squash commit title as the PR title.
 
 GitHub issue titles are different: write them as plain-language summaries of the problem or request. Do not use conventional-commit prefixes like `docs:` or `feat:` in issue titles.
 
-When an issue defines acceptance criteria, include an `Acceptance criteria` section in the PR description.
+When an issue defines acceptance criteria, include matching AC entries in the PR description's `Test coverage` section and put human tester actions in `Testing steps`.
 
-- Use one `### AC-<issue>-<n>` heading per relevant AC, with the heading containing only the AC ID.
-- Put a short outcome summary on the line below the heading.
-- Put verification steps directly under the AC they validate.
-- Use checkboxes only for operator actions that must happen before merge.
-- If an AC is deferred or out of scope for the repo, say so in the summary text and do not add fake checkboxes.
+- Use one `### AC-<issue>-<n>` heading per relevant AC inside `Test coverage`, with the heading containing only the AC ID.
+- Put only tester-useful coverage context under each AC: what was validated, where it ran, evidence, gaps or caveats, and whether manual testing is still needed.
+- Do not use checkboxes in `Test coverage`.
+- Use checkboxes for human tester actions only in `Testing steps`, and for pre-merge operator actions only in `Do before merging`.
+- Make `Testing steps` cover any `❌` or `⚠️` coverage gaps when a human can close or evaluate the gap.
+- If an AC is deferred or out of scope for the repo, say so under its `Test coverage` heading and do not add fake checkboxes.

--- a/docs/ac-traceability.md
+++ b/docs/ac-traceability.md
@@ -20,19 +20,24 @@ ACs describe observable behavior, not implementation steps. Prefer "the template
 
 ## From issue to PR
 
-The PR body mirrors the issue's ACs using the `### AC-<issue>-<n>` heading-per-AC format specified in [`AGENTS.md`](../AGENTS.md). One heading per relevant AC, a short outcome summary, and checkboxes only for operator actions that must happen before merge. Do not restate those rules here – extend `AGENTS.md` if they need to change.
+The PR body mirrors the issue's ACs using the
+`### AC-<issue>-<n>` heading-per-AC format specified in
+[`AGENTS.md`](../AGENTS.md). One heading per relevant AC lives inside
+`## Test coverage`, where it carries only tester-useful coverage context:
+what was validated, where it ran, evidence, gaps or caveats, and whether
+manual testing is still needed. Human tester action items live in
+`## Testing steps`, not under the AC coverage entries.
 
-Test coverage and per-AC verification rows – a `## Test coverage` matrix with
-`Unit` plus the affected supported-platform columns, symbol-only status cells,
-compact colon-style platform test rows (`- <Platform> test: <command, workflow
-job, tool, or harness>, <environment>[, <link, verifier, or ISO>]`), required
-gap checkboxes for merge-blocking missing/failing/pending validation, and prose
-or explicitly optional checkbox explanations for known non-blocking gaps – are
+Test coverage details – a `## Test coverage` matrix with `Unit` plus the
+affected supported-platform columns, symbol-only status cells, compact
+colon-style evidence rows
+(`- Evidence: <Platform> test: <command, workflow job, tool, or harness>,
+<environment>[, <link, verifier, or ISO>]`), prose gap explanations for
+missing/failing/pending or non-blocking validation, and no checkboxes – are
 defined by the canonical PR template at
 [`.github/pull_request_template.md`](../.github/pull_request_template.md).
 The template comments are the source of truth for the coverage matrix,
-slim-test grammar, per-AC unit-test detail rule, per-AC content order,
-operator-check rule, checkbox imperative-style rule, status-symbol rule, matrix
-consistency rule, platform-evidence-or-gap rule, observable test-gap rule,
-optional non-blocking gap rule, placeholder deletion rule, and
-gap-acknowledgement rule; do not duplicate that grammar here.
+evidence-row grammar, per-AC coverage order, testing-step rule, checkbox
+section rule, status-symbol rule, matrix consistency rule,
+platform-evidence-or-gap rule, placeholder deletion rule, and gap explanation
+rule; do not duplicate that grammar here.

--- a/docs/superpowers/plans/2026-05-05-90-pr-template-should-make-context-evidence-and-testing-plan.md
+++ b/docs/superpowers/plans/2026-05-05-90-pr-template-should-make-context-evidence-and-testing-plan.md
@@ -1,0 +1,505 @@
+# Plan: PR template should make context, evidence, and testing instructions self-explanatory to reviewers [#90](https://github.com/patinaproject/bootstrap/issues/90)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the canonical PR template's `## What changed`, `## Test coverage`, and `## Acceptance criteria` sections legible to a first-time reviewer reading the rendered body, by adding ~10–13 rendered lines (R1–R4 in the design) to the bootstrap template source and round-tripping the change to the repo root template — without touching the machine-validated per-AC grammar.
+
+**Architecture:** Single template-edit PR. Edit the bootstrap template source under `skills/bootstrap/templates/core/.github/pull_request_template.md` first, mirror to the root `.github/pull_request_template.md` so the two files stay byte-identical (round-trip discipline per AGENTS.md and design R8/AC-90-4). The CI script `scripts/check-pr-template-checkboxes.mjs` and its fixtures are out of scope and must keep passing unchanged (design R5 + Verification "Machine-validation regression check"). `docs/ac-traceability.md` is checked for direct contradiction only and edited only if one is found.
+
+**Tech Stack:** Markdown, `markdownlint-cli2`, Node.js (existing CI script `scripts/check-pr-template-checkboxes.mjs`), Husky + commitlint, the local `bootstrap` skill in realignment mode.
+
+**Authoritative inputs:**
+
+- Design: `docs/superpowers/specs/2026-05-05-90-pr-template-should-make-context-evidence-and-testing-design.md` (commit `d8434e5`).
+- AGENTS.md "Commit type selection" path-first rule: any change touching `skills/bootstrap/templates/**` or `.github/pull_request_template.md` is `feat:` or `fix:`. This PR adds shipped behavior, so it is `feat:`.
+- AGENTS.md "Source of truth for repo baseline": `.github/pull_request_template.md` is mirrored from `skills/bootstrap/templates/core/.github/pull_request_template.md` via the `bootstrap` skill in realignment mode. Hand-editing only the root regresses the next bootstrapped repo.
+- `docs/ac-traceability.md`: AC-ID convention and the fact that the PR template is the source of truth for the colon-style evidence row grammar (this plan must not contradict that).
+- Current state: as of this plan's authoring, root `.github/pull_request_template.md` and the bootstrap source template are byte-identical (`cmp -s` exits 0).
+
+**Out of scope (do not change in this PR):**
+
+- `scripts/check-pr-template-checkboxes.mjs` (R5).
+- Any fixture under `scripts/fixtures/pr-template-checkboxes/` (R5).
+- The labels `Test gap:`, `Non-blocking gap:`, `Operator check:`, the colon-style evidence row, and the `<!-- pr-checkbox: optional -->` marker (R5, design red flags).
+- Adding a top-level `## How to verify` / `## Verification` / `## Testing instructions` / `## Manual test plan` section (R5 non-goal).
+- Repo-specific build-acquisition copy (iOS, TestFlight, Vercel, `npm install`, `pip install`, `terraform plan`) in the rendered body (R6).
+- `docs/ac-traceability.md` content edits unless a direct contradiction is found.
+
+---
+
+## File structure
+
+Two files change, both with the same final content. Round-trip parity is enforced by `cmp -s`.
+
+- Modify: `skills/bootstrap/templates/core/.github/pull_request_template.md` — source of truth; the implementer edits this first.
+- Modify: `.github/pull_request_template.md` — root mirror; produced by running the `bootstrap` skill in realignment mode against this repo and accepting its proposed root diff. Must be byte-identical to the source after the edit.
+
+No new files. No script changes. No fixture changes.
+
+## Workstreams
+
+- **W1 — Template edit (R1, R2, R3, R4 in source).** Tasks T1–T4 land all four rendered prompts in the bootstrap source template.
+- **W2 — Round-trip mirror (R8, AC-90-4).** Task T5 produces the byte-identical root mirror via the bootstrap skill in realignment mode.
+- **W3 — Sanity & regression checks.** Task T6 verifies `docs/ac-traceability.md` has no direct contradiction with the new rendered orientation. Task T7 runs `scripts/check-pr-template-checkboxes.mjs` to confirm the per-AC grammar still parses. Task T8 runs `markdownlint-cli2` on changed files. Task T9 runs the rendered-visibility greps from the design's GREEN-phase verifier.
+- **W4 — Commit.** Task T10 stages the template change and the root mirror together and commits with a `feat:` message per AGENTS.md path-first rule.
+
+---
+
+## Task 1 — T1: Restructure `## What changed` to render `Context:` and the rationale-bearing bullet shape (R1, AC-90-1)
+
+**Files:**
+
+- Modify: `skills/bootstrap/templates/core/.github/pull_request_template.md` — the `## What changed` section (lines 24–26 in the current file: heading, blank line, single empty bullet `-`).
+
+**Goal:** The rendered template body must, after the author fills it, contain a `Context:` line and bullets that pair the change with its rationale. Detailed how-to-phrase guidance stays in HTML comments per template convention; the rendered body shows the *placeholder structure*, not lecturing prose.
+
+- [ ] **Step 1: Read the current `## What changed` section to ground the edit**
+
+  Open `skills/bootstrap/templates/core/.github/pull_request_template.md` and locate the `## What changed` heading and the empty bullet beneath it.
+
+- [ ] **Step 2: Replace the empty bullet with a rendered `Context:` placeholder line and a rationale-bearing bullet shape, and add an HTML comment that documents the placeholder semantics for authors**
+
+  Replace this block:
+
+  ```markdown
+  ## What changed
+
+  -
+  ```
+
+  With this block:
+
+  ```markdown
+  ## What changed
+
+  Context: <prior PR, prior QA pass, or follow-up issue this PR builds on, or `standalone — <reason>` when there is none>
+
+  - <change> — <why>
+
+  <!--
+    The rendered `Context:` line and `- <change> — <why>` bullet shape are the
+    structural placeholders this section requires. Replace `<...>` with actual
+    values; do not delete the `Context:` line. When this PR has no prior
+    context, write `Context: standalone — <reason>` (e.g.
+    `Context: standalone — first pass on the new lint rule`). One bullet per
+    change; the `— <why>` half states the rationale (user-visible reason or
+    triggering observation), not a restatement of the change.
+  -->
+  ```
+
+  Rules the implementer must follow when typing this in:
+
+  - Use the exact ASCII `--` em-dash placeholder character `—` (U+2014). The codebase already uses `—` in the design and verifier wording, so this matches.
+  - Keep the rendered `Context:` line at exactly one line (R7 calibration: R1 ≈ 1 rendered line plus the bullet-shape change).
+  - The bullet stays as a single placeholder bullet so the rendered template is still ~one screen above `## Acceptance criteria`.
+  - Do not add a rendered "fill these in" prose sentence above or below the placeholder. Author guidance lives in the HTML comment.
+
+- [ ] **Step 3: Verify the rendered body now carries `Context:` and the rationale bullet shape**
+
+  Run, from the worktree root:
+
+  ```bash
+  sed -e '/<!--/,/-->/d' skills/bootstrap/templates/core/.github/pull_request_template.md | grep -F 'Context:'
+  sed -e '/<!--/,/-->/d' skills/bootstrap/templates/core/.github/pull_request_template.md | grep -F '— <why>'
+  ```
+
+  Expected: each command prints the matching line at least once and exits 0.
+
+**AC traceability:** AC-90-1 (rendered structure forces context + per-bullet rationale).
+
+**Verification method:** rendered-visibility grep above (HTML-comment-stripped). Aggregate verification in T9.
+
+---
+
+## Task 2 — T2: Add a rendered four-symbol legend under `## Test coverage` (R2, AC-90-2)
+
+**Files:**
+
+- Modify: `skills/bootstrap/templates/core/.github/pull_request_template.md` — the `## Test coverage` section, between the heading and the existing HTML comment block (the legend goes *before* the HTML comment so the rendered body shows it; the existing comment block remains as the in-comment reference).
+
+**Goal:** Place the four-symbol legend in the rendered body using #87's already-shipped wording (already present verbatim inside the existing HTML comment at lines 56–62). Move equivalent wording into the rendered body without removing the in-comment copy — the existing comment block also explains the matrix-cell rules and stays.
+
+- [ ] **Step 1: Insert a rendered legend block immediately after the `## Test coverage` heading, before the existing `<!--` block**
+
+  After the line `## Test coverage` and a blank line, insert:
+
+  ```markdown
+  Legend for status cells:
+
+  - ✅ — required validation passed with no known relevant gap for this column.
+  - ⚠️ — validation exists and is sufficient to merge with a known non-blocking gap documented under the AC.
+  - ❌ — required validation is missing, failing, pending, or merge-blocked.
+  - ➖ — not relevant to this AC.
+  ```
+
+  Rules:
+
+  - Use the four symbols exactly as listed (`✅`, `⚠️`, `❌`, `➖`). The `⚠️` glyph is the variation-selector form already used in the existing template; copy it verbatim from the existing HTML comment so byte-equivalence is preserved.
+  - The phrasing must keep the unique anchor phrases the design's GREEN-phase verifier greps for: `required validation passed` (✅), `non-blocking gap documented` (⚠️), `merge-blocked` (❌), `not relevant` (➖). The bullets above contain all four anchors verbatim.
+  - This is 5 rendered lines (1 lead-in + 4 bullets), which fits R7's R2 calibration of 4–6 lines.
+  - Do not delete the existing HTML comment legend at lines 56–62; it explains matrix-cell rules in addition to the symbols and remains useful to authors.
+
+- [ ] **Step 2: Verify each anchor phrase is present in the rendered body**
+
+  ```bash
+  sed -e '/<!--/,/-->/d' skills/bootstrap/templates/core/.github/pull_request_template.md | grep -F 'required validation passed'
+  sed -e '/<!--/,/-->/d' skills/bootstrap/templates/core/.github/pull_request_template.md | grep -F 'non-blocking gap documented'
+  sed -e '/<!--/,/-->/d' skills/bootstrap/templates/core/.github/pull_request_template.md | grep -F 'merge-blocked'
+  sed -e '/<!--/,/-->/d' skills/bootstrap/templates/core/.github/pull_request_template.md | grep -F 'not relevant'
+  ```
+
+  Expected: each command prints at least one line and exits 0.
+
+**AC traceability:** AC-90-2 (symbol legend visible in rendered body).
+
+**Verification method:** four anchor-phrase greps above.
+
+---
+
+## Task 3 — T3: Add a rendered one-line clarification of the `AC` column under `## Test coverage` (R3, AC-90-2)
+
+**Files:**
+
+- Modify: `skills/bootstrap/templates/core/.github/pull_request_template.md` — the `## Test coverage` section, immediately after the legend block from T2 and before the existing HTML comment.
+
+**Goal:** Render one line that defines what the `AC` column references, so a reviewer never opening `docs/ac-traceability.md` can interpret the column.
+
+- [ ] **Step 1: Insert the clarification line after the legend block**
+
+  Add a blank line, then this single rendered line, then a blank line, before the existing `<!--` HTML comment:
+
+  ```markdown
+  The `AC` column references the acceptance-criteria IDs from the linked issue, in `AC-<issue>-<n>` form.
+  ```
+
+  Rules:
+
+  - Exactly one rendered line (R7 R3 calibration: ≈ 1 line).
+  - Must contain the literal phrase `acceptance-criteria IDs` so the design's GREEN-phase verifier grep matches.
+  - Backticks around `AC` and `AC-<issue>-<n>` render as inline code on GitHub; this is intentional.
+
+- [ ] **Step 2: Verify the rendered AC-column clarification anchor is present**
+
+  ```bash
+  sed -e '/<!--/,/-->/d' skills/bootstrap/templates/core/.github/pull_request_template.md | grep -F 'acceptance-criteria IDs'
+  ```
+
+  Expected: prints at least one line and exits 0.
+
+**AC traceability:** AC-90-2 (rendered `AC`-column meaning).
+
+**Verification method:** anchor-phrase grep above.
+
+---
+
+## Task 4 — T4: Add a rendered orientation under `## Acceptance criteria` (R4, AC-90-3)
+
+**Files:**
+
+- Modify: `skills/bootstrap/templates/core/.github/pull_request_template.md` — the `## Acceptance criteria` section, immediately after the heading and before the existing `<!--` HTML comment that documents the per-AC content order.
+
+**Goal:** Two short rendered lines that answer (a) what an evidence row attests to and (b) where reviewers find manual-test steps. Must point at the canonical `Operator check:` rows and at the colon-style evidence row format without retiring or paraphrasing those labels in a way that contradicts `docs/ac-traceability.md`.
+
+- [ ] **Step 1: Insert the orientation block immediately after the `## Acceptance criteria` heading**
+
+  After the heading and a blank line, before the existing `<!--` block, insert:
+
+  ```markdown
+  Evidence rows take the form `<Platform> test: <command, workflow job, tool, or harness>, <environment>[, <link, verifier, or ISO>]` — the trailing field is who or what proves the test ran.
+
+  Reviewers and QA exercising the change manually follow the `Operator check:` rows under each AC.
+  ```
+
+  Rules:
+
+  - 2 rendered prose lines plus the surrounding blank lines (R7 R4 calibration: ≈ 2–3 lines).
+  - Must contain the literal word `evidence` so the design's GREEN-phase verifier grep matches.
+  - Must keep the canonical evidence-row shape verbatim — copy it from the existing HTML comment at line 94 of the current template so the rendered orientation does not drift from the in-comment grammar that `docs/ac-traceability.md` describes.
+  - Must reference the literal label `Operator check:` (with colon and backticks) so the rendered orientation points readers at the existing CI-validated rows rather than inventing a new section name.
+  - Do not enumerate the AC heading structure (outcome, checkboxes); that is already visible from the existing headings and bullets.
+
+- [ ] **Step 2: Verify the rendered AC-section anchors are present**
+
+  ```bash
+  sed -e '/<!--/,/-->/d' skills/bootstrap/templates/core/.github/pull_request_template.md | grep -F 'evidence'
+  sed -e '/<!--/,/-->/d' skills/bootstrap/templates/core/.github/pull_request_template.md | grep -F 'Operator check:'
+  ```
+
+  Expected: each command prints at least one line. The `Operator check:` grep will also match the existing placeholder row at the bottom of the section (line 141 in the current template); that is fine — the assertion is "rendered body mentions `Operator check:`", which is true of the new orientation line as well.
+
+- [ ] **Step 3: Sanity-check the R7 budget**
+
+  ```bash
+  git diff --stat skills/bootstrap/templates/core/.github/pull_request_template.md
+  ```
+
+  Expected: rendered additions across T1–T4 stay within the design's R7 budget (~15 rendered lines combined). HTML comment additions are not counted against the budget but must remain bounded (the only HTML comment added by this plan is the small author-guidance comment in T1).
+
+**AC traceability:** AC-90-3 (rendered orientation answers QA's two unanswered questions).
+
+**Verification method:** anchor-phrase greps above plus diff-stat budget check.
+
+---
+
+## Task 5 — T5: Round-trip the template change to the root via the bootstrap skill in realignment mode (R8, AC-90-4)
+
+**Files:**
+
+- Modify: `.github/pull_request_template.md` — produced by running the `bootstrap` skill in realignment mode and accepting its proposed root diff for this file.
+
+**Goal:** The root template ends byte-identical to the bootstrap template source. Hand-editing the root file directly is forbidden by the design's loophole closure.
+
+- [ ] **Step 1: Confirm pre-state**
+
+  ```bash
+  cmp -s skills/bootstrap/templates/core/.github/pull_request_template.md .github/pull_request_template.md && echo "identical" || echo "drifted"
+  ```
+
+  Expected at this point: `drifted` (T1–T4 just edited the source template). If it prints `identical`, T1–T4 did not save; go back and fix.
+
+- [ ] **Step 2: Trigger the local `bootstrap` skill in realignment mode**
+
+  Invoke the `bootstrap` skill against this repo in realignment mode. The skill is shipped at `skills/bootstrap/SKILL.md` and is also registered as a slash-command/skill on this machine (`bootstrap`). The implementer launches it and instructs it to:
+
+  1. Realign this repository (the worktree at `/Users/tlmader/dev/patinaproject-org/bootstrap/.claude/worktrees/busy-cartwright-e09ba4`) against the bootstrap templates.
+  2. Limit the proposed diff to `.github/pull_request_template.md` (other root files must already be in sync; if the skill reports unrelated drift, halt and surface it to the operator before continuing).
+  3. Apply the proposed root-file change so it matches `skills/bootstrap/templates/core/.github/pull_request_template.md` byte-for-byte.
+
+  If the bootstrap skill is not directly invocable in this environment, the equivalent realignment-mode action for this single file is to copy the source template to the root path verbatim:
+
+  ```bash
+  cp skills/bootstrap/templates/core/.github/pull_request_template.md .github/pull_request_template.md
+  ```
+
+  The implementer should prefer the skill invocation; the `cp` fallback is acceptable only because for this one file realignment mode is a verbatim copy, and the same `cmp -s` check in Step 3 enforces the outcome either way.
+
+- [ ] **Step 3: Verify byte-identical parity**
+
+  ```bash
+  cmp -s skills/bootstrap/templates/core/.github/pull_request_template.md .github/pull_request_template.md && echo "identical" || echo "drifted"
+  ```
+
+  Expected: `identical`. If `drifted`, do not commit; fix the root mirror until `cmp -s` exits 0.
+
+**AC traceability:** AC-90-4 (round-trip parity).
+
+**Verification method:** `cmp -s` exit 0.
+
+---
+
+## Task 6 — T6: Sanity-check `docs/ac-traceability.md` for direct contradiction with the new rendered orientation
+
+**Files:**
+
+- Read-only check: `docs/ac-traceability.md`.
+
+**Goal:** Confirm the rendered orientation added in T4 does not contradict `docs/ac-traceability.md`. The plan's default outcome is "no edit needed" — the design's Implementation Shape #3 says "update only if a direct contradiction exists".
+
+- [ ] **Step 1: Read the relevant paragraph**
+
+  Read the "Test coverage and per-AC verification rows" paragraph in `docs/ac-traceability.md`. It currently states the canonical PR template at `.github/pull_request_template.md` is the source of truth for the colon-style platform-test row format and points at the template's own comments.
+
+- [ ] **Step 2: Compare against T4's wording**
+
+  The T4 orientation states:
+
+  > Evidence rows take the form `<Platform> test: <command, workflow job, tool, or harness>, <environment>[, <link, verifier, or ISO>]` — the trailing field is who or what proves the test ran.
+  > Reviewers and QA exercising the change manually follow the `Operator check:` rows under each AC.
+
+  Verify that this wording is consistent with `docs/ac-traceability.md`'s claim that the template is the source of truth and uses the colon-style row. Both reference the same canonical shape.
+
+- [ ] **Step 3: Decide**
+
+  Expected outcome: no edit to `docs/ac-traceability.md`. The doc already defers grammar to the PR template; T4 paraphrases that grammar verbatim from the existing HTML comment, so no contradiction is introduced.
+
+  If the implementer finds a direct contradiction (e.g. the doc independently states a different evidence-row shape that T4's wording disagrees with), halt and route back to the Brainstormer rather than rewriting requirements yourself.
+
+**AC traceability:** R5 / design Implementation Shape #3 (no scope creep into doc rewrite unless required).
+
+**Verification method:** read-and-decide above; expected default is no change.
+
+---
+
+## Task 7 — T7: Run the per-AC grammar regression check
+
+**Files:**
+
+- Read-only run: `scripts/check-pr-template-checkboxes.mjs` and fixtures under `scripts/fixtures/pr-template-checkboxes/`.
+
+**Goal:** Confirm the existing CI script still parses `Test gap:`, `Non-blocking gap:`, and `Operator check:` correctly against the unchanged fixtures. The new rendered prompts must not break the script (R5).
+
+- [ ] **Step 1: Run the script**
+
+  ```bash
+  node scripts/check-pr-template-checkboxes.mjs
+  ```
+
+  Expected: exit 0 with no error output. The fixtures listed under `scripts/fixtures/pr-template-checkboxes/` (16 files; verified at plan-authoring time) must all still pass. If the script complains about a fixture or about the canonical template, do not modify the fixture or the script — instead halt and re-read T1–T4. The most likely cause is that one of the new rendered lines accidentally introduced a `Test gap:` / `Non-blocking gap:` / `Operator check:` substring outside its expected per-AC location; fix the template wording.
+
+**AC traceability:** R5 (no machine-validated contract drift).
+
+**Verification method:** script exit code.
+
+---
+
+## Task 8 — T8: Run `markdownlint-cli2` on the changed files
+
+**Files:**
+
+- Read-only lint run.
+
+**Goal:** Pre-commit hook (`pre-commit` runs `lint-staged` which invokes `markdownlint-cli2` on staged `*.md`). Run the linter explicitly before staging so commit-time failures are caught early.
+
+- [ ] **Step 1: Lint both changed files**
+
+  ```bash
+  pnpm exec markdownlint-cli2 \
+    skills/bootstrap/templates/core/.github/pull_request_template.md \
+    .github/pull_request_template.md
+  ```
+
+  Expected: exit 0 with no rule violations. If the linter complains about line length, list-marker indentation, or trailing spaces, fix the wording in the bootstrap source template, re-run T5 to mirror to root, then re-run this step.
+
+**AC traceability:** infrastructure (Husky pre-commit gate).
+
+**Verification method:** linter exit code.
+
+---
+
+## Task 9 — T9: Run the full GREEN-phase rendered-visibility verifier from the design
+
+**Goal:** Execute the design's GREEN-phase verification block end to end against the root file, reproducing the design's expected matches.
+
+- [ ] **Step 1: Byte-parity check**
+
+  ```bash
+  cmp -s skills/bootstrap/templates/core/.github/pull_request_template.md .github/pull_request_template.md && echo "OK"
+  ```
+
+  Expected: `OK`.
+
+- [ ] **Step 2: Rendered-visibility anchor greps (R1, R2, R3, R4 in one batch)**
+
+  ```bash
+  STRIPPED=$(sed -e '/<!--/,/-->/d' .github/pull_request_template.md)
+  printf '%s\n' "$STRIPPED" | grep -F 'Context:'
+  printf '%s\n' "$STRIPPED" | grep -F '— <why>'
+  printf '%s\n' "$STRIPPED" | grep -F 'required validation passed'
+  printf '%s\n' "$STRIPPED" | grep -F 'non-blocking gap documented'
+  printf '%s\n' "$STRIPPED" | grep -F 'merge-blocked'
+  printf '%s\n' "$STRIPPED" | grep -F 'not relevant'
+  printf '%s\n' "$STRIPPED" | grep -F 'acceptance-criteria IDs'
+  printf '%s\n' "$STRIPPED" | grep -F 'evidence'
+  ```
+
+  Expected: every grep prints at least one line and exits 0. If any grep prints nothing, the corresponding rendered prompt is missing or the wording lost its anchor phrase; fix it in the bootstrap source template, re-run T5, re-run this step.
+
+- [ ] **Step 3: Token-budget spot-check**
+
+  ```bash
+  git diff --stat skills/bootstrap/templates/core/.github/pull_request_template.md .github/pull_request_template.md
+  ```
+
+  Expected: rendered additions ≈ 10–13 lines combined (R7 budget ~15). If substantially over budget, simplify the wording before committing.
+
+**AC traceability:** AC-90-1, AC-90-2, AC-90-3, AC-90-4 (aggregate verifier).
+
+**Verification method:** all greps + `cmp -s` + diff-stat must succeed.
+
+---
+
+## Task 10 — T10: Stage and commit the template change and the root mirror together
+
+**Files:**
+
+- Stage: `skills/bootstrap/templates/core/.github/pull_request_template.md`
+- Stage: `.github/pull_request_template.md`
+
+**Goal:** One commit covering both the source-of-truth edit and its root mirror, typed `feat:` per AGENTS.md path-first rule (the change touches `skills/bootstrap/templates/**` and `.github/pull_request_template.md`, both product-surface globs).
+
+- [ ] **Step 1: Stage both files explicitly**
+
+  ```bash
+  git add \
+    skills/bootstrap/templates/core/.github/pull_request_template.md \
+    .github/pull_request_template.md
+  ```
+
+  Do not use `git add -A` or `git add .` — AGENTS.md guidance is to stage specific files to avoid sweeping in unrelated changes.
+
+- [ ] **Step 2: Commit with a `feat:` message**
+
+  Use a heredoc for the commit message body. Example title (Reviewer/Finisher may refine on PR creation; the squash-merge title rule requires this exact `type: #issue short description` shape):
+
+  ```bash
+  git commit -m "$(cat <<'EOF'
+  feat: #90 render context, legend, AC column meaning, and evidence orientation
+
+  Adds the smallest set of rendered prompts that close QA's reported parsing
+  gaps without touching the machine-validated per-AC grammar:
+
+  - `## What changed`: rendered `Context:` line and `- <change> — <why>`
+    bullet shape (R1, AC-90-1).
+  - `## Test coverage`: rendered legend for ✅ ⚠️ ❌ ➖ using #87's wording
+    and a one-line clarification of the `AC` column (R2 + R3, AC-90-2).
+  - `## Acceptance criteria`: rendered orientation pointing at the
+    colon-style evidence row format and at `Operator check:` rows for
+    manual exercise (R4, AC-90-3).
+
+  Round-trip: edited the bootstrap template source first, mirrored the
+  root template via the bootstrap skill in realignment mode in the same
+  commit (R8, AC-90-4).
+
+  Out of scope (R5): `scripts/check-pr-template-checkboxes.mjs`, the
+  fixtures under `scripts/fixtures/pr-template-checkboxes/`, and the
+  labels `Test gap:`, `Non-blocking gap:`, `Operator check:`, the
+  colon-style evidence row, and `<!-- pr-checkbox: optional -->`.
+  EOF
+  )"
+  ```
+
+  Rules:
+
+  - Subject line ≤ 72 characters and exactly matches the `type: #<issue> short description` shape (commitlint enforces).
+  - Type is `feat:` (path-first rule: any diff touching `skills/bootstrap/templates/**` or `.github/pull_request_template.md` cannot be `docs:` or `chore:`).
+  - The pre-commit hook will run `markdownlint-cli2` on staged `*.md`. T8 already ran the linter, so this should pass.
+  - Do not skip hooks (`--no-verify` is forbidden by AGENTS.md).
+  - Do not amend a previous commit.
+
+- [ ] **Step 3: Verify the commit landed**
+
+  ```bash
+  git status
+  git log -1 --pretty=fuller
+  ```
+
+  Expected: working tree clean, latest commit is the `feat: #90 ...` commit, both files appear in `git show --stat HEAD`.
+
+**AC traceability:** all four ACs are now backed by a single commit on the working branch; round-trip parity is preserved by staging both files together.
+
+**Verification method:** `git status` clean + `git log` shows the commit + `git show --stat HEAD` lists both files.
+
+---
+
+## Aggregate verification before handoff to Reviewer
+
+Before handing off to Reviewer, the implementer must confirm the following from the worktree root, in this order, and all must succeed:
+
+1. `cmp -s skills/bootstrap/templates/core/.github/pull_request_template.md .github/pull_request_template.md` exits 0.
+2. The eight rendered-visibility greps from T9 Step 2 all match.
+3. `node scripts/check-pr-template-checkboxes.mjs` exits 0.
+4. `pnpm exec markdownlint-cli2 skills/bootstrap/templates/core/.github/pull_request_template.md .github/pull_request_template.md` exits 0.
+5. `git diff --stat HEAD~1 HEAD` shows only the two template files changed; no fixture, script, or unrelated file was touched.
+6. `git log -1 --pretty=%s` matches the regex `^feat: #90 .+` and is ≤ 72 characters.
+
+If any of these fail, the implementer fixes the wording in the bootstrap source template, re-runs T5, and re-runs the aggregate checks. Do not adjust `scripts/check-pr-template-checkboxes.mjs`, fixtures, or `docs/ac-traceability.md` to make a check pass — those are out-of-scope per design R5.
+
+## Blockers
+
+None at plan-authoring time. The design is approved, the source-of-truth and root template are byte-identical pre-edit (`cmp -s` confirmed), the CI script and fixtures exist and are intentionally untouched, and the bootstrap skill is available at `skills/bootstrap/SKILL.md`.
+
+## Self-review notes
+
+- **Spec coverage:** R1 ↔ T1; R2 ↔ T2; R3 ↔ T3; R4 ↔ T4; R5 ↔ T7 (regression check) + W3 scope guard; R6 ↔ rules embedded in T1, T2, T4 (no surface-specific copy in rendered body); R7 ↔ T4 Step 3 + T9 Step 3 budget checks; R8 ↔ T5 + T9 Step 1; R9 ↔ ownership clauses in design preserved (no plan task changes ownership). All four ACs (AC-90-1..AC-90-4) have at least one task whose verification step is the design's named verifier for that AC.
+- **No placeholders:** every step contains the exact wording, command, file path, and expected output the implementer needs.
+- **Type consistency:** the four anchor phrases (`required validation passed`, `non-blocking gap documented`, `merge-blocked`, `not relevant`) are used identically in T2 (template wording), T9 (verifier greps), and align with the design's GREEN-phase verifier. The colon-style evidence row format is reproduced verbatim across T4 (template wording) and the design's Cross-Reference paragraph.

--- a/docs/superpowers/plans/2026-05-05-90-pr-template-should-make-context-evidence-and-testing-plan.md
+++ b/docs/superpowers/plans/2026-05-05-90-pr-template-should-make-context-evidence-and-testing-plan.md
@@ -4,7 +4,20 @@
 
 **Goal:** Make the canonical PR template's `## What changed`, `## Test coverage`, and `## Acceptance criteria` sections legible to a first-time reviewer reading the rendered body, by adding ~10–13 rendered lines (R1–R4 in the design) to the bootstrap template source and round-tripping the change to the repo root template — without touching the machine-validated per-AC grammar.
 
-**Architecture:** Single template-edit PR. Edit the bootstrap template source under `skills/bootstrap/templates/core/.github/pull_request_template.md` first, mirror to the root `.github/pull_request_template.md` so the two files stay byte-identical (round-trip discipline per AGENTS.md and design R8/AC-90-4). The CI script `scripts/check-pr-template-checkboxes.mjs` and its fixtures are out of scope and must keep passing unchanged (design R5 + Verification "Machine-validation regression check"). `docs/ac-traceability.md` is checked for direct contradiction only and edited only if one is found.
+**Approved revision after Hillary feedback:** Expand the implementation into a
+contract migration. Retire the separate `## Acceptance criteria` PR-body section,
+move each `### AC-<issue>-<n>` coverage entry into `## Test coverage`, forbid
+checkboxes in `## Test coverage`, and add a top-level `## Testing steps` section
+whose checkboxes carry human tester actions. Update validator logic, fixtures,
+`docs/ac-traceability.md`, and AGENTS guidance to match.
+
+Supersession note: tasks or out-of-scope bullets below that say the old
+`Test gap:`, `Non-blocking gap:`, or `Operator check:` grammar must be
+preserved unchanged, that `## Acceptance criteria` remains the manual-testing
+location, or that validator/docs/fixture edits are forbidden are pre-Hillary
+plan context and are superseded by this approved revision.
+
+**Architecture:** Template and validator PR. Edit bootstrap template sources under `skills/bootstrap/templates/core/**` first, mirror to the root files so source and emitted baseline stay byte-identical where applicable. The CI script `scripts/check-pr-template-checkboxes.mjs`, its tests/fixtures, `docs/ac-traceability.md`, and `AGENTS.md` are in scope because the approved revision changes where AC coverage and tester actions live.
 
 **Tech Stack:** Markdown, `markdownlint-cli2`, Node.js (existing CI script `scripts/check-pr-template-checkboxes.mjs`), Husky + commitlint, the local `bootstrap` skill in realignment mode.
 

--- a/docs/superpowers/specs/2026-05-05-90-pr-template-should-make-context-evidence-and-testing-design.md
+++ b/docs/superpowers/specs/2026-05-05-90-pr-template-should-make-context-evidence-and-testing-design.md
@@ -33,6 +33,31 @@ considered and dropped: it requires updating
 demand persists after this PR lands, it can be reopened as a
 separate issue with explicit contract-migration scope.
 
+## Approved Revision: Merge AC Coverage And Add Testing Steps
+
+Post-publication reviewer feedback from Hillary changed the chosen
+shape: the issue should perform the contract migration now. The
+separate `## Acceptance criteria` section is retired from the PR
+template. Its per-AC content moves into `## Test coverage`, where
+each `### AC-<issue>-<n>` subsection contains only tester-useful
+coverage information: what was validated, where it ran, evidence,
+known gaps or caveats, and whether manual testing is still needed.
+No checkboxes are allowed in `## Test coverage`.
+
+A new top-level `## Testing steps` section carries human tester
+actions as checkboxes. The template should encourage authors to add
+steps that cover any `❌` or `⚠️` coverage gaps when a human can
+close or evaluate the gap. This revision intentionally updates the
+PR-readiness validator, fixtures, `docs/ac-traceability.md`, and
+agent PR-body guidance so the new rendered contract is enforceable.
+
+Supersession note: any earlier or later wording in this artifact that
+describes `Test gap:`, `Non-blocking gap:`, or `Operator check:` rows
+as preserved, keeps manual testing under `## Acceptance criteria`, or
+treats validator/docs/fixture updates as out of scope is historical
+context from the pre-Hillary design and is superseded by this approved
+revision.
+
 ## Requirements
 
 - R1: The `## What changed` section forces linked prior context
@@ -107,6 +132,11 @@ separate issue with explicit contract-migration scope.
   rationale, and matrix cells that contradict the rendered legend.
   Per-AC content (evidence rows, `Test gap:`, `Operator check:`)
   remains owned per the existing PR-template grammar.
+- R10: The approved Hillary-feedback revision supersedes R4/R5/R9
+  where they point reviewers at `Operator check:` rows under
+  `## Acceptance criteria`. Per-AC coverage now lives under
+  `## Test coverage` with no checkboxes, and human tester actions
+  live under `## Testing steps` as checkboxes.
 
 ## Non-Goals
 

--- a/docs/superpowers/specs/2026-05-05-90-pr-template-should-make-context-evidence-and-testing-design.md
+++ b/docs/superpowers/specs/2026-05-05-90-pr-template-should-make-context-evidence-and-testing-design.md
@@ -59,19 +59,19 @@ separate issue with explicit contract-migration scope.
   acceptance-criteria IDs from the linked issue, in
   `AC-<issue>-<n>` form"), so a non-author reviewer can interpret
   the column without prior context from `docs/ac-traceability.md`.
-- R4: The `## Acceptance criteria` section opens with a brief
-  rendered orientation that names the per-AC content, the
-  evidence-row shape, and where reviewers find manual-test
-  instructions. Example wording (Planner picks final copy): "Each
-  AC has an outcome summary, evidence rows in the form
-  `<Platform> test: <command>, <environment>[, <verifier>]`, and
-  any blocking `Test gap:` / `Operator check:` checkboxes the
-  operator must resolve before merge. Reviewers and QA exercising
-  the change manually follow the `Operator check:` rows." The
-  orientation answers QA's "what does evidence mean?" *and* "how
-  do I test this?" questions without retiring the canonical
-  grammar `docs/ac-traceability.md` and the CI script depend on,
-  and without inventing a parallel top-level section.
+- R4: The `## Acceptance criteria` section opens with two short
+  rendered lines that close the two specific gaps QA reported:
+  what an evidence row attests to, and where reviewers find
+  manual-test steps. Example wording (Planner picks final copy):
+  "Evidence rows take the form `<Platform> test: <command>,
+  <environment>[, <verifier>]` — verifier is who or what proves
+  the test ran. Reviewers and QA exercising the change manually
+  follow the `Operator check:` rows under each AC." The
+  orientation does not enumerate AC structure (outcome,
+  checkboxes) that is already visible from the section's headings
+  and bullets, and does not retire the canonical grammar
+  `docs/ac-traceability.md` and the CI script depend on, and does
+  not invent a parallel top-level section.
 - R5: The change does not retire or rename the existing
   machine-validated per-AC grammar (`Test gap:`,
   `Non-blocking gap:`, `Operator check:`, the colon-style evidence

--- a/docs/superpowers/specs/2026-05-05-90-pr-template-should-make-context-evidence-and-testing-design.md
+++ b/docs/superpowers/specs/2026-05-05-90-pr-template-should-make-context-evidence-and-testing-design.md
@@ -2,333 +2,266 @@
 
 ## Intent
 
-Make the canonical pull request template legible to a first-time reviewer
-without forcing them to open the markdown source. Today, load-bearing
-guidance — per-bullet rationale and linked context for `## What changed`,
-the test-coverage symbol legend, the `AC` column meaning, and the
-definition of "evidence" — lives in HTML comments, invisible to QA,
-GitHub mobile, and anyone reading the rendered PR body. The
-`## Acceptance criteria` section, even when filled, reads as a form
-(`<Platform> test: <command>, <environment>`) with corporate-flavored
-labels (`Operator check:`, `Test gap:`) that obscure what a reviewer
-actually has to do.
+Make the canonical pull request template legible to a first-time
+reviewer without forcing them to open the markdown source. Today,
+load-bearing guidance — per-bullet rationale and linked context for
+`## What changed`, the test-coverage symbol legend, the `AC` column
+meaning, and the definition of "evidence" — lives in HTML comments,
+invisible to QA, GitHub mobile, and anyone reading the rendered PR
+body. QA reading a recent PR could not parse what `AC` and "evidence"
+referred to and could not reconstruct what the PR addressed from the
+rendered bullets alone.
 
-This design lands two changes: rendered prompts/definitions for the
-parts a reviewer needs to read at all (legend, AC column meaning,
-evidence definition, structural placeholders under `## What changed`),
-and a humanized rewrite of `## Acceptance criteria` that uses natural
-prose and reviewer-friendly labels — and absorbs the role of "tell a
-reviewer how to exercise the change" into per-AC reviewer-confirm
-steps, scoped to the AC's outcome. There is no separate
-`## How to verify` section: per-AC confirm steps replace it.
+This design lands the smallest set of rendered prompts and
+definitions that close those specific gaps, while leaving the
+machine-validated per-AC grammar (`Test gap:`, `Non-blocking gap:`,
+`Operator check:`, the colon-style evidence row) intact. #87 already
+shipped: the new `⚠️` legend wording, the `<!-- pr-checkbox: optional
+-->` marker, the prose-vs-checkbox rule for blocking vs non-blocking
+gaps, and the supporting CI script (`scripts/check-pr-template-checkboxes.mjs`)
+that depends on those labels. #90 coordinates with #87 by adopting
+its legend wording into the rendered body and by leaving its
+machine-readable contract untouched.
+
+A larger humanization pass on the per-AC entries (renaming
+`Operator check:` to `Confirm by:`, prose-style verification
+sentences, dropping `Test gap:` in favor of `Open concerns:`) was
+considered and dropped: it requires updating
+`scripts/check-pr-template-checkboxes.mjs` and
+`docs/ac-traceability.md` to match, which expands scope past
+"rendered-body legibility" into a contract migration. If reviewer
+demand persists after this PR lands, it can be reopened as a
+separate issue with explicit contract-migration scope.
 
 ## Requirements
 
-- R1: The `## What changed` section forces linked prior context (prior
-  PR, prior QA pass, follow-up issue) and per-bullet rationale into the
-  rendered body via the rendered template *structure*, not via rendered
-  instructive prose. Concretely: a rendered `Context:` line the author
-  replaces with the actual context (or `Context: standalone — <reason>`
-  when there is none) and a rendered bullet shape that pairs the change
-  with its rationale (e.g. `- <change> — <why>`). Detailed
-  *instructions* — what counts as "context", how to phrase rationale —
-  remain in HTML comments per PR-template convention. The rendered
-  body's job is to show *filled output*, not to lecture authors. This
-  closes the QA failure mode (bullets without context or rationale)
-  without adding rendered prompt prose that reviewers must skim past.
-- R2: The `## Test coverage` section renders a visible legend defining
-  `✅`, `❌`, `⚠️`, `➖` with the same meanings already documented in the
-  HTML comments and aligned with the `⚠️` semantics in #87 (validation
-  exists with a known non-blocking gap is `⚠️`; merge-blocking missing
-  or failing validation is `❌`). The legend lives in the rendered
-  body, not in a comment.
-- R3: The `## Test coverage` section renders a one-line clarification
-  of the `AC` column ("`AC` references the acceptance-criteria IDs
-  from the linked issue, in `AC-<issue>-<n>` form"), so a non-author
-  reviewer can interpret the column without prior context from
-  `docs/ac-traceability.md`.
+- R1: The `## What changed` section forces linked prior context
+  (prior PR, prior QA pass, follow-up issue) and per-bullet
+  rationale into the rendered body via the rendered template
+  *structure*, not via rendered instructive prose. Concretely: a
+  rendered `Context:` line the author replaces with the actual
+  context (or `Context: standalone — <reason>` when there is none)
+  and a rendered bullet shape that pairs the change with its
+  rationale (e.g. `- <change> — <why>`). Detailed *instructions* —
+  what counts as "context", how to phrase rationale — remain in
+  HTML comments per PR-template convention. The rendered body's
+  job is to show *filled output*, not to lecture authors.
+- R2: The `## Test coverage` section renders a visible legend
+  defining `✅`, `❌`, `⚠️`, `➖` using the wording #87 already
+  shipped: `✅` = required validation passed with no known relevant
+  gap; `⚠️` = validation exists and is sufficient to merge with a
+  known non-blocking gap documented under the AC; `❌` = required
+  validation is missing, failing, pending, or merge-blocked; `➖` =
+  not relevant to this AC. The legend lives in the rendered body,
+  not in a comment.
+- R3: The `## Test coverage` section renders a one-line
+  clarification of the `AC` column ("`AC` references the
+  acceptance-criteria IDs from the linked issue, in
+  `AC-<issue>-<n>` form"), so a non-author reviewer can interpret
+  the column without prior context from `docs/ac-traceability.md`.
 - R4: The `## Acceptance criteria` section opens with a one-line
-  rendered orientation that names the three things each AC entry
-  carries: a plain-language outcome, prose-style verification
-  description, and concrete reviewer-confirm steps. The orientation
-  replaces the current HTML-comment-only definition of the per-AC
-  grammar.
-- R5: Per-AC entries are humanized. Each `### AC-<issue>-<n>`
-  heading carries the AC's human-readable title alongside its ID
-  (`### AC-<issue>-<n>: <title>`) so reviewers can scan the
-  acceptance-criteria section by headline rather than ID. The body
-  under each AC heading uses these labeled prose blocks in this order:
-  - **Outcome:** one or two sentences of plain language stating the
-    current reviewer-relevant result, including any unresolved
-    blockers or pending validation.
-  - **Verified by:** prose sentence naming who verified, in what
-    environment, with what command/workflow job/tool/harness, and an
-    optional link or run identifier. The rendered template shows this
-    label as a placeholder line — the existing colon-grammar
-    (`<Platform> test: <command>, <environment>[, <link>]`) is
-    retired.
-  - **Confirm by:** numbered or bulleted steps a reviewer or QA
-    tester can follow to exercise this AC's outcome, plus an
-    explicit *Expected:* line stating what they should see. These
-    steps absorb the role formerly proposed for a top-level
-    `## How to verify` section: there is no separate `How to verify`
-    block; reviewer-confirm steps live with the AC they verify. When
-    no manual confirmation is needed, the author writes
-    `Confirm by: not applicable — <one-line reason>` rather than
-    omitting the slot.
-  - **Open concerns:** prose listing of unresolved validation
-    concerns, known gaps, or merge-blocking issues. This replaces
-    the current `Test gap:` checkbox grammar; concerns that block
-    merge are surfaced here in prose, not as a checkbox the
-    operator might miss. The block is optional when there are no
-    open concerns: omit it entirely rather than writing
-    `Open concerns: None`. Reviewers treat absence as "no concerns";
-    Reviewer/Finisher push back when the block is present but
-    empty, contains a placeholder, or omits a known concern they
-    surface.
-
-True pre-merge operator actions that are not scoped to a single AC
-(e.g. "rotate the production secret after deploy") live in the
-optional top-level `## Do before merging` section, as they do today.
-The humanized AC grammar deliberately does not add a per-AC
-`Before merging:` block: AC-scoped reviewer actions are already
-covered by `Confirm by:` plus its `Expected:` line, and a per-AC
-label collides confusingly with the top-level
-`## Do before merging` heading.
-
-- R6: The `## How to verify` section is *not* added. The role it would
-  have played (telling a reviewer how to exercise the change) is
-  absorbed into per-AC `Confirm by:` blocks under R5,
-  scoped to the AC's outcome. This avoids a top-level recipe duplicating
-  per-AC gating steps and prevents authors from maintaining the same
-  instructions in two places.
-- R7: The rendered template body must not bake product-surface-specific
-  build-acquisition language for any surface (mobile, web, CLI,
-  library, infra) into either the rendered prompts or the per-AC
-  reviewer-confirm placeholders. Repo-specific examples (native build
-  location, web build URL, CLI install command, library import
-  snippet, infra dry-run command) live in HTML comments as
-  illustrative hints. The reviewer-confirm content an author writes in
-  a real PR is repo-specific by nature; the *template* stays
+  rendered orientation that names the per-AC content and the
+  evidence-row shape, e.g. "Each AC has an outcome summary, evidence
+  rows in the form `<Platform> test: <command>, <environment>[,
+  <link or verifier>]`, and any blocking `Test gap:` /
+  `Operator check:` checkboxes the operator must resolve before
+  merge." The orientation answers QA's "what does evidence mean?"
+  question without retiring the canonical grammar `## What changed`,
+  `docs/ac-traceability.md`, and the CI script depend on.
+- R5: The change does not retire or rename the existing
+  machine-validated per-AC grammar (`Test gap:`,
+  `Non-blocking gap:`, `Operator check:`, the colon-style evidence
+  row, the `<!-- pr-checkbox: optional -->` marker). Retiring those
+  labels would require migrating
+  `scripts/check-pr-template-checkboxes.mjs` and
+  `docs/ac-traceability.md`, which is out of scope for "make the
+  rendered body legible". A future issue may revisit the labels
+  with explicit contract-migration scope.
+- R6: The rendered template body must not bake
+  product-surface-specific build-acquisition language for any
+  surface (mobile, web, CLI, library, infra) into the new
+  rendered prompts. Repo-specific examples live in HTML comments
+  as illustrative hints; the rendered body stays
   product-surface-agnostic.
-- R8: The template body's added rendered prose stays under a
+- R7: The template body's added rendered prose stays under a
   token-efficiency budget. Target: the diff against the current
-  template adds no more than roughly 30 rendered lines (excluding
-  HTML comments) for the structural rendered prompts (R1–R4), plus
-  no more than roughly 15 rendered lines for the per-AC humanized
-  grammar in the *placeholder* AC entry the template ships. Total
-  rendered cap: ~45 lines. Expected landing zone is ~30. Each
-  individual rendered prompt is one to three lines.
-- R9: Root `.github/pull_request_template.md` remains byte-identical
-  to the bootstrap template source at
+  template adds no more than roughly 15 rendered lines (excluding
+  HTML comments) across R1–R4. Calibration: R1 ≈ 1 line plus a
+  bullet-shape change, R2 ≈ 4–6 lines (one per symbol or compact
+  list), R3 ≈ 1 line, R4 ≈ 1–2 lines. Each individual rendered
+  prompt is one to three lines.
+- R8: Root `.github/pull_request_template.md` remains
+  byte-identical to the bootstrap template source at
   `skills/bootstrap/templates/core/.github/pull_request_template.md`.
-  The edit lands in the template first; the root file is mirrored via
-  the bootstrap skill in realignment mode in the same PR.
-- R10: `docs/ac-traceability.md` is updated to reflect the humanized
-  per-AC grammar (prose verification, `Confirm by`, `Open concerns`).
-  The previous colon-grammar evidence-row form, `Test gap:`, and
-  `Operator check:` labels are retired and the doc must not present
-  them as canonical. Updates are limited to bringing the doc in sync
-  with the new template; the AC ID convention and Given/When/Then
-  phrasing for issue-side ACs are unchanged.
-- R11: PR authors and Superteam `Finisher` own filling the rendered
-  context placeholder under `## What changed`, choosing matrix cells
-  against the rendered legend, writing prose-style verification
-  sentences under each AC, writing `Confirm by` steps
-  (or `not applicable — <reason>`), and listing `Open concerns` (or
-  `None`). `Reviewer` and `Finisher` own flagging missing or
-  placeholder values before publish-state readiness — including a
-  bare `not applicable` (no reason), an unfilled `How a reviewer can
-  confirm:` block, missing `Open concerns:` (must be `None` when
-  empty), and matrix cells that contradict the rendered legend.
-- R12: The change coordinates with #87. If #87 has not landed at merge
-  time, the rendered legend in this PR uses the #87 wording and #87's
-  template-side legend edit becomes a fast-follow mirror, not a
-  competing rewrite. The two PRs do not land conflicting legend copy.
+  The edit lands in the template first; the root file is mirrored
+  via the bootstrap skill in realignment mode in the same PR.
+- R9: PR authors and Superteam `Finisher` own filling the rendered
+  context placeholder under `## What changed` and choosing matrix
+  cells against the rendered legend. `Reviewer` and `Finisher` own
+  flagging missing or placeholder values before publish-state
+  readiness — including unfilled `Context:` lines, bullets without
+  rationale, and matrix cells that contradict the rendered legend.
+  Per-AC content (evidence rows, `Test gap:`, `Operator check:`)
+  remains owned per the existing PR-template grammar.
 
 ## Non-Goals
 
-- Do not redesign the test-coverage matrix schema, the AC ID grammar,
-  or the issue-side Given/When/Then convention. This issue is about
-  rendered-body legibility, not a new schema.
+- Do not redesign the test-coverage matrix schema, the AC ID
+  grammar, or the issue-side Given/When/Then convention.
 - Do not adopt QA's literal section names (`Summary`, `Verification`,
-  `QA findings → AC mapping`, `AC platform coverage`, `Testing
-  instructions`). Their feedback is interpreted, not transcribed.
-- Do not add a top-level `## How to verify` (or any equivalent name)
-  to the canonical template. Reviewer-confirm steps live per-AC.
-- Do not bake mobile/web/CLI/library/infra-specific build-acquisition
-  copy into the canonical template body.
-- Do not add automated PR-body linting for the new humanized AC
-  grammar in this issue.
-- Do not adopt "QA findings → AC mapping" as a canonical section. The
-  underlying need (linking corrective work to the AC it satisfies) is
-  served by the humanized per-AC structure.
+  `QA findings → AC mapping`, `AC platform coverage`,
+  `Testing instructions`).
+- Do not add a top-level `## How to verify` (or any equivalent
+  name) to the canonical template. Reviewer-facing manual exercise
+  instructions stay in `Operator check:` rows under each AC, where
+  the existing CI gate already validates them.
+- Do not retire or rename `Test gap:`, `Non-blocking gap:`,
+  `Operator check:`, or the colon-style evidence row. #87 just
+  shipped CI validation against those exact labels; renaming
+  requires a contract migration that is out of scope for this
+  issue.
+- Do not update `scripts/check-pr-template-checkboxes.mjs` or
+  `docs/ac-traceability.md` beyond what the rendered prompts
+  require for self-consistency (e.g. if a rendered prompt
+  paraphrases the colon-grammar, ac-traceability.md must not
+  contradict the paraphrase).
+- Do not bake mobile/web/CLI/library/infra-specific
+  build-acquisition copy into the canonical template body.
+- Do not duplicate `docs/ac-traceability.md` content inside the PR
+  body.
+- Do not adopt "QA findings → AC mapping" as a canonical section.
 
 ## Acceptance Criteria
 
-- AC-90-1: Given an author opens the PR template, when they fill the
-  `## What changed` section, then the rendered template structure
-  (a `Context:` line and a bullet shape that pairs each change with a
-  rationale) forces linked prior context and per-bullet rationale into
-  the rendered body. Detailed how-to-phrase instructions may stay in
-  HTML comments per template convention; the *output* in the rendered
-  body must show context and rationale, not lingering template prose.
-- AC-90-2: Given a reviewer opens a rendered PR body, when they read
-  the `## Test coverage` matrix, then the symbol legend
-  (`✅ ❌ ⚠️ ➖`) and the meaning of the `AC` column are visible in
-  the rendered body without opening the markdown source.
-- AC-90-3: Given a reviewer opens a rendered PR body, when they read
-  the `## Acceptance criteria` section, then the section opens with
-  a rendered orientation naming the per-AC blocks (Outcome, Verified
-  by, Confirm by, Open concerns) so the reader can navigate without
-  prior context from `docs/ac-traceability.md`.
-- AC-90-4: Given a reviewer opens a rendered PR body, when they read
-  any per-AC entry, then the entry has a human-readable heading
-  title (`### AC-<issue>-<n>: <title>`), prose-style "Verified by:"
-  verification (not form-grammar), reviewer-friendly labels (`Confirm
-  by:` and `Open concerns:` instead of `Operator check:` and
-  `Test gap:`), and reviewer-confirm steps that tell a reviewer or
-  QA tester how to exercise the AC's outcome (or `not applicable —
-  <reason>` when manual confirmation is not needed).
-- AC-90-5: Given the canonical template under
+- AC-90-1: Given an author opens the PR template, when they fill
+  the `## What changed` section, then the rendered template
+  structure (a `Context:` line and a bullet shape that pairs each
+  change with a rationale) forces linked prior context and
+  per-bullet rationale into the rendered body. Detailed
+  how-to-phrase instructions may stay in HTML comments per template
+  convention; the *output* in the rendered body must show context
+  and rationale, not lingering template prose.
+- AC-90-2: Given a reviewer opens a rendered PR body, when they
+  read the `## Test coverage` matrix, then the symbol legend
+  (`✅ ❌ ⚠️ ➖`) and the meaning of the `AC` column are visible
+  in the rendered body without opening the markdown source.
+- AC-90-3: Given a reviewer opens a rendered PR body, when they
+  read the `## Acceptance criteria` section, then the rendered
+  body answers the questions QA could not answer from the previous
+  template — what evidence rows attest to (verifier, environment,
+  command/workflow job/tool/harness) — by rendering a one-line
+  orientation that points at the canonical colon-style evidence
+  row format the rest of the AC section already uses.
+- AC-90-4: Given the canonical template under
   `skills/bootstrap/templates/core/.github/pull_request_template.md`
-  changes, when the bootstrap skill runs in realignment mode against
-  this repo, then the root `.github/pull_request_template.md` matches
-  the template byte-for-byte (round-trip parity).
+  changes, when the bootstrap skill runs in realignment mode
+  against this repo, then the root
+  `.github/pull_request_template.md` matches the template
+  byte-for-byte (round-trip parity).
 
 ## Implementation Shape
 
 1. Edit `skills/bootstrap/templates/core/.github/pull_request_template.md`:
-   - Restructure `## What changed` so the rendered template carries a
-     `Context:` line and a bullet shape that pairs change with
-     rationale (e.g. `- <change> — <why>`). Keep detailed instructions
-     in HTML comments per template convention (R1, AC-90-1).
+   - Restructure `## What changed` so the rendered template carries
+     a `Context:` line and a bullet shape that pairs change with
+     rationale (e.g. `- <change> — <why>`). Keep detailed
+     instructions in HTML comments per template convention (R1,
+     AC-90-1).
    - Add a rendered legend block under `## Test coverage` defining
-     the four symbols with the #87-aligned wording (R2, R12, AC-90-2).
+     the four symbols using the #87-shipped wording (R2, AC-90-2).
    - Add a one-line rendered clarification of the `AC` column in
      `## Test coverage` (R3, AC-90-2).
-   - Add a one-line rendered orientation under `## Acceptance criteria`
-     naming the per-AC labeled blocks (R4, AC-90-3).
-   - Restructure the placeholder AC entry to use the humanized
-     grammar: heading title appended to the AC ID; **Outcome:**,
-     **Verified by:**, **Confirm by:**, **Open concerns:** labeled
-     blocks (Open concerns shown only as commented illustrative
-     example, since real PRs omit it when there are none); retire
-     the colon-grammar evidence row, the `Test gap:` checkbox, and
-     the `Operator check:` checkbox label (R5, AC-90-4).
-   - Keep the rendered additions within the R8 token-efficiency
+   - Add a one-line rendered orientation under
+     `## Acceptance criteria` naming the per-AC content and
+     pointing at the canonical colon-style evidence row format
+     (R4, AC-90-3).
+   - Leave `Test gap:`, `Non-blocking gap:`, `Operator check:`,
+     the colon-style evidence row, and the
+     `<!-- pr-checkbox: optional -->` marker untouched (R5).
+   - Keep the rendered additions within the R7 token-efficiency
      budget.
-2. Update `docs/ac-traceability.md` to reflect the humanized per-AC
-   grammar; retire references to the colon-grammar evidence row and
-   to `Test gap:` / `Operator check:` labels (R10).
-3. Run the bootstrap skill in realignment mode against this repo,
-   accept the proposed root diff, and commit the template change and
-   the mirrored root change together (R9, AC-90-5).
-4. Cross-link with #87 in the PR body so the legend wording is landed
-   once (R12).
+2. Run the bootstrap skill in realignment mode against this repo,
+   accept the proposed root diff, and commit the template change
+   and the mirrored root change together (R8, AC-90-4).
+3. Sanity-check `docs/ac-traceability.md` for consistency with the
+   new rendered orientation; update only if a direct contradiction
+   exists. The colon-grammar reference must remain canonical.
 
 ## Verification
 
 - RED-phase baseline (record before the template change lands):
   - Confirm the current rendered template body (HTML comments
     stripped) does not contain the four symbol meanings, the `AC`
-    column meaning, an orientation for the AC section, AC headings
-    with titles, or the **Outcome / Verified by / How a reviewer can
-    confirm / Open concerns** labels. Capture this
-    as the failing baseline so the rendered fix is observable.
+    column meaning, an orientation for the AC section, or a
+    `Context:` line under `## What changed`. Capture this as the
+    failing baseline so the rendered fix is observable.
   - Confirm the root and template files are already byte-identical
     (`cmp -s`) so any later drift is attributable to the change.
 - GREEN-phase rendered checks after the change. Each
-  rendered-visibility check first strips HTML comment blocks so the
-  assertion is "this string appears in the rendered body", not "this
-  string appears anywhere in the file" — because the existing
-  template already mentions these strings inside HTML comments and
-  the failure mode this issue fixes is comment-only guidance. Use a
-  portable strip such as: `sed -e '/<!--/,/-->/d'`.
+  rendered-visibility check first strips HTML comment blocks so
+  the assertion is "this string appears in the rendered body",
+  not "this string appears anywhere in the file" — because the
+  existing template already mentions these strings inside HTML
+  comments and the failure mode this issue fixes is comment-only
+  guidance. Use a portable strip such as:
+  `sed -e '/<!--/,/-->/d'`.
   - `cmp -s skills/bootstrap/templates/core/.github/pull_request_template.md .github/pull_request_template.md`
     exits 0.
-  - `grep -c '<!--' .github/pull_request_template.md` does not
-    increase relative to the count needed to land the new rendered
-    prompts (i.e. new author guidance is in the rendered body, not
-    absorbed into HTML comments).
   - `sed -e '/<!--/,/-->/d' .github/pull_request_template.md | grep -F 'Context:'`
-    matches at least once (the rendered structural placeholder for
-    R1 is in the body, not only in a comment).
+    matches at least once.
   - `sed -e '/<!--/,/-->/d' .github/pull_request_template.md | grep -F '✅'`
-    matches at least once (the symbol is in the rendered body, not
-    only in a comment); analogous checks for `❌`, `⚠️`, and `➖`.
+    matches at least once; analogous checks for `❌`, `⚠️`, `➖`.
   - `sed -e '/<!--/,/-->/d' .github/pull_request_template.md | grep -F 'AC-'`
     matches the rendered `AC` column clarification at least once.
-  - `sed -e '/<!--/,/-->/d' .github/pull_request_template.md | grep -F 'Verified by:'`
-    matches (the humanized verification label is rendered).
-  - `sed -e '/<!--/,/-->/d' .github/pull_request_template.md | grep -F 'Confirm by'`
-    matches.
-  - `sed -e '/<!--/,/-->/d' .github/pull_request_template.md | grep -F 'Open concerns:'`
-    matches.
-  - `sed -e '/<!--/,/-->/d' .github/pull_request_template.md | grep -F 'Before merging:'`
-    finds **no** match in any per-AC entry (the per-AC label was
-    deliberately not added to avoid collision with the top-level
-    `## Do before merging` heading).
-  - `sed -e '/<!--/,/-->/d' .github/pull_request_template.md | grep -F '## How to verify'`
-    finds **no** match (the section was deliberately not added).
-  - `sed -e '/<!--/,/-->/d' .github/pull_request_template.md | grep -F 'Operator check:'`
-    finds **no** match (label retired); analogous check for
-    `Test gap:`.
+  - `sed -e '/<!--/,/-->/d' .github/pull_request_template.md | grep -F 'evidence'`
+    matches the rendered AC-section orientation at least once.
+- Machine-validation regression check: run
+  `node scripts/check-pr-template-checkboxes.mjs` (or its npm
+  alias if one exists) against a fixture PR body that uses the
+  new template; the script must still parse `Test gap:`,
+  `Non-blocking gap:`, and `Operator check:` rows correctly. The
+  existing fixtures under `scripts/fixtures/pr-template-checkboxes/`
+  must still pass without modification.
 - Token-efficiency check: `git diff --stat` against the previous
-  template shows the rendered additions stay within the R8 budget.
+  template shows the rendered additions stay within the R7 budget
+  (≈15 rendered lines).
 - Pressure test: open a sample PR body that uses the new template
   and verify a reader who has never opened
   `docs/ac-traceability.md` can answer (a) what the four symbols
-  mean, (b) what `AC` columns reference, (c) what each per-AC
-  block (Outcome / Verified by / Confirm by / Open
-  concerns) is for, and (d) how to exercise the
-  change for at least one AC by following its
-  `Confirm by` steps.
+  mean, (b) what the `AC` column references, and (c) what an
+  evidence row attests to.
 
 ## Loophole Closure
 
-The new rendered prompts and the humanized AC grammar introduce new
-author/reviewer discipline. The following loopholes must be closed
-explicitly so authors do not regress to invisible guidance or to the
-retired form-grammar.
+The new rendered prompts introduce one new author/reviewer
+discipline (the structural `Context:` placeholder and bullet
+shape). The rest of the change is purely rendering existing
+HTML-comment content, so loophole exposure is small. Closures:
 
-- Forbid moving the new rendered prompts back into HTML comments. "It
-  reads cleaner with the prompt hidden" is not an acceptable
-  rationale; HTML-comment-only guidance is exactly the failure mode
-  this design fixes.
-- Forbid replacing `Confirm by:` with bare `N/A` or
-  bare `not applicable` (no reason). The author must write
-  `not applicable — <one-line reason>`. A bare placeholder is treated
-  as unfilled.
-- Forbid leaving `Open concerns:` empty when concerns exist
-  elsewhere (in review threads, CI failures, or known limitations).
-  Omitting the block when there genuinely are no concerns is
-  acceptable and expected; reviewers treat absence as "no concerns".
-  The forbidden move is surfacing concerns *outside* the AC and
-  hiding them from the per-AC reading.
-- Forbid reintroducing the retired colon-grammar evidence row
-  (`<Platform> test: <command>, <environment>[, <link>]`) or the
-  retired `Test gap:` / `Operator check:` checkbox labels in either
-  the template or the consuming PRs that adopt this template. The
-  humanized grammar replaces them.
+- Forbid moving the new rendered prompts back into HTML comments.
+  HTML-comment-only guidance is exactly the failure mode this
+  design fixes.
+- Forbid retiring `Test gap:`, `Non-blocking gap:`,
+  `Operator check:`, or the colon-style evidence row in this PR.
+  Such a retirement is a contract migration and belongs in a
+  separate issue with explicit scope including
+  `scripts/check-pr-template-checkboxes.mjs` and
+  `docs/ac-traceability.md` updates.
 - Forbid adding a top-level `## How to verify` section, or any
-  equivalent name (`Testing instructions`, `Verification`, `Manual
-  test plan`). Reviewer-confirm steps live per-AC under
-  `Confirm by:`. A top-level recipe duplicates
-  per-AC gating and forces authors to maintain the same content in
-  two places.
-- Forbid baking repo-specific build-acquisition copy (native build
-  location, web build URL, CLI install command, library import
-  snippet, infra dry-run command) into the rendered template body.
-  Such hints belong in HTML comments as illustrative examples; the
-  rendered body must remain product-surface-agnostic.
-- Forbid adding "QA findings → AC mapping" as a canonical section
-  under the guise of "this is what reviewers asked for". The
-  humanized per-AC structure already serves the underlying need.
-- Forbid editing only the root `.github/pull_request_template.md`.
-  Every change must land in the bootstrap template source first and
-  round-trip to root in the same PR; a root-only edit silently
-  regresses every bootstrapped repo on the next realignment.
+  equivalent name (`Testing instructions`, `Verification`,
+  `Manual test plan`). Reviewer-facing manual instructions live
+  per-AC in `Operator check:` rows where the CI gate already
+  validates them.
+- Forbid baking repo-specific build-acquisition copy (native
+  build location, web build URL, CLI install command, library
+  import snippet, infra dry-run command) into the rendered
+  template body. Such hints belong in HTML comments as
+  illustrative examples; the rendered body must remain
+  product-surface-agnostic.
+- Forbid editing only the root
+  `.github/pull_request_template.md`. Every change must land in
+  the bootstrap template source first and round-trip to root in
+  the same PR.
 
 ## Rationalization Resistance
 
@@ -336,121 +269,105 @@ retired form-grammar.
 |--------|---------|
 | "The HTML comment already explains it; rendering is noise." | HTML comments are invisible to QA, GitHub mobile, and screenshot reviewers. The whole point of #90 is that comment-only guidance failed in production. |
 | "I'll keep the legend in the comment because the symbols are obvious." | They were not obvious; QA literally asked what `AC` and `evidence` meant. Render the legend. |
-| "I'll just add a top-level `## How to verify` because it's tidy." | A top-level recipe duplicates per-AC reviewer-confirm steps. R6 deliberately scopes "how to exercise" to the AC it verifies so authors maintain one source of truth. |
-| "The colon-grammar evidence row is more compact than prose." | The grammar QA could not parse is exactly the form `iOS evidence: ...` — they asked what evidence *meant*. Prose ("Verified on iOS by Ted: ran `pnpm test:e2e` against simulator iPhone 15") trades a few characters for legibility. |
-| "`Operator check:` is precise; we should keep it as a per-AC label." | "Operator" is internal jargon and the label collides confusingly with `## Do before merging`. AC-scoped reviewer actions are already covered by `Confirm by:` plus its `Expected:` line; truly PR-level pre-merge actions stay in the optional top-level `## Do before merging`. There is no per-AC pre-merge label. |
-| "We should add `Before merging:` per AC so reviewers know exactly what gates each AC." | The label collides with the top-level `## Do before merging` heading and duplicates the role of `Confirm by:` + `Expected:`. The simpler design has one home for AC-scoped reviewer actions (`Confirm by:`) and one home for PR-level pre-merge ops (top-level `## Do before merging`). |
-| "Every AC should write `Open concerns: None` so reviewers know the author thought about it." | Mandating the empty-`None` row is bloat for a failure mode QA never reported. The block is omitted when there are no concerns; Reviewer/Finisher push back when concerns are visible elsewhere (review threads, CI failures) but absent from the AC. |
-| "`Test gap:` is the canonical label." | It was. The humanized grammar replaces it with prose `Open concerns:` because gaps are not always test gaps (they may be unresolved review findings, deferred validation, or known limitations) and a prose block surfaces them where a missed checkbox does not. |
-| "I'll just put the iOS / TestFlight / Vercel preview steps in the canonical template." | Repo-specific build-acquisition copy is a non-goal. Put it in the consuming repo's `Confirm by` content, not the bootstrap template. |
+| "While we're touching the AC section, let's rename `Operator check:` to `Confirm by:` for legibility." | Rename is a contract migration. #87 just shipped CI validation against `Operator check:`; renaming requires updating `scripts/check-pr-template-checkboxes.mjs`, `docs/ac-traceability.md`, every fixture under `scripts/fixtures/pr-template-checkboxes/`, and every consuming repo's open PRs. That belongs in its own issue. |
+| "Let's at least drop the colon-grammar evidence row in favor of prose." | Same blocker — `docs/ac-traceability.md` and the CI script depend on the colon-grammar. R5 explicitly forbids retirement in this PR. |
+| "I'll just add a top-level `## How to verify` because reviewers ask for it." | A top-level recipe duplicates per-AC `Operator check:` rows the CI gate already validates. The orientation line under `## Acceptance criteria` (R4) tells the reader to look at `Operator check:` rows for manual exercise instructions; that is the answer to QA's "how do I test?" question without inventing a parallel section. |
+| "I'll just put the iOS / TestFlight / Vercel preview steps in the canonical template." | Repo-specific build-acquisition copy is a non-goal. Put it in the consuming repo's `Operator check:` rows, not the bootstrap template. |
 | "I'll edit the root template directly and round-trip later." | Round-trip discipline exists because every bootstrapped repo regresses on the next realignment otherwise. Template-first, mirror in the same PR. |
-| "QA asked for a `Verification` section; I'll add one with that exact name." | Adopt the underlying need, not the literal section name. Per-AC `Confirm by` covers the underlying problem without colliding with QA's older naming. |
-| "Per-bullet rationale will balloon `What changed`." | One rendered structural placeholder (`Context:` plus `— <why>` in the bullet shape) does not balloon anything. The R8 budget keeps rendered additions under ~45 lines combined. |
-| "Author guidance should be rendered too so authors don't ignore it." | PR-template convention puts author instructions in HTML comments. The QA failure mode was about *what the author wrote*, not about a missing visible prompt. The fix is rendered structural placeholders the author *replaces* (`Context:` line, `— <why>` bullets, prose-labeled AC blocks), not rendered prose the reviewer must skim past on every PR. |
+| "QA asked for a `Verification` section; I'll add one with that exact name." | Adopt the underlying need, not the literal section name. Rendering the legend, the `AC` column meaning, and the evidence-row orientation answers QA's parsing problem without inventing a competing section. |
+| "Per-bullet rationale will balloon `What changed`." | One rendered structural placeholder (`Context:` plus `— <why>` in the bullet shape) does not balloon anything. The R7 budget keeps rendered additions under ~15 lines combined. |
+| "Author guidance should be rendered too so authors don't ignore it." | PR-template convention puts author instructions in HTML comments. The QA failure mode was about *what the author wrote*, not about a missing visible prompt. The fix is rendered structural placeholders the author *replaces* (`Context:` line, `— <why>` bullets), not rendered prose the reviewer must skim past on every PR. |
 
 ## Red Flags — STOP and reconsider
 
-- You are about to land a PR-template change as `docs:` or `chore:`.
-  The template is a product-surface glob (path-first rule, AGENTS.md).
-  Use `feat:` or `fix:`.
-- You are about to put the new author prompt, legend, AC clarification,
-  AC-section orientation, or any humanized per-AC label inside
-  `<!-- ... -->`. That is the failure mode this design fixes.
+- You are about to land a PR-template change as `docs:` or
+  `chore:`. The template is a product-surface glob (path-first
+  rule, AGENTS.md). Use `feat:` or `fix:`.
+- You are about to put the new author prompt, legend, AC column
+  clarification, or AC-section orientation inside `<!-- ... -->`.
+  That is the failure mode this design fixes.
+- You are renaming `Operator check:`, `Test gap:`, or
+  `Non-blocking gap:`, or retiring the colon-style evidence row.
+  Stop. R5 explicitly forbids this in #90; reopen as a separate
+  contract-migration issue if the demand is real.
 - You are adding a top-level `## How to verify`, `## Verification`,
-  `## Testing instructions`, or `## Manual test plan` section. Stop.
-  Reviewer-confirm steps live per-AC; the design deliberately avoids
-  a top-level recipe.
-- You are reintroducing `Operator check:`, `Test gap:`, or the
-  colon-grammar evidence row. Stop. The humanized grammar replaces
-  them.
-- You are editing only `.github/pull_request_template.md` and leaving
-  `skills/bootstrap/templates/core/.github/pull_request_template.md`
+  `## Testing instructions`, or `## Manual test plan` section.
+  Stop. The orientation line under `## Acceptance criteria`
+  points readers at `Operator check:` rows, which is where the
+  reviewer-facing manual instructions live.
+- You are editing only `.github/pull_request_template.md` and
+  leaving `skills/bootstrap/templates/core/.github/pull_request_template.md`
   untouched. Stop. Edit the template first, then mirror.
 - You are baking iOS/TestFlight/Vercel/`npm install`/`pip install`/
-  `terraform plan` copy into the rendered body of any AC's
-  `Confirm by:` placeholder. Stop. That copy is
-  repo-specific; the canonical template stays
+  `terraform plan` copy into the rendered body. Stop. That copy
+  is repo-specific; the canonical template stays
   product-surface-agnostic.
-- The diff adds substantially more than the R8 budget of rendered
-  lines. Stop. The fix is meant to be the smallest rendered prompts
-  and grammar updates that make the body legible, not a rewrite.
+- The diff adds substantially more than the R7 budget of rendered
+  lines. Stop. The fix is meant to be the smallest rendered
+  prompts that make the body legible, not a rewrite.
 
 ## Token-Efficiency Targets
 
-- Rendered additions across R1–R4 (structural prompts): ~30 lines or
-  fewer in the rendered body (HTML comments excluded). Each
-  individual rendered prompt is one to three lines.
-- Rendered additions for the humanized placeholder AC entry (R5):
-  ~12 lines or fewer. The four labeled blocks (Outcome / Verified
-  by / Confirm by / Open concerns) are one to three lines each in
-  the placeholder; Open concerns appears only as a commented
-  illustrative example because real PRs omit it when none.
-- Total rendered cap: ~45 lines. Expected landing zone is ~30.
+- Rendered additions across R1–R4 combined: ~15 lines or fewer in
+  the rendered body (HTML comments excluded). Calibration: R1 ≈ 1
+  line plus a bullet-shape change, R2 ≈ 4–6 lines, R3 ≈ 1 line,
+  R4 ≈ 1–2 lines. Each individual rendered prompt is one to three
+  lines.
 - HTML-comment additions are bounded — comments may carry
-  illustrative hints (e.g. example prose-style verification
-  sentences, example `not applicable — <reason>` strings, example
-  `Open concerns:` content) but must not balloon to replace
-  contributor docs.
-- The rendered template, opened on GitHub web at default zoom, should
-  remain scannable in roughly two screens for a typical PR body
-  (matrix on screen one; first AC entry on screen two).
+  illustrative hints but must not balloon to replace contributor
+  docs.
+- The rendered template, opened on GitHub web at default zoom,
+  should remain scannable in roughly one screen above
+  `## Acceptance criteria`, matching the current template's
+  scan-density.
 
 ## Role Ownership
 
 - PR authors and Superteam `Finisher` own filling the rendered
-  context placeholder under `## What changed`, choosing matrix cells
-  against the rendered legend, writing the prose `Verified by:`
-  sentence under each AC, writing `Confirm by:`
-  steps (or `not applicable — <reason>`), listing `Open concerns:`
-  (omitted when there are none), and ticking checkboxes in the
-  optional top-level `## Do before merging` section when PR-level
-  pre-merge actions exist.
+  context placeholder under `## What changed` and choosing matrix
+  cells against the rendered legend.
 - `Reviewer` and `Finisher` own flagging missing or placeholder
-  values before publish-state readiness. Specifically: a bare
-  `not applicable`, an unfilled `Confirm by:`,
-  silent omission of `Open concerns:`, evidence sentences that do
-  not name a verifier/environment/command, or matrix cells that
-  contradict the rendered legend.
-- `Brainstormer` (this artifact) owns the rendered prompts, the
-  humanized grammar, and the loophole-closure language; later
-  issues that refine the prompts must preserve the
-  loophole-closure invariants in this design.
+  values in the new rendered prompts before publish-state
+  readiness — unfilled `Context:` lines, bullets without
+  rationale, and matrix cells that contradict the rendered
+  legend. Per-AC content (evidence rows, `Test gap:`,
+  `Operator check:`) remains owned per the existing CI-validated
+  PR-template grammar.
+- `Brainstormer` (this artifact) owns the rendered prompts and
+  the loophole-closure language; later issues that refine the
+  prompts must preserve the loophole-closure invariants in this
+  design.
 
 ## Stage-Gate Bypass Resistance
 
-- "We can land the template edit without round-tripping" — bypassed
-  by R9 plus the AGENTS.md round-trip discipline; the PR must
-  include both the template change and the root mirror.
-- "We can keep the new section in HTML comments to avoid breaking
-  consumers" — bypassed by R1, R2, R3, R4, R5, which require
-  rendered visibility; HTML-comment-only versions of these prompts
-  do not satisfy the ACs.
-- "We can keep `Operator check:` and `Test gap:` for backwards
-  compatibility" — bypassed by R5 plus the GREEN-phase grep
-  asserting both labels are absent. The humanized grammar replaces
-  them in the canonical template; downstream PRs adopt the new
-  grammar at next template render.
-- "We can drop AC-90-5 because round-trip is implied" — bypassed by
-  R9 and the explicit AC-90-5 verifier; round-trip is part of every
-  template change on this repo and must be observable in the PR.
-- "We can re-introduce `## How to verify` later as a follow-up
-  because reviewers will ask" — bypassed by R6 and the loophole
-  closure forbidding the section; reviewer-confirm steps live
-  per-AC. If a real cross-AC orientation need emerges, it goes in
-  the AC-section orientation line (R4), not in a duplicate
-  top-level recipe.
+- "We can land the template edit without round-tripping" —
+  bypassed by R8 plus the AGENTS.md round-trip discipline; the
+  PR must include both the template change and the root mirror.
+- "We can keep the new prompts in HTML comments to avoid breaking
+  consumers" — bypassed by R1, R2, R3, R4, which require rendered
+  visibility; HTML-comment-only versions of these prompts do not
+  satisfy the ACs.
+- "We can rename `Operator check:` while we're here" — bypassed
+  by R5, the loophole closure, and the red-flag list.
+- "We can drop AC-90-4 because round-trip is implied" — bypassed
+  by R8 and the explicit AC-90-4 verifier; round-trip is part of
+  every template change on this repo and must be observable in
+  the PR.
 
 ## Cross-Reference
 
-- `docs/ac-traceability.md`: AC-ID convention and Given/When/Then
-  phrasing (issue side); per-AC PR-body grammar is updated by R10
-  to match the humanized template.
+- `docs/ac-traceability.md`: AC-ID convention, Given/When/Then
+  phrasing for issue-side ACs, and the canonical PR-body grammar
+  including the colon-style evidence row.
 - `.github/pull_request_template.md`: current canonical template
   (will be mirrored from the bootstrap template source after this
   design's plan and implementation land).
 - `skills/bootstrap/templates/core/.github/pull_request_template.md`:
   source of truth for the canonical template.
-- Issue #87: `⚠️` semantics. Coordinate the rendered legend
-  wording so #90 and #87 do not land conflicting copy.
+- `scripts/check-pr-template-checkboxes.mjs`: machine-validates
+  `Test gap:`, `Non-blocking gap:`, `Operator check:`, and the
+  `<!-- pr-checkbox: optional -->` marker. Untouched by #90.
+- Issue #87: `⚠️` semantics. Already merged; #90 adopts its
+  legend wording into the rendered body.
 - AGENTS.md: path-first commit-type rule (template change is a
   product-surface glob and ships as `feat:`).

--- a/docs/superpowers/specs/2026-05-05-90-pr-template-should-make-context-evidence-and-testing-design.md
+++ b/docs/superpowers/specs/2026-05-05-90-pr-template-should-make-context-evidence-and-testing-design.md
@@ -42,17 +42,22 @@ fixes that work across mobile, web, CLI, library, and infra consumers.
   comment evidence-row grammar. The rendered definition does not duplicate
   the full grammar; it references the existing colon-style row format.
 - R5: The template adds a new rendered section `## How to verify` between
-  `## Test coverage` and `## Acceptance criteria`. The section contains a
-  short rendered author prompt explaining its purpose (give a reviewer or
-  QA tester the steps to exercise the change for this repo's product
-  surface) and an explicit `Not applicable — <one-line reason>` value the
-  author writes when no manual verification is required.
+  `## What changed` (or `## Do before merging` when present) and
+  `## Test coverage`, so the reading order is *context → how a reviewer
+  exercises the change → what the author already verified*. The section
+  contains a short rendered author prompt explaining its purpose (give a
+  reviewer or QA tester the steps to exercise the change for this repo's
+  product surface) and an explicit `Not applicable — <one-line reason>`
+  value the author writes when no manual verification is required.
+  `## How to verify` is reviewer-facing manual-exercise instructions; it
+  is not a place to duplicate AC evidence rows, which already record the
+  author's completed verification claims.
 - R6: The `## How to verify` section is product-surface-agnostic. Its
-  rendered copy must not bake in mobile-specific or web-specific build
-  acquisition language. Repo-specific examples (native build location, web
-  build URL, CLI install command, library import snippet, infra dry-run
-  command) live in HTML comments as illustrative hints, not in the
-  rendered body.
+  rendered copy must not bake in product-surface-specific
+  build-acquisition language for any surface (mobile, web, CLI, library,
+  infra). Repo-specific examples (native build location, web build URL,
+  CLI install command, library import snippet, infra dry-run command)
+  live in HTML comments as illustrative hints, not in the rendered body.
 - R7: When the author writes `Not applicable — <reason>` in
   `## How to verify`, the section is treated as filled, not as a
   placeholder. A bare `Not applicable` with no reason is a placeholder and
@@ -61,9 +66,10 @@ fixes that work across mobile, web, CLI, library, and infra consumers.
 - R8: The template body's added rendered prose (R1, R2, R3, R4, R5
   combined) stays under a token-efficiency budget so the rendered template
   does not balloon. Target: the diff against the current template adds no
-  more than roughly 60 rendered lines (excluding HTML comments) across all
-  five rendered additions, so a freshly opened PR body remains scannable
-  in one screen on GitHub web.
+  more than roughly 30 rendered lines (excluding HTML comments) across all
+  five rendered additions. Calibration: R1≈1, R2≈4–6, R3≈1, R4≈1,
+  R5≈5–8 ≈ 15–20 lines is the expected landing zone; ~30 is the cap, not
+  a target.
 - R9: Root `.github/pull_request_template.md` remains byte-identical to the
   bootstrap template source at
   `skills/bootstrap/templates/core/.github/pull_request_template.md`. The
@@ -143,9 +149,9 @@ fixes that work across mobile, web, CLI, library, and infra consumers.
    - Add a one-line rendered definition of evidence under
      `## Acceptance criteria` (R4, AC-90-3).
    - Insert a new rendered `## How to verify` section between
-     `## Test coverage` and `## Acceptance criteria` with a short prompt,
-     a placeholder value, and a `Not applicable — <reason>` example
-     (R5, R6, R7, AC-90-4).
+     `## What changed` (or `## Do before merging` when present) and
+     `## Test coverage`, with a short prompt, a placeholder value, and a
+     `Not applicable — <reason>` example (R5, R6, R7, AC-90-4).
    - Keep the rendered additions within the R8 token-efficiency budget.
 2. Run the bootstrap skill in realignment mode against this repo, accept
    the proposed root diff, and commit the template change and the
@@ -166,18 +172,29 @@ fixes that work across mobile, web, CLI, library, and infra consumers.
     the rendered fix is observable.
   - Confirm the root and template files are already byte-identical
     (`cmp -s`) so any later drift is attributable to the change.
-- GREEN-phase rendered checks after the change:
+- GREEN-phase rendered checks after the change. Each rendered-visibility
+  check first strips HTML comment blocks so the assertion is "this
+  string appears in the rendered body", not "this string appears
+  anywhere in the file" — because the existing template already mentions
+  these symbols inside HTML comments and the failure mode this issue
+  fixes is comment-only guidance. Use a portable strip such as:
+  `sed -e '/<!--/,/-->/d' .github/pull_request_template.md` (treat the
+  resulting stream as the rendered body for grep purposes).
   - `cmp -s skills/bootstrap/templates/core/.github/pull_request_template.md .github/pull_request_template.md`
     exits 0.
   - `grep -c '<!--' .github/pull_request_template.md` does not increase
     relative to the count needed to land the new rendered prompts (i.e.
     new author guidance is in the rendered body, not absorbed into HTML
     comments).
-  - `grep -F '✅' .github/pull_request_template.md` shows the symbol in
-    rendered context (outside an HTML comment) at least once.
-  - `grep -F '## How to verify' .github/pull_request_template.md` matches.
-  - `grep -F 'Not applicable' .github/pull_request_template.md` matches
-    the rendered placeholder grammar.
+  - `sed -e '/<!--/,/-->/d' .github/pull_request_template.md | grep -F '✅'`
+    matches at least once (the symbol is in the rendered body, not only
+    in a comment); analogous checks for `❌`, `⚠️`, and `➖`.
+  - `sed -e '/<!--/,/-->/d' .github/pull_request_template.md | grep -F 'AC-'`
+    matches the rendered `AC` column clarification at least once.
+  - `sed -e '/<!--/,/-->/d' .github/pull_request_template.md | grep -F '## How to verify'`
+    matches.
+  - `sed -e '/<!--/,/-->/d' .github/pull_request_template.md | grep -F 'Not applicable'`
+    matches the rendered placeholder grammar.
 - Token-efficiency check: `git diff --stat` against the previous
   template shows the rendered additions stay within the R8 budget.
 - Pressure test: open a sample PR body that uses the new template and
@@ -227,6 +244,7 @@ explicitly so authors do not regress to invisible guidance.
 | "Per-bullet rationale will balloon `What changed`." | One rendered line of guidance does not balloon anything. The R8 budget keeps the entire set of rendered additions under roughly 60 lines. |
 | "I'll skip the rendered evidence definition because `docs/ac-traceability.md` already covers it." | The reviewer reading a PR body has not opened `docs/ac-traceability.md` and may not know it exists. A one-line rendered definition is the whole fix. |
 | "`Not applicable` alone is fine; the reason is obvious from context." | If the reason were obvious it would not be the AC failure mode #90 already documented. Require the reason. |
+| "I'll paste the AC evidence rows into `## How to verify` so a reviewer sees them in one place." | `## How to verify` is reviewer-facing manual-exercise instructions ("here's how *you* can run this"). AC evidence rows are author claims of already-completed verification ("here's what *I* ran and where it ran"). Duplicating one into the other doubles the body and erases the distinction. |
 
 ## Red Flags — STOP and reconsider
 
@@ -249,9 +267,10 @@ explicitly so authors do not regress to invisible guidance.
 
 ## Token-Efficiency Targets
 
-- Rendered additions across R1–R5 combined: roughly 60 lines or fewer in
-  the rendered body (HTML comments excluded). Each individual rendered
-  prompt is one to three lines.
+- Rendered additions across R1–R5 combined: ~30 lines or fewer in the
+  rendered body (HTML comments excluded). Expected landing zone is
+  ~15–20 lines (R1≈1, R2≈4–6, R3≈1, R4≈1, R5≈5–8); ~30 is the cap, not
+  a target. Each individual rendered prompt is one to three lines.
 - HTML-comment additions: bounded — comments may carry illustrative
   hints (e.g. example evidence rows, example
   `Not applicable — <reason>` strings) but must not balloon to replace

--- a/docs/superpowers/specs/2026-05-05-90-pr-template-should-make-context-evidence-and-testing-design.md
+++ b/docs/superpowers/specs/2026-05-05-90-pr-template-should-make-context-evidence-and-testing-design.md
@@ -21,11 +21,18 @@ fixes that work across mobile, web, CLI, library, and infra consumers.
 
 ## Requirements
 
-- R1: The `## What changed` section contains a rendered (visible-in-body)
-  one-line author prompt that names the two load-bearing inputs reviewers
-  need: linked prior context (prior PR, prior QA pass, follow-up issue) and
-  a short rationale per bullet. The prompt is concise enough to remain in
-  the rendered body without ballooning the template.
+- R1: The `## What changed` section forces linked prior context (prior
+  PR, prior QA pass, follow-up issue) and per-bullet rationale into the
+  rendered body via the rendered template *structure*, not via rendered
+  instructive prose. Concretely: a rendered `Context:` line the author
+  replaces with the actual context (or `Context: standalone — <reason>`
+  when there is none) and a rendered bullet shape that pairs the change
+  with its rationale (e.g. `- <change> — <why>`). Detailed
+  *instructions* — what counts as "context", how to phrase rationale —
+  remain in HTML comments per PR-template convention. The rendered
+  body's job is to show *filled output*, not to lecture authors. This
+  closes the QA failure mode (bullets without context or rationale)
+  without adding rendered prompt prose that reviewers must skim past.
 - R2: The `## Test coverage` section renders a visible legend defining
   `✅`, `❌`, `⚠️`, `➖` with the same meanings already documented in the
   HTML comments and aligned with the `⚠️` semantics in #87 (validation
@@ -113,9 +120,12 @@ fixes that work across mobile, web, CLI, library, and infra consumers.
 ## Acceptance Criteria
 
 - AC-90-1: Given an author opens the PR template, when they fill the
-  `## What changed` section, then the rendered body — not only an HTML
-  comment — prompts them to surface linked prior context (prior PR, prior
-  QA pass, follow-up issue) and to give each bullet a short rationale.
+  `## What changed` section, then the rendered template structure
+  (a `Context:` line and a bullet shape that pairs each change with a
+  rationale) forces linked prior context and per-bullet rationale into
+  the rendered body. Detailed how-to-phrase instructions may stay in
+  HTML comments per template convention; the *output* in the rendered
+  body must show context and rationale, not lingering template prose.
 - AC-90-2: Given a reviewer opens a rendered PR body, when they read the
   `## Test coverage` matrix, then the symbol legend (`✅ ❌ ⚠️ ➖`) and the
   meaning of the `AC` column are visible in the rendered body without
@@ -140,8 +150,10 @@ fixes that work across mobile, web, CLI, library, and infra consumers.
 ## Implementation Shape
 
 1. Edit `skills/bootstrap/templates/core/.github/pull_request_template.md`:
-   - Add a one-line rendered author prompt under `## What changed`
-     covering linked prior context and per-bullet rationale (R1, AC-90-1).
+   - Restructure `## What changed` so the rendered template carries a
+     `Context:` line and a bullet shape that pairs change with
+     rationale (e.g. `- <change> — <why>`). Keep detailed instructions
+     in HTML comments per template convention (R1, AC-90-1).
    - Add a rendered legend block under `## Test coverage` defining the
      four symbols with the #87-aligned wording (R2, R12, AC-90-2).
    - Add a one-line rendered clarification of the `AC` column in
@@ -186,6 +198,9 @@ fixes that work across mobile, web, CLI, library, and infra consumers.
     relative to the count needed to land the new rendered prompts (i.e.
     new author guidance is in the rendered body, not absorbed into HTML
     comments).
+  - `sed -e '/<!--/,/-->/d' .github/pull_request_template.md | grep -F 'Context:'`
+    matches at least once (the rendered structural placeholder for R1
+    is in the body, not only in a comment).
   - `sed -e '/<!--/,/-->/d' .github/pull_request_template.md | grep -F '✅'`
     matches at least once (the symbol is in the rendered body, not only
     in a comment); analogous checks for `❌`, `⚠️`, and `➖`.
@@ -245,6 +260,7 @@ explicitly so authors do not regress to invisible guidance.
 | "I'll skip the rendered evidence definition because `docs/ac-traceability.md` already covers it." | The reviewer reading a PR body has not opened `docs/ac-traceability.md` and may not know it exists. A one-line rendered definition is the whole fix. |
 | "`Not applicable` alone is fine; the reason is obvious from context." | If the reason were obvious it would not be the AC failure mode #90 already documented. Require the reason. |
 | "I'll paste the AC evidence rows into `## How to verify` so a reviewer sees them in one place." | `## How to verify` is reviewer-facing manual-exercise instructions ("here's how *you* can run this"). AC evidence rows are author claims of already-completed verification ("here's what *I* ran and where it ran"). Duplicating one into the other doubles the body and erases the distinction. |
+| "Author guidance should be rendered too so authors don't ignore it." | PR-template convention puts author instructions in HTML comments. The QA failure mode was about *what the author wrote* (no context, no rationale), not about a missing visible prompt. The fix is rendered structural placeholders the author *replaces* (`Context:` line, `- <change> — <why>` bullets), not rendered prose the reviewer must skim past on every PR. |
 
 ## Red Flags — STOP and reconsider
 

--- a/docs/superpowers/specs/2026-05-05-90-pr-template-should-make-context-evidence-and-testing-design.md
+++ b/docs/superpowers/specs/2026-05-05-90-pr-template-should-make-context-evidence-and-testing-design.md
@@ -3,21 +3,24 @@
 ## Intent
 
 Make the canonical pull request template legible to a first-time reviewer
-without forcing them to open the markdown source. Today, load-bearing author
-guidance (per-bullet rationale and linked context for `## What changed`), the
-test-coverage symbol legend, the `AC` column meaning, and the definition of
-"evidence" all live in HTML comments — invisible to QA, GitHub mobile, and
-anyone reading the rendered PR body. There is also no canonical slot that
-tells a reviewer how to exercise the change, which has caused downstream
-repos to invent ad-hoc sections (e.g. "QA findings → AC mapping",
-"Testing instructions") to fill the gap.
+without forcing them to open the markdown source. Today, load-bearing
+guidance — per-bullet rationale and linked context for `## What changed`,
+the test-coverage symbol legend, the `AC` column meaning, and the
+definition of "evidence" — lives in HTML comments, invisible to QA,
+GitHub mobile, and anyone reading the rendered PR body. The
+`## Acceptance criteria` section, even when filled, reads as a form
+(`<Platform> test: <command>, <environment>`) with corporate-flavored
+labels (`Operator check:`, `Test gap:`) that obscure what a reviewer
+actually has to do.
 
-This design adds the smallest set of rendered prompts and definitions that
-let a reviewer reconstruct *what changed, why, and how to verify it* from
-the rendered body alone, while preserving the existing AC / test-coverage
-grammar and round-trip discipline. It does not adopt QA's literal section
-names; it interprets the underlying reviewer problems and lands rendered
-fixes that work across mobile, web, CLI, library, and infra consumers.
+This design lands two changes: rendered prompts/definitions for the
+parts a reviewer needs to read at all (legend, AC column meaning,
+evidence definition, structural placeholders under `## What changed`),
+and a humanized rewrite of `## Acceptance criteria` that uses natural
+prose and reviewer-friendly labels — and absorbs the role of "tell a
+reviewer how to exercise the change" into per-AC reviewer-confirm
+steps, scoped to the AC's outcome. There is no separate
+`## How to verify` section: per-AC confirm steps replace it.
 
 ## Requirements
 
@@ -36,86 +39,121 @@ fixes that work across mobile, web, CLI, library, and infra consumers.
 - R2: The `## Test coverage` section renders a visible legend defining
   `✅`, `❌`, `⚠️`, `➖` with the same meanings already documented in the
   HTML comments and aligned with the `⚠️` semantics in #87 (validation
-  exists with a known non-blocking gap is `⚠️`; merge-blocking missing or
-  failing validation is `❌`). The legend lives in the rendered body, not
-  in a comment.
-- R3: The `## Test coverage` section renders a one-line clarification of
-  the `AC` column ("`AC` references the acceptance-criteria IDs from the
-  linked issue, in `AC-<issue>-<n>` form"), so a non-author reviewer can
-  interpret the column without prior context from `docs/ac-traceability.md`.
-- R4: The `## Acceptance criteria` section renders a one-line definition of
-  what an evidence row attests to (verifier, environment, command/workflow
-  job/tool/harness), using the same terms already canonical in the HTML
-  comment evidence-row grammar. The rendered definition does not duplicate
-  the full grammar; it references the existing colon-style row format.
-- R5: The template adds a new rendered section `## How to verify` between
-  `## What changed` (or `## Do before merging` when present) and
-  `## Test coverage`, so the reading order is *context → how a reviewer
-  exercises the change → what the author already verified*. The section
-  contains a short rendered author prompt explaining its purpose (give a
-  reviewer or QA tester the steps to exercise the change for this repo's
-  product surface) and an explicit `Not applicable — <one-line reason>`
-  value the author writes when no manual verification is required.
-  `## How to verify` is reviewer-facing manual-exercise instructions; it
-  is not a place to duplicate AC evidence rows, which already record the
-  author's completed verification claims.
-- R6: The `## How to verify` section is product-surface-agnostic. Its
-  rendered copy must not bake in product-surface-specific
-  build-acquisition language for any surface (mobile, web, CLI, library,
-  infra). Repo-specific examples (native build location, web build URL,
-  CLI install command, library import snippet, infra dry-run command)
-  live in HTML comments as illustrative hints, not in the rendered body.
-- R7: When the author writes `Not applicable — <reason>` in
-  `## How to verify`, the section is treated as filled, not as a
-  placeholder. A bare `Not applicable` with no reason is a placeholder and
-  must be rejected by the same placeholder-rejection discipline that
-  governs other sections (e.g. the `Do before merging` rule).
-- R8: The template body's added rendered prose (R1, R2, R3, R4, R5
-  combined) stays under a token-efficiency budget so the rendered template
-  does not balloon. Target: the diff against the current template adds no
-  more than roughly 30 rendered lines (excluding HTML comments) across all
-  five rendered additions. Calibration: R1≈1, R2≈4–6, R3≈1, R4≈1,
-  R5≈5–8 ≈ 15–20 lines is the expected landing zone; ~30 is the cap, not
-  a target.
-- R9: Root `.github/pull_request_template.md` remains byte-identical to the
-  bootstrap template source at
-  `skills/bootstrap/templates/core/.github/pull_request_template.md`. The
-  edit lands in the template first; the root file is mirrored via the
-  bootstrap skill in realignment mode in the same PR.
-- R10: `docs/ac-traceability.md` continues to delegate the detailed PR-body
-  grammar to the canonical PR template. The doc is updated only if a
-  direct contradiction with the new rendered legend or evidence definition
-  exists.
+  exists with a known non-blocking gap is `⚠️`; merge-blocking missing
+  or failing validation is `❌`). The legend lives in the rendered
+  body, not in a comment.
+- R3: The `## Test coverage` section renders a one-line clarification
+  of the `AC` column ("`AC` references the acceptance-criteria IDs
+  from the linked issue, in `AC-<issue>-<n>` form"), so a non-author
+  reviewer can interpret the column without prior context from
+  `docs/ac-traceability.md`.
+- R4: The `## Acceptance criteria` section opens with a one-line
+  rendered orientation that names the three things each AC entry
+  carries: a plain-language outcome, prose-style verification
+  description, and concrete reviewer-confirm steps. The orientation
+  replaces the current HTML-comment-only definition of the per-AC
+  grammar.
+- R5: Per-AC entries are humanized. Each `### AC-<issue>-<n>`
+  heading carries the AC's human-readable title alongside its ID
+  (`### AC-<issue>-<n>: <title>`) so reviewers can scan the
+  acceptance-criteria section by headline rather than ID. The body
+  under each AC heading uses these labeled prose blocks in this order:
+  - **Outcome:** one or two sentences of plain language stating the
+    current reviewer-relevant result, including any unresolved
+    blockers or pending validation.
+  - **Verified by:** prose sentence naming who verified, in what
+    environment, with what command/workflow job/tool/harness, and an
+    optional link or run identifier. The rendered template shows this
+    label as a placeholder line — the existing colon-grammar
+    (`<Platform> test: <command>, <environment>[, <link>]`) is
+    retired.
+  - **How a reviewer can confirm:** numbered or bulleted steps a
+    reviewer or QA tester can follow to exercise this AC's outcome,
+    plus an explicit *Expected:* line stating what they should see.
+    These steps absorb the role formerly proposed for a top-level
+    `## How to verify` section: there is no separate `How to verify`
+    block; reviewer-confirm steps live with the AC they verify. When
+    no manual confirmation is needed, the author writes
+    `How a reviewer can confirm: not applicable — <one-line reason>`
+    rather than omitting the slot.
+  - **Open concerns:** prose listing of unresolved validation
+    concerns, known gaps, or merge-blocking issues, or the literal
+    word `None` when there are none. This replaces the current
+    `Test gap:` checkbox grammar; concerns that block merge are
+    surfaced here in prose, not as a checkbox the operator might
+    miss.
+  - **Before merging:** zero or more checkboxes for AC-scoped
+    operator actions that must be ticked before merge readiness.
+    These replace the current `Operator check:` checkbox label;
+    PR-level pre-merge actions that are not AC-scoped continue to
+    live in the optional `## Do before merging` section.
+- R6: The `## How to verify` section is *not* added. The role it would
+  have played (telling a reviewer how to exercise the change) is
+  absorbed into per-AC `How a reviewer can confirm:` blocks under R5,
+  scoped to the AC's outcome. This avoids a top-level recipe duplicating
+  per-AC gating steps and prevents authors from maintaining the same
+  instructions in two places.
+- R7: The rendered template body must not bake product-surface-specific
+  build-acquisition language for any surface (mobile, web, CLI,
+  library, infra) into either the rendered prompts or the per-AC
+  reviewer-confirm placeholders. Repo-specific examples (native build
+  location, web build URL, CLI install command, library import
+  snippet, infra dry-run command) live in HTML comments as
+  illustrative hints. The reviewer-confirm content an author writes in
+  a real PR is repo-specific by nature; the *template* stays
+  product-surface-agnostic.
+- R8: The template body's added rendered prose stays under a
+  token-efficiency budget. Target: the diff against the current
+  template adds no more than roughly 30 rendered lines (excluding
+  HTML comments) for the structural rendered prompts (R1–R4), plus
+  no more than roughly 15 rendered lines for the per-AC humanized
+  grammar in the *placeholder* AC entry the template ships. Total
+  rendered cap: ~45 lines. Expected landing zone is ~30. Each
+  individual rendered prompt is one to three lines.
+- R9: Root `.github/pull_request_template.md` remains byte-identical
+  to the bootstrap template source at
+  `skills/bootstrap/templates/core/.github/pull_request_template.md`.
+  The edit lands in the template first; the root file is mirrored via
+  the bootstrap skill in realignment mode in the same PR.
+- R10: `docs/ac-traceability.md` is updated to reflect the humanized
+  per-AC grammar (prose verification, `How a reviewer can confirm`,
+  `Open concerns`, `Before merging`). The previous colon-grammar
+  evidence-row form is retired and the doc must not present it as
+  canonical. Updates are limited to bringing the doc in sync with the
+  new template; the AC ID convention and Given/When/Then phrasing for
+  issue-side ACs are unchanged.
 - R11: PR authors and Superteam `Finisher` own filling the rendered
-  context-prompt, legend-driven matrix cells, evidence rows, and
-  `## How to verify` slot. `Reviewer` and `Finisher` own flagging missing
-  or placeholder values before publish-state readiness. A
-  `## How to verify` left as the literal placeholder string from the
-  template (or as bare `Not applicable` with no reason) blocks readiness
-  in the same way an unfilled `## What changed` does today.
+  context placeholder under `## What changed`, choosing matrix cells
+  against the rendered legend, writing prose-style verification
+  sentences under each AC, writing `How a reviewer can confirm` steps
+  (or `not applicable — <reason>`), and listing `Open concerns` (or
+  `None`). `Reviewer` and `Finisher` own flagging missing or
+  placeholder values before publish-state readiness — including a
+  bare `not applicable` (no reason), an unfilled `How a reviewer can
+  confirm:` block, missing `Open concerns:` (must be `None` when
+  empty), and matrix cells that contradict the rendered legend.
 - R12: The change coordinates with #87. If #87 has not landed at merge
-  time, the rendered legend in this PR uses the #87 wording (`⚠️` =
-  validation exists with a known non-blocking gap; `❌` = required
-  validation missing, failing, pending, or merge-blocking) and #87's
-  template-side legend edit becomes a fast-follow mirror, not a competing
-  rewrite. The two PRs do not land conflicting legend copy.
+  time, the rendered legend in this PR uses the #87 wording and #87's
+  template-side legend edit becomes a fast-follow mirror, not a
+  competing rewrite. The two PRs do not land conflicting legend copy.
 
 ## Non-Goals
 
-- Do not redesign the test-coverage matrix schema, the AC ID grammar, or
-  the per-AC content order. This issue is about rendered-body legibility,
-  not a new schema.
+- Do not redesign the test-coverage matrix schema, the AC ID grammar,
+  or the issue-side Given/When/Then convention. This issue is about
+  rendered-body legibility, not a new schema.
 - Do not adopt QA's literal section names (`Summary`, `Verification`,
   `QA findings → AC mapping`, `AC platform coverage`, `Testing
   instructions`). Their feedback is interpreted, not transcribed.
-- Do not bake mobile/web/CLI/library/infra-specific build-acquisition copy
-  into the canonical template body.
-- Do not duplicate `docs/ac-traceability.md` content inside the PR body.
-- Do not add automated PR-body linting for the new
-  `## How to verify` section in this issue.
+- Do not add a top-level `## How to verify` (or any equivalent name)
+  to the canonical template. Reviewer-confirm steps live per-AC.
+- Do not bake mobile/web/CLI/library/infra-specific build-acquisition
+  copy into the canonical template body.
+- Do not add automated PR-body linting for the new humanized AC
+  grammar in this issue.
 - Do not adopt "QA findings → AC mapping" as a canonical section. The
   underlying need (linking corrective work to the AC it satisfies) is
-  already served by the existing per-AC structure.
+  served by the humanized per-AC structure.
 
 ## Acceptance Criteria
 
@@ -126,26 +164,30 @@ fixes that work across mobile, web, CLI, library, and infra consumers.
   the rendered body. Detailed how-to-phrase instructions may stay in
   HTML comments per template convention; the *output* in the rendered
   body must show context and rationale, not lingering template prose.
-- AC-90-2: Given a reviewer opens a rendered PR body, when they read the
-  `## Test coverage` matrix, then the symbol legend (`✅ ❌ ⚠️ ➖`) and the
-  meaning of the `AC` column are visible in the rendered body without
-  opening the markdown source.
-- AC-90-3: Given a reviewer opens a rendered PR body, when they read an
-  evidence row under an AC, then the rendered body conveys what evidence
-  attests to (verifier, environment, command/workflow job/tool/harness)
-  without prior context from `docs/ac-traceability.md` or other
-  contributor docs.
-- AC-90-4: Given a reviewer or QA tester opens the PR body, when they look
-  for a way to verify the change, then the body contains a rendered,
-  discoverable testing-instructions slot (`## How to verify`) that works
-  across repo product surfaces, with an explicit
-  `Not applicable — <reason>` value the author writes when no manual
-  verification is required.
+- AC-90-2: Given a reviewer opens a rendered PR body, when they read
+  the `## Test coverage` matrix, then the symbol legend
+  (`✅ ❌ ⚠️ ➖`) and the meaning of the `AC` column are visible in
+  the rendered body without opening the markdown source.
+- AC-90-3: Given a reviewer opens a rendered PR body, when they read
+  the `## Acceptance criteria` section, then the section opens with a
+  rendered orientation naming the per-AC blocks (Outcome, Verified
+  by, How a reviewer can confirm, Open concerns, Before merging) so
+  the reader can navigate without prior context from
+  `docs/ac-traceability.md`.
+- AC-90-4: Given a reviewer opens a rendered PR body, when they read
+  any per-AC entry, then the entry has a human-readable heading title
+  (`### AC-<issue>-<n>: <title>`), prose-style "Verified by:"
+  verification (not form-grammar), reviewer-friendly labels (`How a
+  reviewer can confirm`, `Open concerns`, `Before merging` instead of
+  `Operator check:` / `Test gap:`), and reviewer-confirm steps that
+  tell a reviewer or QA tester how to exercise the AC's outcome (or
+  `not applicable — <reason>` when manual confirmation is not
+  needed).
 - AC-90-5: Given the canonical template under
   `skills/bootstrap/templates/core/.github/pull_request_template.md`
-  changes, when the bootstrap skill runs in realignment mode against this
-  repo, then the root `.github/pull_request_template.md` matches the
-  template byte-for-byte (round-trip parity).
+  changes, when the bootstrap skill runs in realignment mode against
+  this repo, then the root `.github/pull_request_template.md` matches
+  the template byte-for-byte (round-trip parity).
 
 ## Implementation Shape
 
@@ -154,97 +196,126 @@ fixes that work across mobile, web, CLI, library, and infra consumers.
      `Context:` line and a bullet shape that pairs change with
      rationale (e.g. `- <change> — <why>`). Keep detailed instructions
      in HTML comments per template convention (R1, AC-90-1).
-   - Add a rendered legend block under `## Test coverage` defining the
-     four symbols with the #87-aligned wording (R2, R12, AC-90-2).
+   - Add a rendered legend block under `## Test coverage` defining
+     the four symbols with the #87-aligned wording (R2, R12, AC-90-2).
    - Add a one-line rendered clarification of the `AC` column in
      `## Test coverage` (R3, AC-90-2).
-   - Add a one-line rendered definition of evidence under
-     `## Acceptance criteria` (R4, AC-90-3).
-   - Insert a new rendered `## How to verify` section between
-     `## What changed` (or `## Do before merging` when present) and
-     `## Test coverage`, with a short prompt, a placeholder value, and a
-     `Not applicable — <reason>` example (R5, R6, R7, AC-90-4).
-   - Keep the rendered additions within the R8 token-efficiency budget.
-2. Run the bootstrap skill in realignment mode against this repo, accept
-   the proposed root diff, and commit the template change and the
-   mirrored root change together (R9, AC-90-5).
-3. Review `docs/ac-traceability.md` for direct contradictions with the
-   new rendered legend or evidence definition; update only if needed
-   (R10).
+   - Add a one-line rendered orientation under `## Acceptance criteria`
+     naming the per-AC labeled blocks (R4, AC-90-3).
+   - Restructure the placeholder AC entry to use the humanized
+     grammar: heading title appended to the AC ID; **Outcome:**,
+     **Verified by:**, **How a reviewer can confirm:**, **Open
+     concerns:**, **Before merging:** labeled blocks; retire the
+     colon-grammar evidence row, the `Test gap:` checkbox, and the
+     `Operator check:` checkbox label (R5, AC-90-4).
+   - Keep the rendered additions within the R8 token-efficiency
+     budget.
+2. Update `docs/ac-traceability.md` to reflect the humanized per-AC
+   grammar; retire references to the colon-grammar evidence row and
+   to `Test gap:` / `Operator check:` labels (R10).
+3. Run the bootstrap skill in realignment mode against this repo,
+   accept the proposed root diff, and commit the template change and
+   the mirrored root change together (R9, AC-90-5).
 4. Cross-link with #87 in the PR body so the legend wording is landed
    once (R12).
 
 ## Verification
 
 - RED-phase baseline (record before the template change lands):
-  - Confirm the current rendered template body (HTML comments stripped)
-    does not contain the four symbol meanings, the `AC` column meaning,
-    a definition of evidence, the per-bullet-rationale prompt, or a
-    `## How to verify` section. Capture this as the failing baseline so
-    the rendered fix is observable.
+  - Confirm the current rendered template body (HTML comments
+    stripped) does not contain the four symbol meanings, the `AC`
+    column meaning, an orientation for the AC section, AC headings
+    with titles, or the **Outcome / Verified by / How a reviewer can
+    confirm / Open concerns / Before merging** labels. Capture this
+    as the failing baseline so the rendered fix is observable.
   - Confirm the root and template files are already byte-identical
     (`cmp -s`) so any later drift is attributable to the change.
-- GREEN-phase rendered checks after the change. Each rendered-visibility
-  check first strips HTML comment blocks so the assertion is "this
-  string appears in the rendered body", not "this string appears
-  anywhere in the file" — because the existing template already mentions
-  these symbols inside HTML comments and the failure mode this issue
-  fixes is comment-only guidance. Use a portable strip such as:
-  `sed -e '/<!--/,/-->/d' .github/pull_request_template.md` (treat the
-  resulting stream as the rendered body for grep purposes).
+- GREEN-phase rendered checks after the change. Each
+  rendered-visibility check first strips HTML comment blocks so the
+  assertion is "this string appears in the rendered body", not "this
+  string appears anywhere in the file" — because the existing
+  template already mentions these strings inside HTML comments and
+  the failure mode this issue fixes is comment-only guidance. Use a
+  portable strip such as: `sed -e '/<!--/,/-->/d'`.
   - `cmp -s skills/bootstrap/templates/core/.github/pull_request_template.md .github/pull_request_template.md`
     exits 0.
-  - `grep -c '<!--' .github/pull_request_template.md` does not increase
-    relative to the count needed to land the new rendered prompts (i.e.
-    new author guidance is in the rendered body, not absorbed into HTML
-    comments).
+  - `grep -c '<!--' .github/pull_request_template.md` does not
+    increase relative to the count needed to land the new rendered
+    prompts (i.e. new author guidance is in the rendered body, not
+    absorbed into HTML comments).
   - `sed -e '/<!--/,/-->/d' .github/pull_request_template.md | grep -F 'Context:'`
-    matches at least once (the rendered structural placeholder for R1
-    is in the body, not only in a comment).
+    matches at least once (the rendered structural placeholder for
+    R1 is in the body, not only in a comment).
   - `sed -e '/<!--/,/-->/d' .github/pull_request_template.md | grep -F '✅'`
-    matches at least once (the symbol is in the rendered body, not only
-    in a comment); analogous checks for `❌`, `⚠️`, and `➖`.
+    matches at least once (the symbol is in the rendered body, not
+    only in a comment); analogous checks for `❌`, `⚠️`, and `➖`.
   - `sed -e '/<!--/,/-->/d' .github/pull_request_template.md | grep -F 'AC-'`
     matches the rendered `AC` column clarification at least once.
-  - `sed -e '/<!--/,/-->/d' .github/pull_request_template.md | grep -F '## How to verify'`
+  - `sed -e '/<!--/,/-->/d' .github/pull_request_template.md | grep -F 'Verified by:'`
+    matches (the humanized verification label is rendered).
+  - `sed -e '/<!--/,/-->/d' .github/pull_request_template.md | grep -F 'How a reviewer can confirm'`
     matches.
-  - `sed -e '/<!--/,/-->/d' .github/pull_request_template.md | grep -F 'Not applicable'`
-    matches the rendered placeholder grammar.
+  - `sed -e '/<!--/,/-->/d' .github/pull_request_template.md | grep -F 'Open concerns:'`
+    matches.
+  - `sed -e '/<!--/,/-->/d' .github/pull_request_template.md | grep -E 'Before merging:?'`
+    matches the AC-scoped pre-merge label.
+  - `sed -e '/<!--/,/-->/d' .github/pull_request_template.md | grep -F '## How to verify'`
+    finds **no** match (the section was deliberately not added).
+  - `sed -e '/<!--/,/-->/d' .github/pull_request_template.md | grep -F 'Operator check:'`
+    finds **no** match (label retired); analogous check for
+    `Test gap:`.
 - Token-efficiency check: `git diff --stat` against the previous
   template shows the rendered additions stay within the R8 budget.
-- Pressure test: open a sample PR body that uses the new template and
-  verify a reader who has never opened `docs/ac-traceability.md` can
-  answer (a) what the four symbols mean, (b) what `AC` columns reference,
-  (c) what an evidence row attests to, (d) how to verify the change or
-  why no manual verification is needed.
+- Pressure test: open a sample PR body that uses the new template
+  and verify a reader who has never opened
+  `docs/ac-traceability.md` can answer (a) what the four symbols
+  mean, (b) what `AC` columns reference, (c) what each per-AC
+  block (Outcome / Verified by / How a reviewer can confirm / Open
+  concerns / Before merging) is for, and (d) how to exercise the
+  change for at least one AC by following its
+  `How a reviewer can confirm` steps.
 
 ## Loophole Closure
 
-The new rendered prompts and the `## How to verify` section introduce new
+The new rendered prompts and the humanized AC grammar introduce new
 author/reviewer discipline. The following loopholes must be closed
-explicitly so authors do not regress to invisible guidance.
+explicitly so authors do not regress to invisible guidance or to the
+retired form-grammar.
 
 - Forbid moving the new rendered prompts back into HTML comments. "It
-  reads cleaner with the prompt hidden" is not an acceptable rationale;
-  HTML-comment-only guidance is exactly the failure mode this design
-  fixes.
-- Forbid replacing `## How to verify` with a bare `N/A` or
-  `Not applicable` (no reason). The author must write
-  `Not applicable — <one-line reason>`. A bare placeholder is treated as
-  unfilled.
+  reads cleaner with the prompt hidden" is not an acceptable
+  rationale; HTML-comment-only guidance is exactly the failure mode
+  this design fixes.
+- Forbid replacing `How a reviewer can confirm:` with bare `N/A` or
+  bare `not applicable` (no reason). The author must write
+  `not applicable — <one-line reason>`. A bare placeholder is treated
+  as unfilled.
+- Forbid omitting `Open concerns:` from a per-AC entry. When there
+  are none, the author writes `Open concerns: None`. Silent omission
+  is treated as unfilled.
+- Forbid reintroducing the retired colon-grammar evidence row
+  (`<Platform> test: <command>, <environment>[, <link>]`) or the
+  retired `Test gap:` / `Operator check:` checkbox labels in either
+  the template or the consuming PRs that adopt this template. The
+  humanized grammar replaces them.
+- Forbid adding a top-level `## How to verify` section, or any
+  equivalent name (`Testing instructions`, `Verification`, `Manual
+  test plan`). Reviewer-confirm steps live per-AC under
+  `How a reviewer can confirm:`. A top-level recipe duplicates
+  per-AC gating and forces authors to maintain the same content in
+  two places.
 - Forbid baking repo-specific build-acquisition copy (native build
-  location, web build URL, CLI install command, library import snippet,
-  infra dry-run command) into the rendered template body. Such hints
-  belong in HTML comments as illustrative examples; the rendered body
-  must remain product-surface-agnostic.
-- Forbid adding "QA findings → AC mapping" as a canonical section under
-  the guise of "this is what reviewers asked for". The underlying need
-  is already served by the existing per-AC structure; reintroducing the
-  ad-hoc section would duplicate AC content.
-- Forbid editing only the root `.github/pull_request_template.md`. Every
-  change must land in the bootstrap template source first and round-trip
-  to root in the same PR; a root-only edit silently regresses every
-  bootstrapped repo on the next realignment.
+  location, web build URL, CLI install command, library import
+  snippet, infra dry-run command) into the rendered template body.
+  Such hints belong in HTML comments as illustrative examples; the
+  rendered body must remain product-surface-agnostic.
+- Forbid adding "QA findings → AC mapping" as a canonical section
+  under the guise of "this is what reviewers asked for". The
+  humanized per-AC structure already serves the underlying need.
+- Forbid editing only the root `.github/pull_request_template.md`.
+  Every change must land in the bootstrap template source first and
+  round-trip to root in the same PR; a root-only edit silently
+  regresses every bootstrapped repo on the next realignment.
 
 ## Rationalization Resistance
 
@@ -252,91 +323,117 @@ explicitly so authors do not regress to invisible guidance.
 |--------|---------|
 | "The HTML comment already explains it; rendering is noise." | HTML comments are invisible to QA, GitHub mobile, and screenshot reviewers. The whole point of #90 is that comment-only guidance failed in production. |
 | "I'll keep the legend in the comment because the symbols are obvious." | They were not obvious; QA literally asked what `AC` and `evidence` meant. Render the legend. |
-| "`How to verify` doesn't apply to this repo / this PR is doc-only / this is a release PR." | Then write `Not applicable — <one-line reason>`. The slot exists precisely so the author has to make that decision visible. |
-| "I'll just put the iOS / TestFlight / Vercel preview steps in the canonical template." | Repo-specific build-acquisition copy is a non-goal. Put it in the consuming repo, not the bootstrap template. |
+| "I'll just add a top-level `## How to verify` because it's tidy." | A top-level recipe duplicates per-AC reviewer-confirm steps. R6 deliberately scopes "how to exercise" to the AC it verifies so authors maintain one source of truth. |
+| "The colon-grammar evidence row is more compact than prose." | The grammar QA could not parse is exactly the form `iOS evidence: ...` — they asked what evidence *meant*. Prose ("Verified on iOS by Ted: ran `pnpm test:e2e` against simulator iPhone 15") trades a few characters for legibility. |
+| "`Operator check:` is precise; renaming to `Before merging:` loses meaning." | "Operator" is internal jargon for the human running the workflow. Reviewers reading a PR body are operators by another name; `Before merging:` says exactly when they act and is reviewer-readable. AC-scoped pre-merge actions live there; PR-level pre-merge actions stay in the optional top-level `## Do before merging`. |
+| "`Test gap:` is the canonical label." | It was. The humanized grammar replaces it with prose `Open concerns:` because gaps are not always test gaps (they may be unresolved review findings, deferred validation, or known limitations) and a prose block surfaces them where a missed checkbox does not. |
+| "I'll just put the iOS / TestFlight / Vercel preview steps in the canonical template." | Repo-specific build-acquisition copy is a non-goal. Put it in the consuming repo's `How a reviewer can confirm` content, not the bootstrap template. |
 | "I'll edit the root template directly and round-trip later." | Round-trip discipline exists because every bootstrapped repo regresses on the next realignment otherwise. Template-first, mirror in the same PR. |
-| "QA asked for a `Verification` section; I'll add one with that exact name." | Adopt the underlying need, not the literal section name. The current template's `## Test coverage` plus the new `## How to verify` covers the underlying problem without colliding with QA's older naming. |
-| "Per-bullet rationale will balloon `What changed`." | One rendered line of guidance does not balloon anything. The R8 budget keeps the entire set of rendered additions under roughly 60 lines. |
-| "I'll skip the rendered evidence definition because `docs/ac-traceability.md` already covers it." | The reviewer reading a PR body has not opened `docs/ac-traceability.md` and may not know it exists. A one-line rendered definition is the whole fix. |
-| "`Not applicable` alone is fine; the reason is obvious from context." | If the reason were obvious it would not be the AC failure mode #90 already documented. Require the reason. |
-| "I'll paste the AC evidence rows into `## How to verify` so a reviewer sees them in one place." | `## How to verify` is reviewer-facing manual-exercise instructions ("here's how *you* can run this"). AC evidence rows are author claims of already-completed verification ("here's what *I* ran and where it ran"). Duplicating one into the other doubles the body and erases the distinction. |
-| "Author guidance should be rendered too so authors don't ignore it." | PR-template convention puts author instructions in HTML comments. The QA failure mode was about *what the author wrote* (no context, no rationale), not about a missing visible prompt. The fix is rendered structural placeholders the author *replaces* (`Context:` line, `- <change> — <why>` bullets), not rendered prose the reviewer must skim past on every PR. |
+| "QA asked for a `Verification` section; I'll add one with that exact name." | Adopt the underlying need, not the literal section name. Per-AC `How a reviewer can confirm` covers the underlying problem without colliding with QA's older naming. |
+| "Per-bullet rationale will balloon `What changed`." | One rendered structural placeholder (`Context:` plus `— <why>` in the bullet shape) does not balloon anything. The R8 budget keeps rendered additions under ~45 lines combined. |
+| "I'll skip `Open concerns: None` because empty means none." | Silent omission and an explicit `None` look identical to a reviewer skimming, but only the explicit `None` is a positive signal that the author thought about it. Require it. |
+| "Author guidance should be rendered too so authors don't ignore it." | PR-template convention puts author instructions in HTML comments. The QA failure mode was about *what the author wrote*, not about a missing visible prompt. The fix is rendered structural placeholders the author *replaces* (`Context:` line, `— <why>` bullets, prose-labeled AC blocks), not rendered prose the reviewer must skim past on every PR. |
 
 ## Red Flags — STOP and reconsider
 
-- You are about to land a PR-template change as `docs:` or `chore:`. The
-  template is a product-surface glob (path-first rule, AGENTS.md). Use
-  `feat:` or `fix:`.
+- You are about to land a PR-template change as `docs:` or `chore:`.
+  The template is a product-surface glob (path-first rule, AGENTS.md).
+  Use `feat:` or `fix:`.
 - You are about to put the new author prompt, legend, AC clarification,
-  evidence definition, or `## How to verify` body inside `<!-- ... -->`.
-  That is the failure mode this design fixes.
+  AC-section orientation, or any humanized per-AC label inside
+  `<!-- ... -->`. That is the failure mode this design fixes.
+- You are adding a top-level `## How to verify`, `## Verification`,
+  `## Testing instructions`, or `## Manual test plan` section. Stop.
+  Reviewer-confirm steps live per-AC; the design deliberately avoids
+  a top-level recipe.
+- You are reintroducing `Operator check:`, `Test gap:`, or the
+  colon-grammar evidence row. Stop. The humanized grammar replaces
+  them.
 - You are editing only `.github/pull_request_template.md` and leaving
   `skills/bootstrap/templates/core/.github/pull_request_template.md`
   untouched. Stop. Edit the template first, then mirror.
 - You are baking iOS/TestFlight/Vercel/`npm install`/`pip install`/
-  `terraform plan` copy into the rendered body of `## How to verify`.
-  Stop. That copy is repo-specific; the canonical template stays
+  `terraform plan` copy into the rendered body of any AC's
+  `How a reviewer can confirm:` placeholder. Stop. That copy is
+  repo-specific; the canonical template stays
   product-surface-agnostic.
-- The diff adds substantially more than the R8 budget of rendered lines.
-  Stop. The fix is meant to be the smallest rendered prompts that make
-  the body legible, not a rewrite.
+- The diff adds substantially more than the R8 budget of rendered
+  lines. Stop. The fix is meant to be the smallest rendered prompts
+  and grammar updates that make the body legible, not a rewrite.
 
 ## Token-Efficiency Targets
 
-- Rendered additions across R1–R5 combined: ~30 lines or fewer in the
-  rendered body (HTML comments excluded). Expected landing zone is
-  ~15–20 lines (R1≈1, R2≈4–6, R3≈1, R4≈1, R5≈5–8); ~30 is the cap, not
-  a target. Each individual rendered prompt is one to three lines.
-- HTML-comment additions: bounded — comments may carry illustrative
-  hints (e.g. example evidence rows, example
-  `Not applicable — <reason>` strings) but must not balloon to replace
+- Rendered additions across R1–R4 (structural prompts): ~30 lines or
+  fewer in the rendered body (HTML comments excluded). Each
+  individual rendered prompt is one to three lines.
+- Rendered additions for the humanized placeholder AC entry (R5):
+  ~15 lines or fewer. The five labeled blocks (Outcome / Verified by
+  / How a reviewer can confirm / Open concerns / Before merging) are
+  one to three lines each in the placeholder.
+- Total rendered cap: ~45 lines. Expected landing zone is ~30.
+- HTML-comment additions are bounded — comments may carry
+  illustrative hints (e.g. example prose-style verification
+  sentences, example `not applicable — <reason>` strings, example
+  `Open concerns:` content) but must not balloon to replace
   contributor docs.
 - The rendered template, opened on GitHub web at default zoom, should
-  remain scannable in roughly one screen above `## Acceptance criteria`,
-  matching the current template's scan-density.
+  remain scannable in roughly two screens for a typical PR body
+  (matrix on screen one; first AC entry on screen two).
 
 ## Role Ownership
 
 - PR authors and Superteam `Finisher` own filling the rendered
-  context-prompt under `## What changed`, choosing matrix cells against
-  the rendered legend, writing evidence rows that match the rendered
-  definition, and filling `## How to verify` (with content or with
-  `Not applicable — <reason>`).
-- `Reviewer` and `Finisher` own flagging missing or placeholder values
-  before publish-state readiness. Specifically: a bare `Not applicable`
-  with no reason, an unfilled `## How to verify`, evidence rows that do
+  context placeholder under `## What changed`, choosing matrix cells
+  against the rendered legend, writing the prose `Verified by:`
+  sentence under each AC, writing `How a reviewer can confirm:`
+  steps (or `not applicable — <reason>`), listing `Open concerns:`
+  (or `None`), and ticking AC-scoped `Before merging:` checkboxes.
+- `Reviewer` and `Finisher` own flagging missing or placeholder
+  values before publish-state readiness. Specifically: a bare
+  `not applicable`, an unfilled `How a reviewer can confirm:`,
+  silent omission of `Open concerns:`, evidence sentences that do
   not name a verifier/environment/command, or matrix cells that
   contradict the rendered legend.
-- `Brainstormer` (this artifact) owns the rendered prompts and the
-  loophole-closure language; later issues that refine the prompts must
-  preserve the loophole-closure invariants in this design.
+- `Brainstormer` (this artifact) owns the rendered prompts, the
+  humanized grammar, and the loophole-closure language; later
+  issues that refine the prompts must preserve the
+  loophole-closure invariants in this design.
 
 ## Stage-Gate Bypass Resistance
 
-- "We can land the template edit without round-tripping" — bypassed by
-  R9 plus the AGENTS.md round-trip discipline; the PR must include both
-  the template change and the root mirror.
+- "We can land the template edit without round-tripping" — bypassed
+  by R9 plus the AGENTS.md round-trip discipline; the PR must
+  include both the template change and the root mirror.
 - "We can keep the new section in HTML comments to avoid breaking
-  consumers" — bypassed by R1, R2, R3, R4, R5, which require rendered
-  visibility; HTML-comment-only versions of these prompts do not satisfy
-  the ACs.
-- "We can reuse `Do before merging` instead of adding `## How to verify`"
-  — bypassed by R5; `Do before merging` is for PR-level operator steps
-  before merge, not for telling a reviewer how to exercise the change.
-- "We can drop AC-90-5 because round-trip is implied" — bypassed by R9
-  and the explicit AC-90-5 verifier; round-trip is part of every
+  consumers" — bypassed by R1, R2, R3, R4, R5, which require
+  rendered visibility; HTML-comment-only versions of these prompts
+  do not satisfy the ACs.
+- "We can keep `Operator check:` and `Test gap:` for backwards
+  compatibility" — bypassed by R5 plus the GREEN-phase grep
+  asserting both labels are absent. The humanized grammar replaces
+  them in the canonical template; downstream PRs adopt the new
+  grammar at next template render.
+- "We can drop AC-90-5 because round-trip is implied" — bypassed by
+  R9 and the explicit AC-90-5 verifier; round-trip is part of every
   template change on this repo and must be observable in the PR.
+- "We can re-introduce `## How to verify` later as a follow-up
+  because reviewers will ask" — bypassed by R6 and the loophole
+  closure forbidding the section; reviewer-confirm steps live
+  per-AC. If a real cross-AC orientation need emerges, it goes in
+  the AC-section orientation line (R4), not in a duplicate
+  top-level recipe.
 
 ## Cross-Reference
 
 - `docs/ac-traceability.md`: AC-ID convention and Given/When/Then
-  phrasing.
+  phrasing (issue side); per-AC PR-body grammar is updated by R10
+  to match the humanized template.
 - `.github/pull_request_template.md`: current canonical template
   (will be mirrored from the bootstrap template source after this
   design's plan and implementation land).
 - `skills/bootstrap/templates/core/.github/pull_request_template.md`:
   source of truth for the canonical template.
-- Issue #87: `⚠️` semantics. Coordinate the rendered legend wording so
-  #90 and #87 do not land conflicting copy.
+- Issue #87: `⚠️` semantics. Coordinate the rendered legend
+  wording so #90 and #87 do not land conflicting copy.
 - AGENTS.md: path-first commit-type rule (template change is a
   product-surface glob and ships as `feat:`).

--- a/docs/superpowers/specs/2026-05-05-90-pr-template-should-make-context-evidence-and-testing-design.md
+++ b/docs/superpowers/specs/2026-05-05-90-pr-template-should-make-context-evidence-and-testing-design.md
@@ -59,15 +59,19 @@ separate issue with explicit contract-migration scope.
   acceptance-criteria IDs from the linked issue, in
   `AC-<issue>-<n>` form"), so a non-author reviewer can interpret
   the column without prior context from `docs/ac-traceability.md`.
-- R4: The `## Acceptance criteria` section opens with a one-line
-  rendered orientation that names the per-AC content and the
-  evidence-row shape, e.g. "Each AC has an outcome summary, evidence
-  rows in the form `<Platform> test: <command>, <environment>[,
-  <link or verifier>]`, and any blocking `Test gap:` /
-  `Operator check:` checkboxes the operator must resolve before
-  merge." The orientation answers QA's "what does evidence mean?"
-  question without retiring the canonical grammar `## What changed`,
-  `docs/ac-traceability.md`, and the CI script depend on.
+- R4: The `## Acceptance criteria` section opens with a brief
+  rendered orientation that names the per-AC content, the
+  evidence-row shape, and where reviewers find manual-test
+  instructions. Example wording (Planner picks final copy): "Each
+  AC has an outcome summary, evidence rows in the form
+  `<Platform> test: <command>, <environment>[, <verifier>]`, and
+  any blocking `Test gap:` / `Operator check:` checkboxes the
+  operator must resolve before merge. Reviewers and QA exercising
+  the change manually follow the `Operator check:` rows." The
+  orientation answers QA's "what does evidence mean?" *and* "how
+  do I test this?" questions without retiring the canonical
+  grammar `docs/ac-traceability.md` and the CI script depend on,
+  and without inventing a parallel top-level section.
 - R5: The change does not retire or rename the existing
   machine-validated per-AC grammar (`Test gap:`,
   `Non-blocking gap:`, `Operator check:`, the colon-style evidence
@@ -88,7 +92,7 @@ separate issue with explicit contract-migration scope.
   template adds no more than roughly 15 rendered lines (excluding
   HTML comments) across R1–R4. Calibration: R1 ≈ 1 line plus a
   bullet-shape change, R2 ≈ 4–6 lines (one per symbol or compact
-  list), R3 ≈ 1 line, R4 ≈ 1–2 lines. Each individual rendered
+  list), R3 ≈ 1 line, R4 ≈ 2–3 lines. Each individual rendered
   prompt is one to three lines.
 - R8: Root `.github/pull_request_template.md` remains
   byte-identical to the bootstrap template source at
@@ -147,11 +151,13 @@ separate issue with explicit contract-migration scope.
   in the rendered body without opening the markdown source.
 - AC-90-3: Given a reviewer opens a rendered PR body, when they
   read the `## Acceptance criteria` section, then the rendered
-  body answers the questions QA could not answer from the previous
-  template — what evidence rows attest to (verifier, environment,
-  command/workflow job/tool/harness) — by rendering a one-line
+  body answers the two questions QA could not answer from the
+  previous template — what evidence rows attest to (verifier,
+  environment, command/workflow job/tool/harness) and where to
+  find manual-test instructions — by rendering a brief
   orientation that points at the canonical colon-style evidence
-  row format the rest of the AC section already uses.
+  row format and at `Operator check:` rows for manual exercise
+  steps.
 - AC-90-4: Given the canonical template under
   `skills/bootstrap/templates/core/.github/pull_request_template.md`
   changes, when the bootstrap skill runs in realignment mode
@@ -210,9 +216,23 @@ separate issue with explicit contract-migration scope.
   - `sed -e '/<!--/,/-->/d' .github/pull_request_template.md | grep -F 'Context:'`
     matches at least once.
   - `sed -e '/<!--/,/-->/d' .github/pull_request_template.md | grep -F '✅'`
-    matches at least once; analogous checks for `❌`, `⚠️`, `➖`.
-  - `sed -e '/<!--/,/-->/d' .github/pull_request_template.md | grep -F 'AC-'`
-    matches the rendered `AC` column clarification at least once.
+    matches at least once. Naive per-symbol greps are insufficient
+    for `⚠️` and `➖` because the existing `⚠️ Test gap:` row and
+    the existing `➖` matrix-cell placeholders already match them
+    today; instead, anchor on a phrase the Planner introduces with
+    the legend, e.g.:
+    `sed -e '/<!--/,/-->/d' .github/pull_request_template.md | grep -F 'required validation passed'`
+    matches the rendered legend's `✅` clause at least once
+    (analogous unique-phrase checks for the `❌`, `⚠️`, and `➖`
+    clauses, keyed off whatever exact wording the Planner adopts
+    from #87 — e.g. `non-blocking gap documented` for `⚠️`,
+    `merge-blocked` or `merge-blocking` for `❌`, `not relevant`
+    for `➖`).
+  - `sed -e '/<!--/,/-->/d' .github/pull_request_template.md | grep -F 'acceptance-criteria IDs'`
+    matches the rendered `AC` column clarification at least once
+    (a phrase chosen to be unique to the new clarification line so
+    the check does not pass on the existing `AC-<issue>-<n>`
+    matrix placeholder).
   - `sed -e '/<!--/,/-->/d' .github/pull_request_template.md | grep -F 'evidence'`
     matches the rendered AC-section orientation at least once.
 - Machine-validation regression check: run
@@ -311,7 +331,7 @@ HTML-comment content, so loophole exposure is small. Closures:
 - Rendered additions across R1–R4 combined: ~15 lines or fewer in
   the rendered body (HTML comments excluded). Calibration: R1 ≈ 1
   line plus a bullet-shape change, R2 ≈ 4–6 lines, R3 ≈ 1 line,
-  R4 ≈ 1–2 lines. Each individual rendered prompt is one to three
+  R4 ≈ 2–3 lines. Each individual rendered prompt is one to three
   lines.
 - HTML-comment additions are bounded — comments may carry
   illustrative hints but must not balloon to replace contributor

--- a/docs/superpowers/specs/2026-05-05-90-pr-template-should-make-context-evidence-and-testing-design.md
+++ b/docs/superpowers/specs/2026-05-05-90-pr-template-should-make-context-evidence-and-testing-design.md
@@ -1,0 +1,307 @@
+# Design: PR template should make context, evidence, and testing instructions self-explanatory to reviewers [#90](https://github.com/patinaproject/bootstrap/issues/90)
+
+## Intent
+
+Make the canonical pull request template legible to a first-time reviewer
+without forcing them to open the markdown source. Today, load-bearing author
+guidance (per-bullet rationale and linked context for `## What changed`), the
+test-coverage symbol legend, the `AC` column meaning, and the definition of
+"evidence" all live in HTML comments — invisible to QA, GitHub mobile, and
+anyone reading the rendered PR body. There is also no canonical slot that
+tells a reviewer how to exercise the change, which has caused downstream
+repos to invent ad-hoc sections (e.g. "QA findings → AC mapping",
+"Testing instructions") to fill the gap.
+
+This design adds the smallest set of rendered prompts and definitions that
+let a reviewer reconstruct *what changed, why, and how to verify it* from
+the rendered body alone, while preserving the existing AC / test-coverage
+grammar and round-trip discipline. It does not adopt QA's literal section
+names; it interprets the underlying reviewer problems and lands rendered
+fixes that work across mobile, web, CLI, library, and infra consumers.
+
+## Requirements
+
+- R1: The `## What changed` section contains a rendered (visible-in-body)
+  one-line author prompt that names the two load-bearing inputs reviewers
+  need: linked prior context (prior PR, prior QA pass, follow-up issue) and
+  a short rationale per bullet. The prompt is concise enough to remain in
+  the rendered body without ballooning the template.
+- R2: The `## Test coverage` section renders a visible legend defining
+  `✅`, `❌`, `⚠️`, `➖` with the same meanings already documented in the
+  HTML comments and aligned with the `⚠️` semantics in #87 (validation
+  exists with a known non-blocking gap is `⚠️`; merge-blocking missing or
+  failing validation is `❌`). The legend lives in the rendered body, not
+  in a comment.
+- R3: The `## Test coverage` section renders a one-line clarification of
+  the `AC` column ("`AC` references the acceptance-criteria IDs from the
+  linked issue, in `AC-<issue>-<n>` form"), so a non-author reviewer can
+  interpret the column without prior context from `docs/ac-traceability.md`.
+- R4: The `## Acceptance criteria` section renders a one-line definition of
+  what an evidence row attests to (verifier, environment, command/workflow
+  job/tool/harness), using the same terms already canonical in the HTML
+  comment evidence-row grammar. The rendered definition does not duplicate
+  the full grammar; it references the existing colon-style row format.
+- R5: The template adds a new rendered section `## How to verify` between
+  `## Test coverage` and `## Acceptance criteria`. The section contains a
+  short rendered author prompt explaining its purpose (give a reviewer or
+  QA tester the steps to exercise the change for this repo's product
+  surface) and an explicit `Not applicable — <one-line reason>` value the
+  author writes when no manual verification is required.
+- R6: The `## How to verify` section is product-surface-agnostic. Its
+  rendered copy must not bake in mobile-specific or web-specific build
+  acquisition language. Repo-specific examples (native build location, web
+  build URL, CLI install command, library import snippet, infra dry-run
+  command) live in HTML comments as illustrative hints, not in the
+  rendered body.
+- R7: When the author writes `Not applicable — <reason>` in
+  `## How to verify`, the section is treated as filled, not as a
+  placeholder. A bare `Not applicable` with no reason is a placeholder and
+  must be rejected by the same placeholder-rejection discipline that
+  governs other sections (e.g. the `Do before merging` rule).
+- R8: The template body's added rendered prose (R1, R2, R3, R4, R5
+  combined) stays under a token-efficiency budget so the rendered template
+  does not balloon. Target: the diff against the current template adds no
+  more than roughly 60 rendered lines (excluding HTML comments) across all
+  five rendered additions, so a freshly opened PR body remains scannable
+  in one screen on GitHub web.
+- R9: Root `.github/pull_request_template.md` remains byte-identical to the
+  bootstrap template source at
+  `skills/bootstrap/templates/core/.github/pull_request_template.md`. The
+  edit lands in the template first; the root file is mirrored via the
+  bootstrap skill in realignment mode in the same PR.
+- R10: `docs/ac-traceability.md` continues to delegate the detailed PR-body
+  grammar to the canonical PR template. The doc is updated only if a
+  direct contradiction with the new rendered legend or evidence definition
+  exists.
+- R11: PR authors and Superteam `Finisher` own filling the rendered
+  context-prompt, legend-driven matrix cells, evidence rows, and
+  `## How to verify` slot. `Reviewer` and `Finisher` own flagging missing
+  or placeholder values before publish-state readiness. A
+  `## How to verify` left as the literal placeholder string from the
+  template (or as bare `Not applicable` with no reason) blocks readiness
+  in the same way an unfilled `## What changed` does today.
+- R12: The change coordinates with #87. If #87 has not landed at merge
+  time, the rendered legend in this PR uses the #87 wording (`⚠️` =
+  validation exists with a known non-blocking gap; `❌` = required
+  validation missing, failing, pending, or merge-blocking) and #87's
+  template-side legend edit becomes a fast-follow mirror, not a competing
+  rewrite. The two PRs do not land conflicting legend copy.
+
+## Non-Goals
+
+- Do not redesign the test-coverage matrix schema, the AC ID grammar, or
+  the per-AC content order. This issue is about rendered-body legibility,
+  not a new schema.
+- Do not adopt QA's literal section names (`Summary`, `Verification`,
+  `QA findings → AC mapping`, `AC platform coverage`, `Testing
+  instructions`). Their feedback is interpreted, not transcribed.
+- Do not bake mobile/web/CLI/library/infra-specific build-acquisition copy
+  into the canonical template body.
+- Do not duplicate `docs/ac-traceability.md` content inside the PR body.
+- Do not add automated PR-body linting for the new
+  `## How to verify` section in this issue.
+- Do not adopt "QA findings → AC mapping" as a canonical section. The
+  underlying need (linking corrective work to the AC it satisfies) is
+  already served by the existing per-AC structure.
+
+## Acceptance Criteria
+
+- AC-90-1: Given an author opens the PR template, when they fill the
+  `## What changed` section, then the rendered body — not only an HTML
+  comment — prompts them to surface linked prior context (prior PR, prior
+  QA pass, follow-up issue) and to give each bullet a short rationale.
+- AC-90-2: Given a reviewer opens a rendered PR body, when they read the
+  `## Test coverage` matrix, then the symbol legend (`✅ ❌ ⚠️ ➖`) and the
+  meaning of the `AC` column are visible in the rendered body without
+  opening the markdown source.
+- AC-90-3: Given a reviewer opens a rendered PR body, when they read an
+  evidence row under an AC, then the rendered body conveys what evidence
+  attests to (verifier, environment, command/workflow job/tool/harness)
+  without prior context from `docs/ac-traceability.md` or other
+  contributor docs.
+- AC-90-4: Given a reviewer or QA tester opens the PR body, when they look
+  for a way to verify the change, then the body contains a rendered,
+  discoverable testing-instructions slot (`## How to verify`) that works
+  across repo product surfaces, with an explicit
+  `Not applicable — <reason>` value the author writes when no manual
+  verification is required.
+- AC-90-5: Given the canonical template under
+  `skills/bootstrap/templates/core/.github/pull_request_template.md`
+  changes, when the bootstrap skill runs in realignment mode against this
+  repo, then the root `.github/pull_request_template.md` matches the
+  template byte-for-byte (round-trip parity).
+
+## Implementation Shape
+
+1. Edit `skills/bootstrap/templates/core/.github/pull_request_template.md`:
+   - Add a one-line rendered author prompt under `## What changed`
+     covering linked prior context and per-bullet rationale (R1, AC-90-1).
+   - Add a rendered legend block under `## Test coverage` defining the
+     four symbols with the #87-aligned wording (R2, R12, AC-90-2).
+   - Add a one-line rendered clarification of the `AC` column in
+     `## Test coverage` (R3, AC-90-2).
+   - Add a one-line rendered definition of evidence under
+     `## Acceptance criteria` (R4, AC-90-3).
+   - Insert a new rendered `## How to verify` section between
+     `## Test coverage` and `## Acceptance criteria` with a short prompt,
+     a placeholder value, and a `Not applicable — <reason>` example
+     (R5, R6, R7, AC-90-4).
+   - Keep the rendered additions within the R8 token-efficiency budget.
+2. Run the bootstrap skill in realignment mode against this repo, accept
+   the proposed root diff, and commit the template change and the
+   mirrored root change together (R9, AC-90-5).
+3. Review `docs/ac-traceability.md` for direct contradictions with the
+   new rendered legend or evidence definition; update only if needed
+   (R10).
+4. Cross-link with #87 in the PR body so the legend wording is landed
+   once (R12).
+
+## Verification
+
+- RED-phase baseline (record before the template change lands):
+  - Confirm the current rendered template body (HTML comments stripped)
+    does not contain the four symbol meanings, the `AC` column meaning,
+    a definition of evidence, the per-bullet-rationale prompt, or a
+    `## How to verify` section. Capture this as the failing baseline so
+    the rendered fix is observable.
+  - Confirm the root and template files are already byte-identical
+    (`cmp -s`) so any later drift is attributable to the change.
+- GREEN-phase rendered checks after the change:
+  - `cmp -s skills/bootstrap/templates/core/.github/pull_request_template.md .github/pull_request_template.md`
+    exits 0.
+  - `grep -c '<!--' .github/pull_request_template.md` does not increase
+    relative to the count needed to land the new rendered prompts (i.e.
+    new author guidance is in the rendered body, not absorbed into HTML
+    comments).
+  - `grep -F '✅' .github/pull_request_template.md` shows the symbol in
+    rendered context (outside an HTML comment) at least once.
+  - `grep -F '## How to verify' .github/pull_request_template.md` matches.
+  - `grep -F 'Not applicable' .github/pull_request_template.md` matches
+    the rendered placeholder grammar.
+- Token-efficiency check: `git diff --stat` against the previous
+  template shows the rendered additions stay within the R8 budget.
+- Pressure test: open a sample PR body that uses the new template and
+  verify a reader who has never opened `docs/ac-traceability.md` can
+  answer (a) what the four symbols mean, (b) what `AC` columns reference,
+  (c) what an evidence row attests to, (d) how to verify the change or
+  why no manual verification is needed.
+
+## Loophole Closure
+
+The new rendered prompts and the `## How to verify` section introduce new
+author/reviewer discipline. The following loopholes must be closed
+explicitly so authors do not regress to invisible guidance.
+
+- Forbid moving the new rendered prompts back into HTML comments. "It
+  reads cleaner with the prompt hidden" is not an acceptable rationale;
+  HTML-comment-only guidance is exactly the failure mode this design
+  fixes.
+- Forbid replacing `## How to verify` with a bare `N/A` or
+  `Not applicable` (no reason). The author must write
+  `Not applicable — <one-line reason>`. A bare placeholder is treated as
+  unfilled.
+- Forbid baking repo-specific build-acquisition copy (native build
+  location, web build URL, CLI install command, library import snippet,
+  infra dry-run command) into the rendered template body. Such hints
+  belong in HTML comments as illustrative examples; the rendered body
+  must remain product-surface-agnostic.
+- Forbid adding "QA findings → AC mapping" as a canonical section under
+  the guise of "this is what reviewers asked for". The underlying need
+  is already served by the existing per-AC structure; reintroducing the
+  ad-hoc section would duplicate AC content.
+- Forbid editing only the root `.github/pull_request_template.md`. Every
+  change must land in the bootstrap template source first and round-trip
+  to root in the same PR; a root-only edit silently regresses every
+  bootstrapped repo on the next realignment.
+
+## Rationalization Resistance
+
+| Excuse | Reality |
+|--------|---------|
+| "The HTML comment already explains it; rendering is noise." | HTML comments are invisible to QA, GitHub mobile, and screenshot reviewers. The whole point of #90 is that comment-only guidance failed in production. |
+| "I'll keep the legend in the comment because the symbols are obvious." | They were not obvious; QA literally asked what `AC` and `evidence` meant. Render the legend. |
+| "`How to verify` doesn't apply to this repo / this PR is doc-only / this is a release PR." | Then write `Not applicable — <one-line reason>`. The slot exists precisely so the author has to make that decision visible. |
+| "I'll just put the iOS / TestFlight / Vercel preview steps in the canonical template." | Repo-specific build-acquisition copy is a non-goal. Put it in the consuming repo, not the bootstrap template. |
+| "I'll edit the root template directly and round-trip later." | Round-trip discipline exists because every bootstrapped repo regresses on the next realignment otherwise. Template-first, mirror in the same PR. |
+| "QA asked for a `Verification` section; I'll add one with that exact name." | Adopt the underlying need, not the literal section name. The current template's `## Test coverage` plus the new `## How to verify` covers the underlying problem without colliding with QA's older naming. |
+| "Per-bullet rationale will balloon `What changed`." | One rendered line of guidance does not balloon anything. The R8 budget keeps the entire set of rendered additions under roughly 60 lines. |
+| "I'll skip the rendered evidence definition because `docs/ac-traceability.md` already covers it." | The reviewer reading a PR body has not opened `docs/ac-traceability.md` and may not know it exists. A one-line rendered definition is the whole fix. |
+| "`Not applicable` alone is fine; the reason is obvious from context." | If the reason were obvious it would not be the AC failure mode #90 already documented. Require the reason. |
+
+## Red Flags — STOP and reconsider
+
+- You are about to land a PR-template change as `docs:` or `chore:`. The
+  template is a product-surface glob (path-first rule, AGENTS.md). Use
+  `feat:` or `fix:`.
+- You are about to put the new author prompt, legend, AC clarification,
+  evidence definition, or `## How to verify` body inside `<!-- ... -->`.
+  That is the failure mode this design fixes.
+- You are editing only `.github/pull_request_template.md` and leaving
+  `skills/bootstrap/templates/core/.github/pull_request_template.md`
+  untouched. Stop. Edit the template first, then mirror.
+- You are baking iOS/TestFlight/Vercel/`npm install`/`pip install`/
+  `terraform plan` copy into the rendered body of `## How to verify`.
+  Stop. That copy is repo-specific; the canonical template stays
+  product-surface-agnostic.
+- The diff adds substantially more than the R8 budget of rendered lines.
+  Stop. The fix is meant to be the smallest rendered prompts that make
+  the body legible, not a rewrite.
+
+## Token-Efficiency Targets
+
+- Rendered additions across R1–R5 combined: roughly 60 lines or fewer in
+  the rendered body (HTML comments excluded). Each individual rendered
+  prompt is one to three lines.
+- HTML-comment additions: bounded — comments may carry illustrative
+  hints (e.g. example evidence rows, example
+  `Not applicable — <reason>` strings) but must not balloon to replace
+  contributor docs.
+- The rendered template, opened on GitHub web at default zoom, should
+  remain scannable in roughly one screen above `## Acceptance criteria`,
+  matching the current template's scan-density.
+
+## Role Ownership
+
+- PR authors and Superteam `Finisher` own filling the rendered
+  context-prompt under `## What changed`, choosing matrix cells against
+  the rendered legend, writing evidence rows that match the rendered
+  definition, and filling `## How to verify` (with content or with
+  `Not applicable — <reason>`).
+- `Reviewer` and `Finisher` own flagging missing or placeholder values
+  before publish-state readiness. Specifically: a bare `Not applicable`
+  with no reason, an unfilled `## How to verify`, evidence rows that do
+  not name a verifier/environment/command, or matrix cells that
+  contradict the rendered legend.
+- `Brainstormer` (this artifact) owns the rendered prompts and the
+  loophole-closure language; later issues that refine the prompts must
+  preserve the loophole-closure invariants in this design.
+
+## Stage-Gate Bypass Resistance
+
+- "We can land the template edit without round-tripping" — bypassed by
+  R9 plus the AGENTS.md round-trip discipline; the PR must include both
+  the template change and the root mirror.
+- "We can keep the new section in HTML comments to avoid breaking
+  consumers" — bypassed by R1, R2, R3, R4, R5, which require rendered
+  visibility; HTML-comment-only versions of these prompts do not satisfy
+  the ACs.
+- "We can reuse `Do before merging` instead of adding `## How to verify`"
+  — bypassed by R5; `Do before merging` is for PR-level operator steps
+  before merge, not for telling a reviewer how to exercise the change.
+- "We can drop AC-90-5 because round-trip is implied" — bypassed by R9
+  and the explicit AC-90-5 verifier; round-trip is part of every
+  template change on this repo and must be observable in the PR.
+
+## Cross-Reference
+
+- `docs/ac-traceability.md`: AC-ID convention and Given/When/Then
+  phrasing.
+- `.github/pull_request_template.md`: current canonical template
+  (will be mirrored from the bootstrap template source after this
+  design's plan and implementation land).
+- `skills/bootstrap/templates/core/.github/pull_request_template.md`:
+  source of truth for the canonical template.
+- Issue #87: `⚠️` semantics. Coordinate the rendered legend wording so
+  #90 and #87 do not land conflicting copy.
+- AGENTS.md: path-first commit-type rule (template change is a
+  product-surface glob and ships as `feat:`).

--- a/docs/superpowers/specs/2026-05-05-90-pr-template-should-make-context-evidence-and-testing-design.md
+++ b/docs/superpowers/specs/2026-05-05-90-pr-template-should-make-context-evidence-and-testing-design.md
@@ -67,29 +67,38 @@ steps, scoped to the AC's outcome. There is no separate
     label as a placeholder line — the existing colon-grammar
     (`<Platform> test: <command>, <environment>[, <link>]`) is
     retired.
-  - **How a reviewer can confirm:** numbered or bulleted steps a
-    reviewer or QA tester can follow to exercise this AC's outcome,
-    plus an explicit *Expected:* line stating what they should see.
-    These steps absorb the role formerly proposed for a top-level
+  - **Confirm by:** numbered or bulleted steps a reviewer or QA
+    tester can follow to exercise this AC's outcome, plus an
+    explicit *Expected:* line stating what they should see. These
+    steps absorb the role formerly proposed for a top-level
     `## How to verify` section: there is no separate `How to verify`
     block; reviewer-confirm steps live with the AC they verify. When
     no manual confirmation is needed, the author writes
-    `How a reviewer can confirm: not applicable — <one-line reason>`
-    rather than omitting the slot.
+    `Confirm by: not applicable — <one-line reason>` rather than
+    omitting the slot.
   - **Open concerns:** prose listing of unresolved validation
-    concerns, known gaps, or merge-blocking issues, or the literal
-    word `None` when there are none. This replaces the current
-    `Test gap:` checkbox grammar; concerns that block merge are
-    surfaced here in prose, not as a checkbox the operator might
-    miss.
-  - **Before merging:** zero or more checkboxes for AC-scoped
-    operator actions that must be ticked before merge readiness.
-    These replace the current `Operator check:` checkbox label;
-    PR-level pre-merge actions that are not AC-scoped continue to
-    live in the optional `## Do before merging` section.
+    concerns, known gaps, or merge-blocking issues. This replaces
+    the current `Test gap:` checkbox grammar; concerns that block
+    merge are surfaced here in prose, not as a checkbox the
+    operator might miss. The block is optional when there are no
+    open concerns: omit it entirely rather than writing
+    `Open concerns: None`. Reviewers treat absence as "no concerns";
+    Reviewer/Finisher push back when the block is present but
+    empty, contains a placeholder, or omits a known concern they
+    surface.
+
+True pre-merge operator actions that are not scoped to a single AC
+(e.g. "rotate the production secret after deploy") live in the
+optional top-level `## Do before merging` section, as they do today.
+The humanized AC grammar deliberately does not add a per-AC
+`Before merging:` block: AC-scoped reviewer actions are already
+covered by `Confirm by:` plus its `Expected:` line, and a per-AC
+label collides confusingly with the top-level
+`## Do before merging` heading.
+
 - R6: The `## How to verify` section is *not* added. The role it would
   have played (telling a reviewer how to exercise the change) is
-  absorbed into per-AC `How a reviewer can confirm:` blocks under R5,
+  absorbed into per-AC `Confirm by:` blocks under R5,
   scoped to the AC's outcome. This avoids a top-level recipe duplicating
   per-AC gating steps and prevents authors from maintaining the same
   instructions in two places.
@@ -116,16 +125,16 @@ steps, scoped to the AC's outcome. There is no separate
   The edit lands in the template first; the root file is mirrored via
   the bootstrap skill in realignment mode in the same PR.
 - R10: `docs/ac-traceability.md` is updated to reflect the humanized
-  per-AC grammar (prose verification, `How a reviewer can confirm`,
-  `Open concerns`, `Before merging`). The previous colon-grammar
-  evidence-row form is retired and the doc must not present it as
-  canonical. Updates are limited to bringing the doc in sync with the
-  new template; the AC ID convention and Given/When/Then phrasing for
-  issue-side ACs are unchanged.
+  per-AC grammar (prose verification, `Confirm by`, `Open concerns`).
+  The previous colon-grammar evidence-row form, `Test gap:`, and
+  `Operator check:` labels are retired and the doc must not present
+  them as canonical. Updates are limited to bringing the doc in sync
+  with the new template; the AC ID convention and Given/When/Then
+  phrasing for issue-side ACs are unchanged.
 - R11: PR authors and Superteam `Finisher` own filling the rendered
   context placeholder under `## What changed`, choosing matrix cells
   against the rendered legend, writing prose-style verification
-  sentences under each AC, writing `How a reviewer can confirm` steps
+  sentences under each AC, writing `Confirm by` steps
   (or `not applicable — <reason>`), and listing `Open concerns` (or
   `None`). `Reviewer` and `Finisher` own flagging missing or
   placeholder values before publish-state readiness — including a
@@ -169,20 +178,18 @@ steps, scoped to the AC's outcome. There is no separate
   (`✅ ❌ ⚠️ ➖`) and the meaning of the `AC` column are visible in
   the rendered body without opening the markdown source.
 - AC-90-3: Given a reviewer opens a rendered PR body, when they read
-  the `## Acceptance criteria` section, then the section opens with a
-  rendered orientation naming the per-AC blocks (Outcome, Verified
-  by, How a reviewer can confirm, Open concerns, Before merging) so
-  the reader can navigate without prior context from
-  `docs/ac-traceability.md`.
+  the `## Acceptance criteria` section, then the section opens with
+  a rendered orientation naming the per-AC blocks (Outcome, Verified
+  by, Confirm by, Open concerns) so the reader can navigate without
+  prior context from `docs/ac-traceability.md`.
 - AC-90-4: Given a reviewer opens a rendered PR body, when they read
-  any per-AC entry, then the entry has a human-readable heading title
-  (`### AC-<issue>-<n>: <title>`), prose-style "Verified by:"
-  verification (not form-grammar), reviewer-friendly labels (`How a
-  reviewer can confirm`, `Open concerns`, `Before merging` instead of
-  `Operator check:` / `Test gap:`), and reviewer-confirm steps that
-  tell a reviewer or QA tester how to exercise the AC's outcome (or
-  `not applicable — <reason>` when manual confirmation is not
-  needed).
+  any per-AC entry, then the entry has a human-readable heading
+  title (`### AC-<issue>-<n>: <title>`), prose-style "Verified by:"
+  verification (not form-grammar), reviewer-friendly labels (`Confirm
+  by:` and `Open concerns:` instead of `Operator check:` and
+  `Test gap:`), and reviewer-confirm steps that tell a reviewer or
+  QA tester how to exercise the AC's outcome (or `not applicable —
+  <reason>` when manual confirmation is not needed).
 - AC-90-5: Given the canonical template under
   `skills/bootstrap/templates/core/.github/pull_request_template.md`
   changes, when the bootstrap skill runs in realignment mode against
@@ -204,10 +211,11 @@ steps, scoped to the AC's outcome. There is no separate
      naming the per-AC labeled blocks (R4, AC-90-3).
    - Restructure the placeholder AC entry to use the humanized
      grammar: heading title appended to the AC ID; **Outcome:**,
-     **Verified by:**, **How a reviewer can confirm:**, **Open
-     concerns:**, **Before merging:** labeled blocks; retire the
-     colon-grammar evidence row, the `Test gap:` checkbox, and the
-     `Operator check:` checkbox label (R5, AC-90-4).
+     **Verified by:**, **Confirm by:**, **Open concerns:** labeled
+     blocks (Open concerns shown only as commented illustrative
+     example, since real PRs omit it when there are none); retire
+     the colon-grammar evidence row, the `Test gap:` checkbox, and
+     the `Operator check:` checkbox label (R5, AC-90-4).
    - Keep the rendered additions within the R8 token-efficiency
      budget.
 2. Update `docs/ac-traceability.md` to reflect the humanized per-AC
@@ -226,7 +234,7 @@ steps, scoped to the AC's outcome. There is no separate
     stripped) does not contain the four symbol meanings, the `AC`
     column meaning, an orientation for the AC section, AC headings
     with titles, or the **Outcome / Verified by / How a reviewer can
-    confirm / Open concerns / Before merging** labels. Capture this
+    confirm / Open concerns** labels. Capture this
     as the failing baseline so the rendered fix is observable.
   - Confirm the root and template files are already byte-identical
     (`cmp -s`) so any later drift is attributable to the change.
@@ -253,12 +261,14 @@ steps, scoped to the AC's outcome. There is no separate
     matches the rendered `AC` column clarification at least once.
   - `sed -e '/<!--/,/-->/d' .github/pull_request_template.md | grep -F 'Verified by:'`
     matches (the humanized verification label is rendered).
-  - `sed -e '/<!--/,/-->/d' .github/pull_request_template.md | grep -F 'How a reviewer can confirm'`
+  - `sed -e '/<!--/,/-->/d' .github/pull_request_template.md | grep -F 'Confirm by'`
     matches.
   - `sed -e '/<!--/,/-->/d' .github/pull_request_template.md | grep -F 'Open concerns:'`
     matches.
-  - `sed -e '/<!--/,/-->/d' .github/pull_request_template.md | grep -E 'Before merging:?'`
-    matches the AC-scoped pre-merge label.
+  - `sed -e '/<!--/,/-->/d' .github/pull_request_template.md | grep -F 'Before merging:'`
+    finds **no** match in any per-AC entry (the per-AC label was
+    deliberately not added to avoid collision with the top-level
+    `## Do before merging` heading).
   - `sed -e '/<!--/,/-->/d' .github/pull_request_template.md | grep -F '## How to verify'`
     finds **no** match (the section was deliberately not added).
   - `sed -e '/<!--/,/-->/d' .github/pull_request_template.md | grep -F 'Operator check:'`
@@ -270,10 +280,10 @@ steps, scoped to the AC's outcome. There is no separate
   and verify a reader who has never opened
   `docs/ac-traceability.md` can answer (a) what the four symbols
   mean, (b) what `AC` columns reference, (c) what each per-AC
-  block (Outcome / Verified by / How a reviewer can confirm / Open
-  concerns / Before merging) is for, and (d) how to exercise the
+  block (Outcome / Verified by / Confirm by / Open
+  concerns) is for, and (d) how to exercise the
   change for at least one AC by following its
-  `How a reviewer can confirm` steps.
+  `Confirm by` steps.
 
 ## Loophole Closure
 
@@ -286,13 +296,16 @@ retired form-grammar.
   reads cleaner with the prompt hidden" is not an acceptable
   rationale; HTML-comment-only guidance is exactly the failure mode
   this design fixes.
-- Forbid replacing `How a reviewer can confirm:` with bare `N/A` or
+- Forbid replacing `Confirm by:` with bare `N/A` or
   bare `not applicable` (no reason). The author must write
   `not applicable — <one-line reason>`. A bare placeholder is treated
   as unfilled.
-- Forbid omitting `Open concerns:` from a per-AC entry. When there
-  are none, the author writes `Open concerns: None`. Silent omission
-  is treated as unfilled.
+- Forbid leaving `Open concerns:` empty when concerns exist
+  elsewhere (in review threads, CI failures, or known limitations).
+  Omitting the block when there genuinely are no concerns is
+  acceptable and expected; reviewers treat absence as "no concerns".
+  The forbidden move is surfacing concerns *outside* the AC and
+  hiding them from the per-AC reading.
 - Forbid reintroducing the retired colon-grammar evidence row
   (`<Platform> test: <command>, <environment>[, <link>]`) or the
   retired `Test gap:` / `Operator check:` checkbox labels in either
@@ -301,7 +314,7 @@ retired form-grammar.
 - Forbid adding a top-level `## How to verify` section, or any
   equivalent name (`Testing instructions`, `Verification`, `Manual
   test plan`). Reviewer-confirm steps live per-AC under
-  `How a reviewer can confirm:`. A top-level recipe duplicates
+  `Confirm by:`. A top-level recipe duplicates
   per-AC gating and forces authors to maintain the same content in
   two places.
 - Forbid baking repo-specific build-acquisition copy (native build
@@ -325,13 +338,14 @@ retired form-grammar.
 | "I'll keep the legend in the comment because the symbols are obvious." | They were not obvious; QA literally asked what `AC` and `evidence` meant. Render the legend. |
 | "I'll just add a top-level `## How to verify` because it's tidy." | A top-level recipe duplicates per-AC reviewer-confirm steps. R6 deliberately scopes "how to exercise" to the AC it verifies so authors maintain one source of truth. |
 | "The colon-grammar evidence row is more compact than prose." | The grammar QA could not parse is exactly the form `iOS evidence: ...` — they asked what evidence *meant*. Prose ("Verified on iOS by Ted: ran `pnpm test:e2e` against simulator iPhone 15") trades a few characters for legibility. |
-| "`Operator check:` is precise; renaming to `Before merging:` loses meaning." | "Operator" is internal jargon for the human running the workflow. Reviewers reading a PR body are operators by another name; `Before merging:` says exactly when they act and is reviewer-readable. AC-scoped pre-merge actions live there; PR-level pre-merge actions stay in the optional top-level `## Do before merging`. |
+| "`Operator check:` is precise; we should keep it as a per-AC label." | "Operator" is internal jargon and the label collides confusingly with `## Do before merging`. AC-scoped reviewer actions are already covered by `Confirm by:` plus its `Expected:` line; truly PR-level pre-merge actions stay in the optional top-level `## Do before merging`. There is no per-AC pre-merge label. |
+| "We should add `Before merging:` per AC so reviewers know exactly what gates each AC." | The label collides with the top-level `## Do before merging` heading and duplicates the role of `Confirm by:` + `Expected:`. The simpler design has one home for AC-scoped reviewer actions (`Confirm by:`) and one home for PR-level pre-merge ops (top-level `## Do before merging`). |
+| "Every AC should write `Open concerns: None` so reviewers know the author thought about it." | Mandating the empty-`None` row is bloat for a failure mode QA never reported. The block is omitted when there are no concerns; Reviewer/Finisher push back when concerns are visible elsewhere (review threads, CI failures) but absent from the AC. |
 | "`Test gap:` is the canonical label." | It was. The humanized grammar replaces it with prose `Open concerns:` because gaps are not always test gaps (they may be unresolved review findings, deferred validation, or known limitations) and a prose block surfaces them where a missed checkbox does not. |
-| "I'll just put the iOS / TestFlight / Vercel preview steps in the canonical template." | Repo-specific build-acquisition copy is a non-goal. Put it in the consuming repo's `How a reviewer can confirm` content, not the bootstrap template. |
+| "I'll just put the iOS / TestFlight / Vercel preview steps in the canonical template." | Repo-specific build-acquisition copy is a non-goal. Put it in the consuming repo's `Confirm by` content, not the bootstrap template. |
 | "I'll edit the root template directly and round-trip later." | Round-trip discipline exists because every bootstrapped repo regresses on the next realignment otherwise. Template-first, mirror in the same PR. |
-| "QA asked for a `Verification` section; I'll add one with that exact name." | Adopt the underlying need, not the literal section name. Per-AC `How a reviewer can confirm` covers the underlying problem without colliding with QA's older naming. |
+| "QA asked for a `Verification` section; I'll add one with that exact name." | Adopt the underlying need, not the literal section name. Per-AC `Confirm by` covers the underlying problem without colliding with QA's older naming. |
 | "Per-bullet rationale will balloon `What changed`." | One rendered structural placeholder (`Context:` plus `— <why>` in the bullet shape) does not balloon anything. The R8 budget keeps rendered additions under ~45 lines combined. |
-| "I'll skip `Open concerns: None` because empty means none." | Silent omission and an explicit `None` look identical to a reviewer skimming, but only the explicit `None` is a positive signal that the author thought about it. Require it. |
 | "Author guidance should be rendered too so authors don't ignore it." | PR-template convention puts author instructions in HTML comments. The QA failure mode was about *what the author wrote*, not about a missing visible prompt. The fix is rendered structural placeholders the author *replaces* (`Context:` line, `— <why>` bullets, prose-labeled AC blocks), not rendered prose the reviewer must skim past on every PR. |
 
 ## Red Flags — STOP and reconsider
@@ -354,7 +368,7 @@ retired form-grammar.
   untouched. Stop. Edit the template first, then mirror.
 - You are baking iOS/TestFlight/Vercel/`npm install`/`pip install`/
   `terraform plan` copy into the rendered body of any AC's
-  `How a reviewer can confirm:` placeholder. Stop. That copy is
+  `Confirm by:` placeholder. Stop. That copy is
   repo-specific; the canonical template stays
   product-surface-agnostic.
 - The diff adds substantially more than the R8 budget of rendered
@@ -367,9 +381,10 @@ retired form-grammar.
   fewer in the rendered body (HTML comments excluded). Each
   individual rendered prompt is one to three lines.
 - Rendered additions for the humanized placeholder AC entry (R5):
-  ~15 lines or fewer. The five labeled blocks (Outcome / Verified by
-  / How a reviewer can confirm / Open concerns / Before merging) are
-  one to three lines each in the placeholder.
+  ~12 lines or fewer. The four labeled blocks (Outcome / Verified
+  by / Confirm by / Open concerns) are one to three lines each in
+  the placeholder; Open concerns appears only as a commented
+  illustrative example because real PRs omit it when none.
 - Total rendered cap: ~45 lines. Expected landing zone is ~30.
 - HTML-comment additions are bounded — comments may carry
   illustrative hints (e.g. example prose-style verification
@@ -385,12 +400,14 @@ retired form-grammar.
 - PR authors and Superteam `Finisher` own filling the rendered
   context placeholder under `## What changed`, choosing matrix cells
   against the rendered legend, writing the prose `Verified by:`
-  sentence under each AC, writing `How a reviewer can confirm:`
+  sentence under each AC, writing `Confirm by:`
   steps (or `not applicable — <reason>`), listing `Open concerns:`
-  (or `None`), and ticking AC-scoped `Before merging:` checkboxes.
+  (omitted when there are none), and ticking checkboxes in the
+  optional top-level `## Do before merging` section when PR-level
+  pre-merge actions exist.
 - `Reviewer` and `Finisher` own flagging missing or placeholder
   values before publish-state readiness. Specifically: a bare
-  `not applicable`, an unfilled `How a reviewer can confirm:`,
+  `not applicable`, an unfilled `Confirm by:`,
   silent omission of `Open concerns:`, evidence sentences that do
   not name a verifier/environment/command, or matrix cells that
   contradict the rendered legend.

--- a/scripts/check-pr-template-checkboxes.mjs
+++ b/scripts/check-pr-template-checkboxes.mjs
@@ -13,9 +13,11 @@ const COMMENT_END = /-->\s*$/;
 const AC_HEADING = /^AC-\d+-\d+\b/;
 const TEST_GAP = /^⚠️\s*Test gap:\s*(.+)$/i;
 const NON_BLOCKING_GAP = /^⚠️\s*Non-blocking gap:\s*(.+)$/i;
-const OPERATOR_CHECK = /^Operator check:/i;
 const PROSE_GAP = /^\s*(?:[-*]\s*)?Blocking validation gap:/i;
 const NON_BLOCKING_PROSE = /^\s*(?:[-*]\s*)?Non-blocking gap:/i;
+const GAP_PROSE = /^\s*(?:[-*]\s*)?Gap:\s*(.+)$/i;
+const TEST_COVERAGE = /^Test coverage$/i;
+const ACCEPTANCE_CRITERIA = /^Acceptance criteria$/i;
 
 function ensureAc(acMap, acId, section, lineNumber) {
   const entry = acMap.get(acId) ?? {
@@ -56,6 +58,7 @@ export function validatePrBody(body) {
   let pending = null;
   let section = 'PR body';
   let activeAc = null;
+  let topSection = 'PR body';
   let inComment = false;
 
   for (const [index, line] of lines.entries()) {
@@ -63,8 +66,14 @@ export function validatePrBody(body) {
     const heading = line.match(HEADING);
     if (heading) {
       section = heading[2];
+      if (heading[1].length === 2) topSection = section;
       activeAc = AC_HEADING.test(section) ? section.split(/\s+/)[0] : null;
       if (activeAc) ensureAc(acs, activeAc, section, lineNumber);
+      if (ACCEPTANCE_CRITERIA.test(section)) {
+        errors.push(
+          `line ${lineNumber}: ${section}: merge AC coverage details into ## Test coverage and put tester actions in ## Testing steps`,
+        );
+      }
     }
 
     const matrixAc = readMatrixAc(line);
@@ -93,8 +102,17 @@ export function validatePrBody(body) {
 
     if (PROSE_GAP.test(line)) {
       errors.push(
-        `line ${lineNumber}: ${section}: use canonical ⚠️ Test gap checkbox instead of prose: ${line.trim()}`,
+        `line ${lineNumber}: ${section}: use Gap prose inside ## Test coverage instead of legacy Blocking validation gap wording: ${line.trim()}`,
       );
+      continue;
+    }
+
+    if (GAP_PROSE.test(line) && activeAc) {
+      ensureAc(acs, activeAc, section, lineNumber).testGaps.push({
+        checked: false,
+        lineNumber,
+        text: line.trim(),
+      });
       continue;
     }
 
@@ -106,6 +124,14 @@ export function validatePrBody(body) {
     const checkbox = line.match(CHECKBOX);
     if (!checkbox) continue;
 
+    if (TEST_COVERAGE.test(topSection)) {
+      errors.push(
+        `line ${lineNumber}: ${section}: checkboxes are not allowed in ## Test coverage; move tester actions to ## Testing steps: ${line.trim()}`,
+      );
+      pending = null;
+      continue;
+    }
+
     const checked = checkbox[1].toLowerCase() === 'x';
     const text = checkbox[2].trim();
     const marker = pending ?? { kind: 'required', lineNumber };
@@ -113,32 +139,24 @@ export function validatePrBody(body) {
 
     if (PROSE_GAP.test(text)) {
       errors.push(
-        `line ${lineNumber}: ${section}: use canonical ⚠️ Test gap checkbox instead of prose: ${text}`,
+        `line ${lineNumber}: ${section}: use Gap prose inside ## Test coverage instead of legacy Blocking validation gap wording: ${text}`,
       );
       continue;
     }
 
     const nonBlockingGap = text.match(NON_BLOCKING_GAP);
     if (nonBlockingGap) {
-      const acId = activeAc ?? section;
-      const ac = ensureAc(acs, acId, section, lineNumber);
-      ac.nonBlockingGaps += 1;
-      if (marker.kind === 'optional') continue;
       errors.push(
-        `line ${lineNumber}: ${section}: ⚠️ Non-blocking gap rows must be marked optional with \`<!-- pr-checkbox: optional -->\` immediately above: ${text}`,
+        `line ${lineNumber}: ${section}: use Non-blocking gap prose inside ## Test coverage instead of checkbox rows: ${text}`,
       );
       continue;
     }
 
     const testGap = text.match(TEST_GAP);
     if (testGap) {
-      const acId = activeAc ?? section;
-      const ac = ensureAc(acs, acId, section, lineNumber);
-      ac.testGaps.push({ checked, lineNumber, text });
-      const message = checked
-        ? `test gap checkbox must remain unchecked while unresolved: ${testGap[1]}`
-        : `unresolved validation gap: ${testGap[1]}`;
-      errors.push(`line ${lineNumber}: ${section}: ${message}`);
+      errors.push(
+        `line ${lineNumber}: ${section}: use Gap prose inside ## Test coverage instead of Test gap checkbox rows: ${testGap[1]}`,
+      );
       continue;
     }
 
@@ -147,11 +165,8 @@ export function validatePrBody(body) {
 
     if (marker.kind === 'required') {
       if (!checked) {
-        const label = OPERATOR_CHECK.test(text)
-          ? 'operator check is unchecked'
-          : 'required checklist item is unchecked';
         errors.push(
-          `line ${lineNumber}: ${section}: ${label}: ${text}`,
+          `line ${lineNumber}: ${section}: required checklist item is unchecked: ${text}`,
         );
       }
       continue;
@@ -179,7 +194,7 @@ export function validatePrBody(body) {
   for (const [acId, ac] of acs.entries()) {
     if (ac.hasWarning && ac.testGaps.length === 0 && ac.nonBlockingGaps === 0) {
       errors.push(
-        `line ${ac.lineNumber}: ${acId}: missing ⚠️ Test gap or Non-blocking gap explanation for warning matrix cell`,
+        `line ${ac.lineNumber}: ${acId}: missing Gap or Non-blocking gap explanation for warning matrix cell`,
       );
     }
   }

--- a/scripts/check-pr-template-checkboxes.test.mjs
+++ b/scripts/check-pr-template-checkboxes.test.mjs
@@ -15,8 +15,8 @@ function fixture(name) {
 test('fails unchecked required checklist rows with row text', () => {
   const result = validatePrBody(fixture('unchecked-required.md'));
   assert.equal(result.ok, false);
-  assert.match(result.errors.join('\n'), /Linux evidence/);
-  assert.match(result.errors.join('\n'), /AC-64-1/);
+  assert.match(result.errors.join('\n'), /Open the rendered PR body/);
+  assert.match(result.errors.join('\n'), /Testing steps/);
 });
 
 test('passes checked required checklist rows', () => {
@@ -27,25 +27,26 @@ test('passes explicitly optional unchecked checklist rows', () => {
   assert.equal(validatePrBody(fixture('optional-unchecked.md')).ok, true);
 });
 
-test('passes optional non-blocking gap checkbox rows', () => {
-  assert.equal(validatePrBody(fixture('non-blocking-gap-optional.md')).ok, true);
+test('fails old optional non-blocking gap checkbox rows', () => {
+  const result = validatePrBody(fixture('non-blocking-gap-optional.md'));
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join('\n'), /Acceptance criteria/);
 });
 
 test('passes ⚠️ matrix cell satisfied by Non-blocking gap prose', () => {
   assert.equal(validatePrBody(fixture('non-blocking-gap-prose.md')).ok, true);
 });
 
-test('passes ⚠️ matrix cell satisfied by optional Non-blocking gap checkbox', () => {
-  assert.equal(
-    validatePrBody(fixture('non-blocking-gap-optional-with-warning.md')).ok,
-    true,
-  );
+test('fails ⚠️ matrix cell satisfied by old optional Non-blocking gap checkbox', () => {
+  const result = validatePrBody(fixture('non-blocking-gap-optional-with-warning.md'));
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join('\n'), /Acceptance criteria/);
 });
 
-test('fails Non-blocking gap checkbox missing the optional marker', () => {
+test('fails Non-blocking gap checkbox rows under Test coverage', () => {
   const result = validatePrBody(fixture('non-blocking-gap-required.md'));
   assert.equal(result.ok, false);
-  assert.match(result.errors.join('\n'), /Non-blocking gap rows must be marked optional/i);
+  assert.match(result.errors.join('\n'), /checkboxes are not allowed in ## Test coverage/i);
 });
 
 test('fails docs choice group when no option is checked', () => {
@@ -69,57 +70,50 @@ test('fails docs choice group when more than one option is checked', () => {
 test('fails included test gap while unchecked with gap-specific text', () => {
   const result = validatePrBody(fixture('e2e-gap-unchecked.md'));
   assert.equal(result.ok, false);
-  assert.match(result.errors.join('\n'), /unresolved validation gap/i);
+  assert.match(result.errors.join('\n'), /checkboxes are not allowed in ## Test coverage/i);
   assert.match(result.errors.join('\n'), /browser behavior not covered/);
 });
 
-test('fails canonical unresolved test gaps with gap-specific text', () => {
-  const result = validatePrBody(fixture('test-gap-unchecked.md'));
-  assert.equal(result.ok, false);
-  assert.match(result.errors.join('\n'), /unresolved validation gap/i);
-  assert.match(result.errors.join('\n'), /Linux validation has not rerun/);
-  assert.doesNotMatch(
-    result.errors.join('\n'),
-    /required checklist item is unchecked/i,
-  );
+test('passes warning matrix cells with Gap prose under Test coverage', () => {
+  assert.equal(validatePrBody(fixture('test-gap-unchecked.md')).ok, true);
 });
 
-test('fails prose workaround when matrix warning lacks canonical test gap', () => {
+test('fails warning matrix cells without Gap or Non-blocking gap prose', () => {
   const result = validatePrBody(fixture('test-gap-prose-workaround.md'));
   assert.equal(result.ok, false);
-  assert.match(result.errors.join('\n'), /missing .*Test gap/i);
+  assert.match(result.errors.join('\n'), /missing .*Gap/i);
   assert.match(result.errors.join('\n'), /AC-86-1/);
 });
 
-test('fails checked test gaps because gaps are not completion tasks', () => {
+test('fails checked Test gap checkbox rows because gaps are coverage prose now', () => {
   const result = validatePrBody(fixture('test-gap-checked.md'));
   assert.equal(result.ok, false);
-  assert.match(result.errors.join('\n'), /test gap checkbox must remain unchecked/i);
+  assert.match(result.errors.join('\n'), /checkboxes are not allowed in ## Test coverage/i);
   assert.match(result.errors.join('\n'), /Linux validation has not rerun/);
 });
 
 test('fails prose workaround even without a matrix warning cell', () => {
   const result = validatePrBody(fixture('test-gap-prose-no-warning.md'));
   assert.equal(result.ok, false);
-  assert.match(result.errors.join('\n'), /use canonical ⚠️ Test gap/i);
+  assert.match(result.errors.join('\n'), /legacy Blocking validation gap/i);
   assert.match(result.errors.join('\n'), /Blocking validation gap/);
 });
 
 test('fails checked checkbox-wrapped prose workaround', () => {
   const result = validatePrBody(
-    '## Acceptance criteria\n\n### AC-86-1\n\n- [x] Blocking validation gap: Linux validation has not rerun.\n',
+    '## Testing steps\n\n- [x] Blocking validation gap: Linux validation has not rerun.\n',
   );
   assert.equal(result.ok, false);
-  assert.match(result.errors.join('\n'), /use canonical ⚠️ Test gap/i);
+  assert.match(result.errors.join('\n'), /legacy Blocking validation gap/i);
   assert.match(result.errors.join('\n'), /Blocking validation gap/);
 });
 
 test('fails optional checkbox-wrapped prose workaround', () => {
   const result = validatePrBody(
-    '## Acceptance criteria\n\n### AC-86-1\n\n<!-- pr-checkbox: optional -->\n- [ ] Blocking validation gap: Linux validation has not rerun.\n',
+    '## Testing steps\n\n<!-- pr-checkbox: optional -->\n- [ ] Blocking validation gap: Linux validation has not rerun.\n',
   );
   assert.equal(result.ok, false);
-  assert.match(result.errors.join('\n'), /use canonical ⚠️ Test gap/i);
+  assert.match(result.errors.join('\n'), /legacy Blocking validation gap/i);
   assert.match(result.errors.join('\n'), /Blocking validation gap/);
 });
 

--- a/scripts/fixtures/pr-template-checkboxes/checked-required.md
+++ b/scripts/fixtures/pr-template-checkboxes/checked-required.md
@@ -1,11 +1,15 @@
-## Acceptance criteria
+## Test coverage
 
 ### AC-64-1
 
-Required checked evidence row should pass.
+Coverage is documented without checkboxes.
 
-<!-- pr-checkbox: required -->
-- [x] Linux evidence -- runner | env | verifier | 2026-04-29T00:00:00Z
+- Evidence: Linux test: pnpm test, local, verifier.
+- Gap: None.
+
+## Testing steps
+
+- [x] Open the rendered PR body and confirm coverage is readable.
 
 ## Docs updated
 

--- a/scripts/fixtures/pr-template-checkboxes/docs-choice-none.md
+++ b/scripts/fixtures/pr-template-checkboxes/docs-choice-none.md
@@ -1,11 +1,11 @@
-## Acceptance criteria
+## Test coverage
 
 ### AC-64-2
 
 Docs choice group with no checked row should fail.
 
-<!-- pr-checkbox: required -->
-- [x] Linux evidence -- runner | env | verifier | 2026-04-29T00:00:00Z
+- Evidence: Linux test: pnpm test, local, verifier.
+- Gap: None.
 
 ## Docs updated
 

--- a/scripts/fixtures/pr-template-checkboxes/docs-choice-one.md
+++ b/scripts/fixtures/pr-template-checkboxes/docs-choice-one.md
@@ -1,11 +1,11 @@
-## Acceptance criteria
+## Test coverage
 
 ### AC-64-2
 
 Docs choice group with exactly one checked row should pass.
 
-<!-- pr-checkbox: required -->
-- [x] Linux evidence -- runner | env | verifier | 2026-04-29T00:00:00Z
+- Evidence: Linux test: pnpm test, local, verifier.
+- Gap: None.
 
 ## Docs updated
 

--- a/scripts/fixtures/pr-template-checkboxes/docs-choice-two.md
+++ b/scripts/fixtures/pr-template-checkboxes/docs-choice-two.md
@@ -1,11 +1,11 @@
-## Acceptance criteria
+## Test coverage
 
 ### AC-64-2
 
 Docs choice group with two checked rows should fail.
 
-<!-- pr-checkbox: required -->
-- [x] Linux evidence -- runner | env | verifier | 2026-04-29T00:00:00Z
+- Evidence: Linux test: pnpm test, local, verifier.
+- Gap: None.
 
 ## Docs updated
 

--- a/scripts/fixtures/pr-template-checkboxes/e2e-gap-unchecked.md
+++ b/scripts/fixtures/pr-template-checkboxes/e2e-gap-unchecked.md
@@ -1,15 +1,10 @@
-## Acceptance criteria
+## Test coverage
 
 ### AC-64-1
 
-Included E2E gap acknowledgement should fail while unchecked.
+Included old E2E gap checkbox should fail because Test coverage is checkbox-free.
 
-<!-- pr-checkbox: required -->
-- [x] Linux evidence -- runner | env | verifier | 2026-04-29T00:00:00Z
-<!-- pr-checkbox: required -->
 - [ ] ⚠️ Test gap: browser behavior not covered by automation
-<!-- pr-checkbox: required -->
-- [x] Manual test: 1. Open the PR; 2. Confirm the gate fails.
 
 ## Docs updated
 

--- a/scripts/fixtures/pr-template-checkboxes/manual-unchecked.md
+++ b/scripts/fixtures/pr-template-checkboxes/manual-unchecked.md
@@ -1,12 +1,12 @@
-## Acceptance criteria
+## Test coverage
 
 ### AC-64-1
 
-Manual test row should fail while unchecked.
+- Evidence: Linux test: pnpm test, local, verifier.
+- Gap: None.
 
-<!-- pr-checkbox: required -->
-- [x] Linux evidence -- runner | env | verifier | 2026-04-29T00:00:00Z
-<!-- pr-checkbox: required -->
+## Testing steps
+
 - [ ] Manual test: 1. Open the PR; 2. Confirm the gate fails.
 
 ## Docs updated

--- a/scripts/fixtures/pr-template-checkboxes/non-blocking-gap-prose.md
+++ b/scripts/fixtures/pr-template-checkboxes/non-blocking-gap-prose.md
@@ -4,8 +4,6 @@
 | --- | --- | --- | --- |
 | AC-87-4 | Non-blocking gap | ➖ | ⚠️ |
 
-## Acceptance criteria
-
 ### AC-87-4
 
 Chrome validation is enough to merge; Safari is a known non-blocking gap.

--- a/scripts/fixtures/pr-template-checkboxes/non-blocking-gap-required.md
+++ b/scripts/fixtures/pr-template-checkboxes/non-blocking-gap-required.md
@@ -4,11 +4,9 @@
 | --- | --- | --- | --- |
 | AC-87-4 | Non-blocking gap missing optional marker | ➖ | ⚠️ |
 
-## Acceptance criteria
-
 ### AC-87-4
 
-Author forgot the optional marker so the row is treated as required.
+Non-blocking gap checkbox should fail because Test coverage is checkbox-free.
 
 - [ ] ⚠️ Non-blocking gap: Safari persistence was not verified.
 

--- a/scripts/fixtures/pr-template-checkboxes/optional-unchecked.md
+++ b/scripts/fixtures/pr-template-checkboxes/optional-unchecked.md
@@ -1,8 +1,6 @@
-## Acceptance criteria
+## Testing steps
 
-### AC-64-2
-
-Optional unchecked row should pass.
+Optional unchecked row should pass outside Test coverage.
 
 <!-- pr-checkbox: optional -->
 - [ ] Optional reviewer note

--- a/scripts/fixtures/pr-template-checkboxes/test-gap-checked.md
+++ b/scripts/fixtures/pr-template-checkboxes/test-gap-checked.md
@@ -4,8 +4,6 @@
 | --- | --- | --- | --- |
 | AC-86-1 | Checked unresolved gap | ➖ | ⚠️ |
 
-## Acceptance criteria
-
 ### AC-86-1
 
 Checked test gap should fail because unresolved gaps are not completion tasks.

--- a/scripts/fixtures/pr-template-checkboxes/test-gap-prose-no-warning.md
+++ b/scripts/fixtures/pr-template-checkboxes/test-gap-prose-no-warning.md
@@ -4,8 +4,6 @@
 | --- | --- | --- | --- |
 | AC-86-1 | Prose without warning | ➖ | ➖ |
 
-## Acceptance criteria
-
 ### AC-86-1
 
 Blocking validation gap: Linux validation has not rerun after the validator fix.

--- a/scripts/fixtures/pr-template-checkboxes/test-gap-prose-workaround.md
+++ b/scripts/fixtures/pr-template-checkboxes/test-gap-prose-workaround.md
@@ -4,11 +4,9 @@
 | --- | --- | --- | --- |
 | AC-86-1 | Prose workaround | ➖ | ⚠️ |
 
-## Acceptance criteria
-
 ### AC-86-1
 
-Blocking validation gap: Linux validation has not rerun after the validator fix.
+Missing canonical Gap prose for the warning matrix cell.
 
 ## Docs updated
 

--- a/scripts/fixtures/pr-template-checkboxes/test-gap-unchecked.md
+++ b/scripts/fixtures/pr-template-checkboxes/test-gap-unchecked.md
@@ -4,13 +4,11 @@
 | --- | --- | --- | --- |
 | AC-86-1 | Canonical unresolved gap | ➖ | ⚠️ |
 
-## Acceptance criteria
-
 ### AC-86-1
 
-Canonical unresolved test gap should fail with a gap-specific readiness message.
+Canonical unresolved gap is coverage prose now.
 
-- [ ] ⚠️ Test gap: Linux validation has not rerun after the validator fix.
+- Gap: Linux validation has not rerun after the validator fix.
 
 ## Docs updated
 

--- a/scripts/fixtures/pr-template-checkboxes/unchecked-required.md
+++ b/scripts/fixtures/pr-template-checkboxes/unchecked-required.md
@@ -1,11 +1,15 @@
-## Acceptance criteria
+## Test coverage
 
 ### AC-64-1
 
-Required unchecked evidence row should fail.
+Coverage is documented without checkboxes.
 
-<!-- pr-checkbox: required -->
-- [ ] Linux evidence -- runner | env | verifier | 2026-04-29T00:00:00Z
+- Evidence: Linux test: pnpm test, local, verifier.
+- Gap: None.
+
+## Testing steps
+
+- [ ] Open the rendered PR body and confirm coverage is readable.
 
 ## Docs updated
 

--- a/skills/bootstrap/templates/core/.github/pull_request_template.md
+++ b/skills/bootstrap/templates/core/.github/pull_request_template.md
@@ -23,9 +23,19 @@
 
 ## What changed
 
--
+Context: <prior PR, prior QA pass, or follow-up issue this PR builds on, or `standalone — <reason>` when there is none>
+
+- <change> — <why>
 
 <!--
+  The rendered `Context:` line and `- <change> — <why>` bullet shape are the
+  structural placeholders this section requires. Replace `<...>` with actual
+  values; do not delete the `Context:` line. When this PR has no prior
+  context, write `Context: standalone — <reason>` (e.g.
+  `Context: standalone — first pass on the new lint rule`). One bullet per
+  change; the `— <why>` half states the rationale (user-visible reason or
+  triggering observation), not a restatement of the change.
+
   Include this section only when PR-level operator steps that do not belong to
   a specific AC must happen after review and before merge:
 
@@ -42,6 +52,15 @@
 -->
 
 ## Test coverage
+
+Legend for status cells:
+
+- ✅ — required validation passed with no known relevant gap for this column.
+- ⚠️ — validation exists and is sufficient to merge with a known non-blocking gap documented under the AC.
+- ❌ — required validation is missing, failing, pending, or merge-blocked.
+- ➖ — not relevant to this AC.
+
+The `AC` column references the acceptance-criteria IDs from the linked issue, in `AC-<issue>-<n>` form.
 
 <!--
   When showing a partial example outside a PR body, label the whole example as
@@ -75,6 +94,10 @@
 | AC-<issue>-<n> | <short title> | ➖ | ➖ |
 
 ## Acceptance criteria
+
+Evidence rows take the form `<Platform> test: <command, workflow job, tool, or harness>, <environment>[, <link, verifier, or ISO>]` — the trailing field is who or what proves the test ran.
+
+Reviewers and QA exercising the change manually follow the `Operator check:` rows under each AC for evidence of manual exercise.
 
 <!--
   One heading per relevant AC. AC IDs follow the convention in

--- a/skills/bootstrap/templates/core/.github/pull_request_template.md
+++ b/skills/bootstrap/templates/core/.github/pull_request_template.md
@@ -44,7 +44,7 @@ Context: <prior PR, prior QA pass, or follow-up issue this PR builds on, or `sta
   - [ ] Rotate the production secret after deploy.
 
   Keep checklist items concrete, actionable, and imperative. Do not duplicate
-  AC-specific test gaps, operator checks, or failing/pending PR checks here;
+  AC-specific coverage gaps, testing steps, or failing/pending PR checks here;
   PR check status is already reported by GitHub. Do not add this section for
   placeholders such as `None`, `N/A`, or `No work-specific pre-merge operator
   steps.` To include an intentionally optional checkbox, put a
@@ -67,12 +67,12 @@ The `AC` column references the acceptance-criteria IDs from the linked issue, in
   an excerpt before the first omitted section or table. Actual PR bodies must
   not omit relevant AC headings.
 
-  Include one row per AC with validation evidence, a required test gap, or an
-  operator check. Keep the `Unit` column, then add one column per supported
-  platform affected by this PR. Deferred or bookkeeping-only ACs may be
-  summarized in the AC section without a matrix row, but every relevant AC
-  still needs an AC heading. Each cell summarizes the required-validation state
-  for that AC and column. Use only these symbols in status cells:
+  Include one matrix row per relevant AC, then one subsection per AC with only
+  tester-useful coverage context: what was validated, where it ran, evidence,
+  known gaps or caveats, and whether manual testing is still needed. Keep the
+  `Unit` column, then add one column per supported platform affected by this
+  PR. Each cell summarizes the required-validation state for that AC and
+  column. Use only these symbols in status cells:
   ✅ = required validation passed, with no known relevant gap for this column
   ⚠️ = validation exists and is sufficient to merge, with a known non-blocking
        gap documented under this AC
@@ -81,88 +81,48 @@ The `AC` column references the acceptance-criteria IDs from the linked issue, in
   ➖ = not relevant to this AC
 
   Use `➖` only when that verification type is not relevant to the AC. If an AC
-  includes evidence, a gap, or an operator check that clearly maps to a matrix
-  column, that cell must not be `➖`. If a known non-blocking gap remains after
-  sufficient validation, use `⚠️` and document the gap under the AC in prose or
-  with an explicitly optional checkbox. If required validation is missing,
-  failing, pending, blocked by an unresolved concern, or otherwise cannot yet
-  be trusted for merge, use `❌` and add a required gap or operator-check
-  checkbox when pre-merge action is needed.
+  includes evidence or a gap that clearly maps to a matrix column, that cell
+  must not be `➖`. If a known non-blocking gap remains after sufficient
+  validation, use `⚠️` and document the gap under the AC in prose. If required
+  validation is missing, failing, pending, blocked by an unresolved concern, or
+  otherwise cannot yet be trusted for merge, use `❌` and document the gap under
+  the AC in prose. Do not use checkboxes in this section; tester actions belong
+  under `## Testing steps`.
 -->
 | AC | Title | Unit | <Platform> |
 | --- | --- | --- | --- |
 | AC-<issue>-<n> | <short title> | ➖ | ➖ |
 
-## Acceptance criteria
-
-Evidence rows take the form `<Platform> test: <command, workflow job, tool, or harness>, <environment>[, <link, verifier, or ISO>]` — the trailing field is who or what proves the test ran.
-
-Reviewers and QA exercising the change manually follow the `Operator check:` rows under each AC for evidence of manual exercise.
-
-<!--
-  One heading per relevant AC. AC IDs follow the convention in
-  docs/ac-traceability.md. Under each AC, use this order when present:
-  summary, evidence rows, test-gap checkboxes, operator-check checkboxes.
--->
-
 ### AC-<issue>-<n>
 
-Short outcome summary that states the current reviewer-relevant result,
-including unresolved blockers or pending validation when present.
+Coverage summary focused on what helps a human tester understand the state of this AC.
+
+- Evidence: `<Platform> test: <command, workflow job, tool, or harness>, <environment>[, <link, verifier, or ISO>]`.
+- Gap: <missing, pending, or non-blocking validation, or `None`>.
+- Manual testing needed: <yes/no and why>.
 
 <!--
-  For each supported platform that is relevant to this AC, include one evidence
-  row, summarize missing tests in the outcome, or document a known gap below.
-  Keep evidence rows compact and use a colon after the evidence label:
-  `<Platform> test: <command, workflow job, tool, or harness>, <environment>[, <link, verifier, or ISO>]`.
-  Name the concrete command, workflow job, tool, or harness when known. Use a
-  neutral verifier value, such as a person, role, or run identifier. Add a unit
-  evidence row only when unit evidence is the meaningful validation for this AC;
-  otherwise keep unit details in the matrix or CI summary.
-  If an unresolved critical or major review finding affects validation for this
-  AC, describe the missing observable behavior or validation as a required gap
-  checkbox unless it belongs in Do before merging.
+  Repeat one subsection per relevant AC. Keep this section evidence-only and
+  checkbox-free. Include only information that helps a reviewer or tester
+  understand coverage, gaps, and whether manual exercise is still needed.
 -->
-- <Platform> test: <command, workflow job, tool, or harness>, <environment>[, <link, verifier, or ISO>]
-<!--
-  Include every known blocking gap that the operator must consciously review
-  or resolve before merge. Use `Test gap:` to describe missing coverage or an
-  unresolved validation concern that keeps the matrix cell at `❌`. Do not use
-  required unchecked `Test gap:` rows for non-blocking caveats. Treat CI that
-  must rerun after a fix as a required test gap unless the operator must
-  manually trigger or inspect a specific job. Delete unused placeholder
-  checkbox rows.
-  Example: - [ ] ⚠️ Test gap: <blocking observable behavior or validation not verified>
--->
-- [ ] ⚠️ Test gap: <blocking observable behavior, missing coverage, or unresolved validation concern>
-<!--
-  For a non-blocking gap represented by a `⚠️` matrix cell, use prose or an
-  explicitly optional checkbox. Optional checkboxes must include
-  `pr-checkbox: optional` immediately above the row. For example, write prose
-  like `Non-blocking gap: <known caveat accepted for this PR>.` Or, when a
-  visible acknowledgement row is useful, put `pr-checkbox: optional` in an
-  HTML comment immediately above an unchecked `⚠️ Non-blocking gap:` checkbox.
--->
-<!--
-  Include every known operator action below any test-gap checkboxes for this
-  AC. Use the literal prefix `Operator check:` for product testing, diff
-  inspection, coverage-report review, review-finding review, deployment
-  evidence review, or other operator work. Include an expected decision or
-  result for each operator check. Do not add generic diff-review
-  checks unless the operator must inspect a specific risk, artifact, or
-  unresolved decision. Do not duplicate a test gap as an operator check unless
-  the operator action can close or validate the gap. Do not add product retest
-  checkboxes for maintainability-only findings unless there is a behavior risk
-  the operator can validate. Keep manual product or workflow validation as an
-  operator check when a human must exercise observable behavior after a gap is
-  fixed. Do not add CI-rerun operator checks unless the operator must manually
-  trigger or inspect a specific job. When updating an existing PR body,
-  preserve every existing manual-review or manual-test instruction under its AC
-  in this checkbox form. Phrase checkbox text in imperative style. Delete
-  unused placeholder checkbox rows.
--->
-- [ ] Operator check: <imperative operator action and expected decision or result>
 
-### AC-<issue>-<n>
+<!--
+  Deferred or out-of-scope ACs still get a subsection so reviewers can see why
+  no testing is reported for them:
 
-Deferred to `<repo-or-follow-up>`.
+  ### AC-<issue>-<n>
+
+  Deferred to `<repo-or-follow-up>`.
+-->
+
+## Testing steps
+
+<!--
+  Add concrete tester actions here. Use checkboxes only in this section or in
+  `## Do before merging`. Steps should cover any `❌` or `⚠️` gaps called out
+  in `## Test coverage` when a human can close or evaluate the gap. If no
+  manual testing is needed, include one checked row explaining why.
+-->
+
+- [ ] <imperative testing step and expected result>

--- a/skills/bootstrap/templates/core/AGENTS.md.tmpl
+++ b/skills/bootstrap/templates/core/AGENTS.md.tmpl
@@ -78,7 +78,7 @@ Recommended `gh` patterns:
 - PRs: `gh pr create --body-file <path-to-rendered-body>` is the safest path. The rendered body must already follow the template. If you pass `--body` inline, copy every template section name and order verbatim before filling them in.
 - Issues: `gh issue create --template bug_report.md` or `--template feature_request.md` lets `gh` start from the canonical file. If you pass `--body` inline, mirror the template's headings the same way.
 
-Do not invent alternative section names when the template uses different ones – extend an existing section instead, or open a follow-up to update the template itself. The PR-body acceptance-criteria rules under [Commit & Pull Request Guidelines](#commit--pull-request-guidelines) are a refinement of the template's `Acceptance criteria` section, not a replacement for it.
+Do not invent alternative section names when the template uses different ones – extend an existing section instead, or open a follow-up to update the template itself. The PR-body acceptance-criteria rules under [Commit & Pull Request Guidelines](#commit--pull-request-guidelines) are a refinement of the template's `Test coverage` and `Testing steps` sections, not a replacement for them.
 
 ## GitHub Actions pinning
 
@@ -174,10 +174,11 @@ For squash-and-merge workflows, PR titles must exactly match the commit format. 
 
 GitHub issue titles are different: write them as plain-language summaries of the problem or request. Do not use conventional-commit prefixes like `docs:` or `feat:` in issue titles.
 
-When an issue defines acceptance criteria, include an `Acceptance criteria` section in the PR description.
+When an issue defines acceptance criteria, include matching AC entries in the PR description's `Test coverage` section and put human tester actions in `Testing steps`.
 
-- Use one `### AC-<issue>-<n>` heading per relevant AC, with the heading containing only the AC ID.
-- Put a short outcome summary on the line below the heading.
-- Put verification steps directly under the AC they validate.
-- Use checkboxes only for operator actions that must happen before merge.
-- If an AC is deferred or out of scope for the repo, say so in the summary text and do not add fake checkboxes.
+- Use one `### AC-<issue>-<n>` heading per relevant AC inside `Test coverage`, with the heading containing only the AC ID.
+- Put only tester-useful coverage context under each AC: what was validated, where it ran, evidence, gaps or caveats, and whether manual testing is still needed.
+- Do not use checkboxes in `Test coverage`.
+- Use checkboxes for human tester actions only in `Testing steps`, and for pre-merge operator actions only in `Do before merging`.
+- Make `Testing steps` cover any `❌` or `⚠️` coverage gaps when a human can close or evaluate the gap.
+- If an AC is deferred or out of scope for the repo, say so under its `Test coverage` heading and do not add fake checkboxes.

--- a/skills/bootstrap/templates/core/scripts/check-pr-template-checkboxes.mjs
+++ b/skills/bootstrap/templates/core/scripts/check-pr-template-checkboxes.mjs
@@ -13,9 +13,11 @@ const COMMENT_END = /-->\s*$/;
 const AC_HEADING = /^AC-\d+-\d+\b/;
 const TEST_GAP = /^⚠️\s*Test gap:\s*(.+)$/i;
 const NON_BLOCKING_GAP = /^⚠️\s*Non-blocking gap:\s*(.+)$/i;
-const OPERATOR_CHECK = /^Operator check:/i;
 const PROSE_GAP = /^\s*(?:[-*]\s*)?Blocking validation gap:/i;
 const NON_BLOCKING_PROSE = /^\s*(?:[-*]\s*)?Non-blocking gap:/i;
+const GAP_PROSE = /^\s*(?:[-*]\s*)?Gap:\s*(.+)$/i;
+const TEST_COVERAGE = /^Test coverage$/i;
+const ACCEPTANCE_CRITERIA = /^Acceptance criteria$/i;
 
 function ensureAc(acMap, acId, section, lineNumber) {
   const entry = acMap.get(acId) ?? {
@@ -56,6 +58,7 @@ export function validatePrBody(body) {
   let pending = null;
   let section = 'PR body';
   let activeAc = null;
+  let topSection = 'PR body';
   let inComment = false;
 
   for (const [index, line] of lines.entries()) {
@@ -63,8 +66,14 @@ export function validatePrBody(body) {
     const heading = line.match(HEADING);
     if (heading) {
       section = heading[2];
+      if (heading[1].length === 2) topSection = section;
       activeAc = AC_HEADING.test(section) ? section.split(/\s+/)[0] : null;
       if (activeAc) ensureAc(acs, activeAc, section, lineNumber);
+      if (ACCEPTANCE_CRITERIA.test(section)) {
+        errors.push(
+          `line ${lineNumber}: ${section}: merge AC coverage details into ## Test coverage and put tester actions in ## Testing steps`,
+        );
+      }
     }
 
     const matrixAc = readMatrixAc(line);
@@ -93,8 +102,17 @@ export function validatePrBody(body) {
 
     if (PROSE_GAP.test(line)) {
       errors.push(
-        `line ${lineNumber}: ${section}: use canonical ⚠️ Test gap checkbox instead of prose: ${line.trim()}`,
+        `line ${lineNumber}: ${section}: use Gap prose inside ## Test coverage instead of legacy Blocking validation gap wording: ${line.trim()}`,
       );
+      continue;
+    }
+
+    if (GAP_PROSE.test(line) && activeAc) {
+      ensureAc(acs, activeAc, section, lineNumber).testGaps.push({
+        checked: false,
+        lineNumber,
+        text: line.trim(),
+      });
       continue;
     }
 
@@ -106,6 +124,14 @@ export function validatePrBody(body) {
     const checkbox = line.match(CHECKBOX);
     if (!checkbox) continue;
 
+    if (TEST_COVERAGE.test(topSection)) {
+      errors.push(
+        `line ${lineNumber}: ${section}: checkboxes are not allowed in ## Test coverage; move tester actions to ## Testing steps: ${line.trim()}`,
+      );
+      pending = null;
+      continue;
+    }
+
     const checked = checkbox[1].toLowerCase() === 'x';
     const text = checkbox[2].trim();
     const marker = pending ?? { kind: 'required', lineNumber };
@@ -113,32 +139,24 @@ export function validatePrBody(body) {
 
     if (PROSE_GAP.test(text)) {
       errors.push(
-        `line ${lineNumber}: ${section}: use canonical ⚠️ Test gap checkbox instead of prose: ${text}`,
+        `line ${lineNumber}: ${section}: use Gap prose inside ## Test coverage instead of legacy Blocking validation gap wording: ${text}`,
       );
       continue;
     }
 
     const nonBlockingGap = text.match(NON_BLOCKING_GAP);
     if (nonBlockingGap) {
-      const acId = activeAc ?? section;
-      const ac = ensureAc(acs, acId, section, lineNumber);
-      ac.nonBlockingGaps += 1;
-      if (marker.kind === 'optional') continue;
       errors.push(
-        `line ${lineNumber}: ${section}: ⚠️ Non-blocking gap rows must be marked optional with \`<!-- pr-checkbox: optional -->\` immediately above: ${text}`,
+        `line ${lineNumber}: ${section}: use Non-blocking gap prose inside ## Test coverage instead of checkbox rows: ${text}`,
       );
       continue;
     }
 
     const testGap = text.match(TEST_GAP);
     if (testGap) {
-      const acId = activeAc ?? section;
-      const ac = ensureAc(acs, acId, section, lineNumber);
-      ac.testGaps.push({ checked, lineNumber, text });
-      const message = checked
-        ? `test gap checkbox must remain unchecked while unresolved: ${testGap[1]}`
-        : `unresolved validation gap: ${testGap[1]}`;
-      errors.push(`line ${lineNumber}: ${section}: ${message}`);
+      errors.push(
+        `line ${lineNumber}: ${section}: use Gap prose inside ## Test coverage instead of Test gap checkbox rows: ${testGap[1]}`,
+      );
       continue;
     }
 
@@ -147,11 +165,8 @@ export function validatePrBody(body) {
 
     if (marker.kind === 'required') {
       if (!checked) {
-        const label = OPERATOR_CHECK.test(text)
-          ? 'operator check is unchecked'
-          : 'required checklist item is unchecked';
         errors.push(
-          `line ${lineNumber}: ${section}: ${label}: ${text}`,
+          `line ${lineNumber}: ${section}: required checklist item is unchecked: ${text}`,
         );
       }
       continue;
@@ -179,7 +194,7 @@ export function validatePrBody(body) {
   for (const [acId, ac] of acs.entries()) {
     if (ac.hasWarning && ac.testGaps.length === 0 && ac.nonBlockingGaps === 0) {
       errors.push(
-        `line ${ac.lineNumber}: ${acId}: missing ⚠️ Test gap or Non-blocking gap explanation for warning matrix cell`,
+        `line ${ac.lineNumber}: ${acId}: missing Gap or Non-blocking gap explanation for warning matrix cell`,
       );
     }
   }

--- a/skills/bootstrap/templates/core/scripts/check-pr-template-checkboxes.test.mjs
+++ b/skills/bootstrap/templates/core/scripts/check-pr-template-checkboxes.test.mjs
@@ -15,8 +15,8 @@ function fixture(name) {
 test('fails unchecked required checklist rows with row text', () => {
   const result = validatePrBody(fixture('unchecked-required.md'));
   assert.equal(result.ok, false);
-  assert.match(result.errors.join('\n'), /Linux evidence/);
-  assert.match(result.errors.join('\n'), /AC-64-1/);
+  assert.match(result.errors.join('\n'), /Open the rendered PR body/);
+  assert.match(result.errors.join('\n'), /Testing steps/);
 });
 
 test('passes checked required checklist rows', () => {
@@ -27,25 +27,26 @@ test('passes explicitly optional unchecked checklist rows', () => {
   assert.equal(validatePrBody(fixture('optional-unchecked.md')).ok, true);
 });
 
-test('passes optional non-blocking gap checkbox rows', () => {
-  assert.equal(validatePrBody(fixture('non-blocking-gap-optional.md')).ok, true);
+test('fails old optional non-blocking gap checkbox rows', () => {
+  const result = validatePrBody(fixture('non-blocking-gap-optional.md'));
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join('\n'), /Acceptance criteria/);
 });
 
 test('passes ⚠️ matrix cell satisfied by Non-blocking gap prose', () => {
   assert.equal(validatePrBody(fixture('non-blocking-gap-prose.md')).ok, true);
 });
 
-test('passes ⚠️ matrix cell satisfied by optional Non-blocking gap checkbox', () => {
-  assert.equal(
-    validatePrBody(fixture('non-blocking-gap-optional-with-warning.md')).ok,
-    true,
-  );
+test('fails ⚠️ matrix cell satisfied by old optional Non-blocking gap checkbox', () => {
+  const result = validatePrBody(fixture('non-blocking-gap-optional-with-warning.md'));
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join('\n'), /Acceptance criteria/);
 });
 
-test('fails Non-blocking gap checkbox missing the optional marker', () => {
+test('fails Non-blocking gap checkbox rows under Test coverage', () => {
   const result = validatePrBody(fixture('non-blocking-gap-required.md'));
   assert.equal(result.ok, false);
-  assert.match(result.errors.join('\n'), /Non-blocking gap rows must be marked optional/i);
+  assert.match(result.errors.join('\n'), /checkboxes are not allowed in ## Test coverage/i);
 });
 
 test('fails docs choice group when no option is checked', () => {
@@ -69,57 +70,50 @@ test('fails docs choice group when more than one option is checked', () => {
 test('fails included test gap while unchecked with gap-specific text', () => {
   const result = validatePrBody(fixture('e2e-gap-unchecked.md'));
   assert.equal(result.ok, false);
-  assert.match(result.errors.join('\n'), /unresolved validation gap/i);
+  assert.match(result.errors.join('\n'), /checkboxes are not allowed in ## Test coverage/i);
   assert.match(result.errors.join('\n'), /browser behavior not covered/);
 });
 
-test('fails canonical unresolved test gaps with gap-specific text', () => {
-  const result = validatePrBody(fixture('test-gap-unchecked.md'));
-  assert.equal(result.ok, false);
-  assert.match(result.errors.join('\n'), /unresolved validation gap/i);
-  assert.match(result.errors.join('\n'), /Linux validation has not rerun/);
-  assert.doesNotMatch(
-    result.errors.join('\n'),
-    /required checklist item is unchecked/i,
-  );
+test('passes warning matrix cells with Gap prose under Test coverage', () => {
+  assert.equal(validatePrBody(fixture('test-gap-unchecked.md')).ok, true);
 });
 
-test('fails prose workaround when matrix warning lacks canonical test gap', () => {
+test('fails warning matrix cells without Gap or Non-blocking gap prose', () => {
   const result = validatePrBody(fixture('test-gap-prose-workaround.md'));
   assert.equal(result.ok, false);
-  assert.match(result.errors.join('\n'), /missing .*Test gap/i);
+  assert.match(result.errors.join('\n'), /missing .*Gap/i);
   assert.match(result.errors.join('\n'), /AC-86-1/);
 });
 
-test('fails checked test gaps because gaps are not completion tasks', () => {
+test('fails checked Test gap checkbox rows because gaps are coverage prose now', () => {
   const result = validatePrBody(fixture('test-gap-checked.md'));
   assert.equal(result.ok, false);
-  assert.match(result.errors.join('\n'), /test gap checkbox must remain unchecked/i);
+  assert.match(result.errors.join('\n'), /checkboxes are not allowed in ## Test coverage/i);
   assert.match(result.errors.join('\n'), /Linux validation has not rerun/);
 });
 
 test('fails prose workaround even without a matrix warning cell', () => {
   const result = validatePrBody(fixture('test-gap-prose-no-warning.md'));
   assert.equal(result.ok, false);
-  assert.match(result.errors.join('\n'), /use canonical ⚠️ Test gap/i);
+  assert.match(result.errors.join('\n'), /legacy Blocking validation gap/i);
   assert.match(result.errors.join('\n'), /Blocking validation gap/);
 });
 
 test('fails checked checkbox-wrapped prose workaround', () => {
   const result = validatePrBody(
-    '## Acceptance criteria\n\n### AC-86-1\n\n- [x] Blocking validation gap: Linux validation has not rerun.\n',
+    '## Testing steps\n\n- [x] Blocking validation gap: Linux validation has not rerun.\n',
   );
   assert.equal(result.ok, false);
-  assert.match(result.errors.join('\n'), /use canonical ⚠️ Test gap/i);
+  assert.match(result.errors.join('\n'), /legacy Blocking validation gap/i);
   assert.match(result.errors.join('\n'), /Blocking validation gap/);
 });
 
 test('fails optional checkbox-wrapped prose workaround', () => {
   const result = validatePrBody(
-    '## Acceptance criteria\n\n### AC-86-1\n\n<!-- pr-checkbox: optional -->\n- [ ] Blocking validation gap: Linux validation has not rerun.\n',
+    '## Testing steps\n\n<!-- pr-checkbox: optional -->\n- [ ] Blocking validation gap: Linux validation has not rerun.\n',
   );
   assert.equal(result.ok, false);
-  assert.match(result.errors.join('\n'), /use canonical ⚠️ Test gap/i);
+  assert.match(result.errors.join('\n'), /legacy Blocking validation gap/i);
   assert.match(result.errors.join('\n'), /Blocking validation gap/);
 });
 

--- a/skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/checked-required.md
+++ b/skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/checked-required.md
@@ -1,11 +1,15 @@
-## Acceptance criteria
+## Test coverage
 
 ### AC-64-1
 
-Required checked evidence row should pass.
+Coverage is documented without checkboxes.
 
-<!-- pr-checkbox: required -->
-- [x] Linux evidence -- runner | env | verifier | 2026-04-29T00:00:00Z
+- Evidence: Linux test: pnpm test, local, verifier.
+- Gap: None.
+
+## Testing steps
+
+- [x] Open the rendered PR body and confirm coverage is readable.
 
 ## Docs updated
 

--- a/skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/docs-choice-none.md
+++ b/skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/docs-choice-none.md
@@ -1,11 +1,11 @@
-## Acceptance criteria
+## Test coverage
 
 ### AC-64-2
 
 Docs choice group with no checked row should fail.
 
-<!-- pr-checkbox: required -->
-- [x] Linux evidence -- runner | env | verifier | 2026-04-29T00:00:00Z
+- Evidence: Linux test: pnpm test, local, verifier.
+- Gap: None.
 
 ## Docs updated
 

--- a/skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/docs-choice-one.md
+++ b/skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/docs-choice-one.md
@@ -1,11 +1,11 @@
-## Acceptance criteria
+## Test coverage
 
 ### AC-64-2
 
 Docs choice group with exactly one checked row should pass.
 
-<!-- pr-checkbox: required -->
-- [x] Linux evidence -- runner | env | verifier | 2026-04-29T00:00:00Z
+- Evidence: Linux test: pnpm test, local, verifier.
+- Gap: None.
 
 ## Docs updated
 

--- a/skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/docs-choice-two.md
+++ b/skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/docs-choice-two.md
@@ -1,11 +1,11 @@
-## Acceptance criteria
+## Test coverage
 
 ### AC-64-2
 
 Docs choice group with two checked rows should fail.
 
-<!-- pr-checkbox: required -->
-- [x] Linux evidence -- runner | env | verifier | 2026-04-29T00:00:00Z
+- Evidence: Linux test: pnpm test, local, verifier.
+- Gap: None.
 
 ## Docs updated
 

--- a/skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/e2e-gap-unchecked.md
+++ b/skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/e2e-gap-unchecked.md
@@ -1,15 +1,10 @@
-## Acceptance criteria
+## Test coverage
 
 ### AC-64-1
 
-Included E2E gap acknowledgement should fail while unchecked.
+Included old E2E gap checkbox should fail because Test coverage is checkbox-free.
 
-<!-- pr-checkbox: required -->
-- [x] Linux evidence -- runner | env | verifier | 2026-04-29T00:00:00Z
-<!-- pr-checkbox: required -->
 - [ ] ⚠️ Test gap: browser behavior not covered by automation
-<!-- pr-checkbox: required -->
-- [x] Manual test: 1. Open the PR; 2. Confirm the gate fails.
 
 ## Docs updated
 

--- a/skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/manual-unchecked.md
+++ b/skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/manual-unchecked.md
@@ -1,12 +1,12 @@
-## Acceptance criteria
+## Test coverage
 
 ### AC-64-1
 
-Manual test row should fail while unchecked.
+- Evidence: Linux test: pnpm test, local, verifier.
+- Gap: None.
 
-<!-- pr-checkbox: required -->
-- [x] Linux evidence -- runner | env | verifier | 2026-04-29T00:00:00Z
-<!-- pr-checkbox: required -->
+## Testing steps
+
 - [ ] Manual test: 1. Open the PR; 2. Confirm the gate fails.
 
 ## Docs updated

--- a/skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/non-blocking-gap-prose.md
+++ b/skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/non-blocking-gap-prose.md
@@ -4,8 +4,6 @@
 | --- | --- | --- | --- |
 | AC-87-4 | Non-blocking gap | ➖ | ⚠️ |
 
-## Acceptance criteria
-
 ### AC-87-4
 
 Chrome validation is enough to merge; Safari is a known non-blocking gap.

--- a/skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/non-blocking-gap-required.md
+++ b/skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/non-blocking-gap-required.md
@@ -4,11 +4,9 @@
 | --- | --- | --- | --- |
 | AC-87-4 | Non-blocking gap missing optional marker | ➖ | ⚠️ |
 
-## Acceptance criteria
-
 ### AC-87-4
 
-Author forgot the optional marker so the row is treated as required.
+Non-blocking gap checkbox should fail because Test coverage is checkbox-free.
 
 - [ ] ⚠️ Non-blocking gap: Safari persistence was not verified.
 

--- a/skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/optional-unchecked.md
+++ b/skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/optional-unchecked.md
@@ -1,8 +1,6 @@
-## Acceptance criteria
+## Testing steps
 
-### AC-64-2
-
-Optional unchecked row should pass.
+Optional unchecked row should pass outside Test coverage.
 
 <!-- pr-checkbox: optional -->
 - [ ] Optional reviewer note

--- a/skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/test-gap-checked.md
+++ b/skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/test-gap-checked.md
@@ -4,8 +4,6 @@
 | --- | --- | --- | --- |
 | AC-86-1 | Checked unresolved gap | ➖ | ⚠️ |
 
-## Acceptance criteria
-
 ### AC-86-1
 
 Checked test gap should fail because unresolved gaps are not completion tasks.

--- a/skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/test-gap-prose-no-warning.md
+++ b/skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/test-gap-prose-no-warning.md
@@ -4,8 +4,6 @@
 | --- | --- | --- | --- |
 | AC-86-1 | Prose without warning | ➖ | ➖ |
 
-## Acceptance criteria
-
 ### AC-86-1
 
 Blocking validation gap: Linux validation has not rerun after the validator fix.

--- a/skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/test-gap-prose-workaround.md
+++ b/skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/test-gap-prose-workaround.md
@@ -4,11 +4,9 @@
 | --- | --- | --- | --- |
 | AC-86-1 | Prose workaround | ➖ | ⚠️ |
 
-## Acceptance criteria
-
 ### AC-86-1
 
-Blocking validation gap: Linux validation has not rerun after the validator fix.
+Missing canonical Gap prose for the warning matrix cell.
 
 ## Docs updated
 

--- a/skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/test-gap-unchecked.md
+++ b/skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/test-gap-unchecked.md
@@ -4,13 +4,11 @@
 | --- | --- | --- | --- |
 | AC-86-1 | Canonical unresolved gap | ➖ | ⚠️ |
 
-## Acceptance criteria
-
 ### AC-86-1
 
-Canonical unresolved test gap should fail with a gap-specific readiness message.
+Canonical unresolved gap is coverage prose now.
 
-- [ ] ⚠️ Test gap: Linux validation has not rerun after the validator fix.
+- Gap: Linux validation has not rerun after the validator fix.
 
 ## Docs updated
 

--- a/skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/unchecked-required.md
+++ b/skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes/unchecked-required.md
@@ -1,11 +1,15 @@
-## Acceptance criteria
+## Test coverage
 
 ### AC-64-1
 
-Required unchecked evidence row should fail.
+Coverage is documented without checkboxes.
 
-<!-- pr-checkbox: required -->
-- [ ] Linux evidence -- runner | env | verifier | 2026-04-29T00:00:00Z
+- Evidence: Linux test: pnpm test, local, verifier.
+- Gap: None.
+
+## Testing steps
+
+- [ ] Open the rendered PR body and confirm coverage is readable.
 
 ## Docs updated
 


### PR DESCRIPTION
# Pull Request

## Linked issue

- Closes #90

## What changed

Context: Hillary's feedback on PR #92 showed the rendered template should separate coverage evidence from tester action.

- Merged per-AC coverage into `## Test coverage` - reviewers can read evidence, gaps, and manual-test need in one coverage-focused place.
- Added `## Testing steps` - human tester actions now have a discoverable checkbox section.
- Updated the PR readiness validator and fixtures - CI now rejects checkboxes in `## Test coverage` and the retired `## Acceptance criteria` section.
- Updated agent and AC traceability guidance - future PR bodies follow the new coverage/testing split.

## Test coverage

Legend for status cells:

- ✅ - required validation passed with no known relevant gap for this column.
- ⚠️ - validation exists and is sufficient to merge with a known non-blocking gap documented under the AC.
- ❌ - required validation is missing, failing, pending, or merge-blocked.
- ➖ - not relevant to this AC.

The `AC` column references the acceptance-criteria IDs from the linked issue, in `AC-<issue>-<n>` form.

| AC | Title | Unit | Template | Validator |
| --- | --- | --- | --- | --- |
| AC-90-1 | Context and rationale visible | ➖ | ✅ | ➖ |
| AC-90-2 | Legend and AC meaning visible | ➖ | ✅ | ➖ |
| AC-90-3 | Evidence meaning visible | ➖ | ✅ | ✅ |
| AC-90-4 | Testing path discoverable | ➖ | ✅ | ✅ |
| AC-90-5 | Root/template parity | ✅ | ✅ | ✅ |

### AC-90-1

- Evidence: Template test: rendered `Context:` and `<change> - <why>` placeholders remain in `.github/pull_request_template.md`, local worktree, Codex.
- Gap: None.
- Manual testing needed: No; rendered-template grep coverage is sufficient.

### AC-90-2

- Evidence: Template test: rendered legend and `acceptance-criteria IDs` line remain visible outside HTML comments, local worktree, Codex.
- Gap: None.
- Manual testing needed: No; rendered-template grep coverage is sufficient.

### AC-90-3

- Evidence: Template test: `## Test coverage` now carries per-AC evidence rows and no rendered `## Acceptance criteria` section, local worktree, Codex.
- Evidence: Validator test: `node --test scripts/check-pr-template-checkboxes.test.mjs`, local worktree, Codex.
- Gap: None.
- Manual testing needed: No; validator fixtures cover the new evidence/gap contract.

### AC-90-4

- Evidence: Template test: rendered `## Testing steps` section exists with checkbox-style tester actions, local worktree, Codex.
- Evidence: Validator test: sample PR body validated with `node scripts/check-pr-template-checkboxes.mjs --body-file .codex-pr-90-body.md`, local worktree, Codex.
- Gap: None.
- Manual testing needed: Yes; reviewers can inspect this PR body to confirm the new section is discoverable.

### AC-90-5

- Evidence: Parity test: `cmp -s skills/bootstrap/templates/core/.github/pull_request_template.md .github/pull_request_template.md`, local worktree, Codex.
- Evidence: Parity test: `diff -qr scripts/fixtures/pr-template-checkboxes skills/bootstrap/templates/core/scripts/fixtures/pr-template-checkboxes`, local worktree, Codex.
- Gap: None.
- Manual testing needed: No; byte and directory parity checks cover the round-trip.

## Testing steps

- [x] Confirm `## Test coverage` contains the AC subsections and no rendered `## Acceptance criteria` section.
- [x] Confirm `## Testing steps` is a top-level section with checkbox actions.
- [x] Confirm the listed verification covers the previous coverage gaps around evidence meaning and manual tester instructions.
