### PR TITLE
docs: #93 link archived repo to skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Bootstrap
 
+> **Archive notice:** Bootstrap now lives in
+> [`patinaproject/skills`](https://github.com/patinaproject/skills). Use that
+> repository for the current plugin, issues, and updates.
+
 Scaffold a new repository – or realign an existing one – to the Patina Project baseline. One invocation, consistent conventions, portable across every major AI coding tool.
 
 Bootstrap is a Claude Code + Codex plugin distributed through the [`patinaproject/skills`](https://github.com/patinaproject/skills) marketplace. It ships a single skill that scaffolds a complete Patina Project baseline repository (commit + PR conventions, PNPM + Husky + markdownlint, agent docs, plugin manifests, release flow, GitHub repo settings) and keeps existing repos aligned with the latest baseline on rerun.


### PR DESCRIPTION
## Linked issue

- Related to #93. This PR completes the README handoff; repository archival must happen through the GitHub repository setting after merge.

## What changed

Context: standalone — archive handoff for the superseded `bootstrap` repository

- Added a README archive notice — visitors should immediately find `patinaproject/skills` for the current plugin, issues, and updates.
- Left `skills/bootstrap/templates/**` unchanged — the archive notice is specific to this repository and should not be emitted into newly bootstrapped repositories.

## Test coverage

Legend for status cells:

- ✅ — required validation passed with no known relevant gap for this column.
- ⚠️ — validation exists and is sufficient to merge with a known non-blocking gap documented under the AC.
- ❌ — required validation is missing, failing, pending, or merge-blocked.
- ➖ — not relevant to this AC.

The `AC` column references the acceptance-criteria IDs from the linked issue, in `AC-<issue>-<n>` form.

| AC | Title | Unit | README |
| --- | --- | --- | --- |
| AC-93-1 | Link to maintained repository | ➖ | ✅ |
| AC-93-2 | Archive repository setting | ➖ | ➖ |

### AC-93-1

The README now shows an archive notice above the existing project summary and links to https://github.com/patinaproject/skills.

- Evidence: `README lint: pnpm lint:md, local clone, 2026-05-12T15:08:50Z`.
- Gap: GitHub-rendered manual link check remains for reviewer confirmation.
- Manual testing needed: yes, to confirm the notice and link render correctly on GitHub.

### AC-93-2

Deferred until after this PR merges because archiving is a repository setting, not a file change.

## Testing steps

- [ ] Open the README on GitHub and confirm the archive notice appears at the top.
- [ ] Open the `patinaproject/skills` link and confirm it resolves to https://github.com/patinaproject/skills.